### PR TITLE
Add debt calculation helpers to payment data layer

### DIFF
--- a/app/src/main/java/com/tutorly/data/db/dao/PaymentDao.kt
+++ b/app/src/main/java/com/tutorly/data/db/dao/PaymentDao.kt
@@ -2,6 +2,7 @@ package com.tutorly.data.db.dao
 
 import androidx.room.*
 import com.tutorly.models.Payment
+import com.tutorly.models.PaymentStatus
 import kotlinx.coroutines.flow.Flow
 
 @Dao
@@ -12,32 +13,32 @@ interface PaymentDao {
     @Query("""
         SELECT EXISTS(
           SELECT 1 FROM payments
-          WHERE studentId = :studentId AND status = 'DUE'
+          WHERE studentId = :studentId AND status IN (:statuses)
         )
     """)
-    suspend fun hasDebt(studentId: Long): Boolean
+    suspend fun hasDebt(studentId: Long, statuses: List<PaymentStatus>): Boolean
 
     @Query("""
         SELECT EXISTS(
           SELECT 1 FROM payments
-          WHERE studentId = :studentId AND status = 'DUE'
+          WHERE studentId = :studentId AND status IN (:statuses)
         )
     """)
-    fun observeHasDebt(studentId: Long): Flow<Boolean>
+    fun observeHasDebt(studentId: Long, statuses: List<PaymentStatus>): Flow<Boolean>
 
     @Query("""
         SELECT COALESCE(SUM(amountCents), 0)
         FROM payments
-        WHERE studentId = :studentId AND status = 'DUE'
+        WHERE studentId = :studentId AND status IN (:statuses)
     """)
-    suspend fun totalDebt(studentId: Long): Long
+    suspend fun totalDebt(studentId: Long, statuses: List<PaymentStatus>): Long
 
     @Query("""
         SELECT COALESCE(SUM(amountCents), 0)
         FROM payments
-        WHERE studentId = :studentId AND status = 'DUE'
+        WHERE studentId = :studentId AND status IN (:statuses)
     """)
-    fun observeTotalDebt(studentId: Long): Flow<Long>
+    fun observeTotalDebt(studentId: Long, statuses: List<PaymentStatus>): Flow<Long>
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insert(payment: Payment): Long

--- a/app/src/main/java/com/tutorly/data/db/dao/PaymentDao.kt
+++ b/app/src/main/java/com/tutorly/data/db/dao/PaymentDao.kt
@@ -15,7 +15,22 @@ interface PaymentDao {
           WHERE studentId = :studentId AND status = 'DUE'
         )
     """)
+    suspend fun hasDebt(studentId: Long): Boolean
+
+    @Query("""
+        SELECT EXISTS(
+          SELECT 1 FROM payments
+          WHERE studentId = :studentId AND status = 'DUE'
+        )
+    """)
     fun observeHasDebt(studentId: Long): Flow<Boolean>
+
+    @Query("""
+        SELECT COALESCE(SUM(amountCents), 0)
+        FROM payments
+        WHERE studentId = :studentId AND status = 'DUE'
+    """)
+    suspend fun totalDebt(studentId: Long): Long
 
     @Query("""
         SELECT COALESCE(SUM(amountCents), 0)

--- a/app/src/main/java/com/tutorly/data/db/dao/StudentDao.kt
+++ b/app/src/main/java/com/tutorly/data/db/dao/StudentDao.kt
@@ -9,6 +9,17 @@ interface StudentDao {
     @Query("SELECT * FROM students WHERE active = 1 ORDER BY name COLLATE NOCASE")
     suspend fun getAllActive(): List<Student>
 
+    @Query(
+        """
+        SELECT * FROM students
+        WHERE active = 1 AND (
+            :q == '' OR name LIKE '%' || :q || '%' OR phone LIKE '%' || :q || '%'
+        )
+        ORDER BY name COLLATE NOCASE
+        """
+    )
+    suspend fun searchActive(q: String): List<Student>
+
     @Query("SELECT * FROM students WHERE id = :id LIMIT 1")
     suspend fun getById(id: Long): Student?
 

--- a/app/src/main/java/com/tutorly/data/db/dao/StudentDao.kt
+++ b/app/src/main/java/com/tutorly/data/db/dao/StudentDao.kt
@@ -25,7 +25,9 @@ interface StudentDao {
 
     @Query("""
         SELECT * FROM students
-        WHERE (:q == '' OR name LIKE '%' || :q || '%' OR phone LIKE '%' || :q || '%')
+        WHERE active = 1 AND (
+            :q == '' OR name LIKE '%' || :q || '%' OR phone LIKE '%' || :q || '%'
+        )
         ORDER BY name COLLATE NOCASE
     """)
     fun observeStudents(q: String): Flow<List<Student>>

--- a/app/src/main/java/com/tutorly/data/repo/room/RoomPaymentsRepository.kt
+++ b/app/src/main/java/com/tutorly/data/repo/room/RoomPaymentsRepository.kt
@@ -3,6 +3,7 @@ package com.tutorly.data.repo.room
 import com.tutorly.data.db.dao.PaymentDao
 import com.tutorly.domain.repo.PaymentsRepository
 import com.tutorly.models.Payment
+import com.tutorly.models.PaymentStatus
 import javax.inject.Inject
 import javax.inject.Singleton
 import kotlinx.coroutines.flow.Flow
@@ -16,16 +17,16 @@ class RoomPaymentsRepository @Inject constructor(
         paymentDao.observePaymentsByStudent(studentId)
 
     override suspend fun hasDebt(studentId: Long): Boolean =
-        paymentDao.hasDebt(studentId)
+        paymentDao.hasDebt(studentId, PaymentStatus.outstandingStatuses)
 
     override fun observeHasDebt(studentId: Long): Flow<Boolean> =
-        paymentDao.observeHasDebt(studentId)
+        paymentDao.observeHasDebt(studentId, PaymentStatus.outstandingStatuses)
 
     override suspend fun totalDebt(studentId: Long): Long =
-        paymentDao.totalDebt(studentId)
+        paymentDao.totalDebt(studentId, PaymentStatus.outstandingStatuses)
 
     override fun observeTotalDebt(studentId: Long): Flow<Long> =
-        paymentDao.observeTotalDebt(studentId)
+        paymentDao.observeTotalDebt(studentId, PaymentStatus.outstandingStatuses)
 
     override suspend fun insert(payment: Payment): Long =
         paymentDao.insert(payment)

--- a/app/src/main/java/com/tutorly/data/repo/room/RoomPaymentsRepository.kt
+++ b/app/src/main/java/com/tutorly/data/repo/room/RoomPaymentsRepository.kt
@@ -3,8 +3,8 @@ package com.tutorly.data.repo.room
 import com.tutorly.data.db.dao.PaymentDao
 import com.tutorly.domain.repo.PaymentsRepository
 import com.tutorly.models.Payment
-import jakarta.inject.Inject
-import jakarta.inject.Singleton
+import javax.inject.Inject
+import javax.inject.Singleton
 import kotlinx.coroutines.flow.Flow
 
 @Singleton

--- a/app/src/main/java/com/tutorly/data/repo/room/RoomPaymentsRepository.kt
+++ b/app/src/main/java/com/tutorly/data/repo/room/RoomPaymentsRepository.kt
@@ -15,8 +15,14 @@ class RoomPaymentsRepository @Inject constructor(
     override fun observePaymentsByStudent(studentId: Long): Flow<List<Payment>> =
         paymentDao.observePaymentsByStudent(studentId)
 
+    override suspend fun hasDebt(studentId: Long): Boolean =
+        paymentDao.hasDebt(studentId)
+
     override fun observeHasDebt(studentId: Long): Flow<Boolean> =
         paymentDao.observeHasDebt(studentId)
+
+    override suspend fun totalDebt(studentId: Long): Long =
+        paymentDao.totalDebt(studentId)
 
     override fun observeTotalDebt(studentId: Long): Flow<Long> =
         paymentDao.observeTotalDebt(studentId)

--- a/app/src/main/java/com/tutorly/data/repo/room/RoomStudentsRepository.kt
+++ b/app/src/main/java/com/tutorly/data/repo/room/RoomStudentsRepository.kt
@@ -2,8 +2,9 @@ package com.tutorly.data.repo.room
 
 import com.tutorly.data.db.dao.PaymentDao
 import com.tutorly.data.db.dao.StudentDao
-import com.tutorly.models.Student
 import com.tutorly.domain.repo.StudentsRepository
+import com.tutorly.models.PaymentStatus
+import com.tutorly.models.Student
 import javax.inject.Inject
 import javax.inject.Singleton
 import kotlinx.coroutines.flow.Flow
@@ -36,10 +37,10 @@ class RoomStudentsRepository @Inject constructor(
         studentDao.delete(student)
 
     override suspend fun hasDebt(studentId: Long): Boolean =
-        paymentDao.hasDebt(studentId)
+        paymentDao.hasDebt(studentId, PaymentStatus.outstandingStatuses)
 
     override fun observeHasDebt(studentId: Long): Flow<Boolean> =
-        paymentDao.observeHasDebt(studentId)
+        paymentDao.observeHasDebt(studentId, PaymentStatus.outstandingStatuses)
 }
 
 

--- a/app/src/main/java/com/tutorly/data/repo/room/RoomStudentsRepository.kt
+++ b/app/src/main/java/com/tutorly/data/repo/room/RoomStudentsRepository.kt
@@ -17,6 +17,9 @@ class RoomStudentsRepository @Inject constructor(
     override suspend fun allActive(): List<Student> =
         studentDao.getAllActive()
 
+    override suspend fun searchActive(query: String): List<Student> =
+        studentDao.searchActive(query)
+
     override suspend fun getById(id: Long): Student? =
         studentDao.getById(id)
 
@@ -31,6 +34,9 @@ class RoomStudentsRepository @Inject constructor(
 
     override suspend fun delete(student: Student) =
         studentDao.delete(student)
+
+    override suspend fun hasDebt(studentId: Long): Boolean =
+        paymentDao.hasDebt(studentId)
 
     override fun observeHasDebt(studentId: Long): Flow<Boolean> =
         paymentDao.observeHasDebt(studentId)

--- a/app/src/main/java/com/tutorly/data/repo/room/RoomStudentsRepository.kt
+++ b/app/src/main/java/com/tutorly/data/repo/room/RoomStudentsRepository.kt
@@ -4,8 +4,8 @@ import com.tutorly.data.db.dao.PaymentDao
 import com.tutorly.data.db.dao.StudentDao
 import com.tutorly.models.Student
 import com.tutorly.domain.repo.StudentsRepository
-import jakarta.inject.Inject
-import jakarta.inject.Singleton
+import javax.inject.Inject
+import javax.inject.Singleton
 import kotlinx.coroutines.flow.Flow
 
 @Singleton

--- a/app/src/main/java/com/tutorly/domain/repo/PaymentsRepository.kt
+++ b/app/src/main/java/com/tutorly/domain/repo/PaymentsRepository.kt
@@ -5,7 +5,9 @@ import kotlinx.coroutines.flow.Flow
 
 interface PaymentsRepository {
     fun observePaymentsByStudent(studentId: Long): Flow<List<Payment>>
+    suspend fun hasDebt(studentId: Long): Boolean
     fun observeHasDebt(studentId: Long): Flow<Boolean>
+    suspend fun totalDebt(studentId: Long): Long
     fun observeTotalDebt(studentId: Long): Flow<Long>
 
     suspend fun insert(payment: Payment): Long

--- a/app/src/main/java/com/tutorly/domain/repo/StudentsRepository.kt
+++ b/app/src/main/java/com/tutorly/domain/repo/StudentsRepository.kt
@@ -6,6 +6,7 @@ import kotlinx.coroutines.flow.Flow
 interface StudentsRepository {
     // sync (suspend) — где нужно мгновенно получить сущность
     suspend fun allActive(): List<Student>
+    suspend fun searchActive(query: String): List<Student>
     suspend fun getById(id: Long): Student?
 
     // observable — для UI
@@ -17,6 +18,7 @@ interface StudentsRepository {
     suspend fun delete(student: Student)
 
     // агрегаты
+    suspend fun hasDebt(studentId: Long): Boolean
     fun observeHasDebt(studentId: Long): Flow<Boolean>
 }
 

--- a/app/src/main/java/com/tutorly/models/Payment.kt
+++ b/app/src/main/java/com/tutorly/models/Payment.kt
@@ -31,7 +31,7 @@ data class Payment(
     val method: String? = null,       // "cash", "transfer", ...
     val at: Instant = Instant.now(),
     val note: String? = null,
-    val status: PaymentStatus = PaymentStatus.DUE // 👈 добавлено
+    val status: PaymentStatus = PaymentStatus.UNPAID
 )
 
 

--- a/app/src/main/java/com/tutorly/models/PaymentStatus.kt
+++ b/app/src/main/java/com/tutorly/models/PaymentStatus.kt
@@ -5,4 +5,9 @@ enum class PaymentStatus {
     PAID,
     CANCELLED,
     UNPAID,
+    ;
+
+    companion object {
+        val outstandingStatuses: List<PaymentStatus> = listOf(UNPAID, DUE)
+    }
 }

--- a/app/src/main/java/com/tutorly/models/PaymentStatus.kt
+++ b/app/src/main/java/com/tutorly/models/PaymentStatus.kt
@@ -1,3 +1,8 @@
 package com.tutorly.models
 
-enum class PaymentStatus { DUE, PAID, CANCELLED, UNPAID }
+enum class PaymentStatus {
+    DUE,
+    PAID,
+    CANCELLED,
+    UNPAID,
+}

--- a/app/src/main/java/com/tutorly/navigation/AppNav.kt
+++ b/app/src/main/java/com/tutorly/navigation/AppNav.kt
@@ -19,7 +19,10 @@ import com.tutorly.ui.components.AppTopBar
 import com.tutorly.ui.screens.*
 
 
+const val ROUTE_CALENDAR = "calendar"
+const val ROUTE_TODAY = "today"
 const val ROUTE_STUDENTS = "students"
+const val ROUTE_FINANCE = "finance"
 const val ROUTE_STUDENT_NEW = "student/new"
 const val ROUTE_STUDENT_EDIT = "student/{studentId}"
 const val ROUTE_LESSON_NEW = "lesson/new?studentId={studentId}" // под автоподстановку
@@ -30,29 +33,33 @@ private fun studentDetailsRoute(studentId: Long) = ROUTE_STUDENT_EDIT.replace("{
 fun AppNavRoot() {
     val nav = rememberNavController()
     val backStack by nav.currentBackStackEntryAsState()
-    val route = backStack?.destination?.route ?: "calendar"
+    val route = backStack?.destination?.route ?: ROUTE_CALENDAR
 
     // какой топбар показывать
     val showGlobalTopBar = when (route) {
-        "students", "finance" -> true   // тут простой заголовок уместен
+        ROUTE_STUDENTS, ROUTE_FINANCE -> true   // тут простой заголовок уместен
         else -> false                   // calendar/today рисуют верх сами
     }
 
     Scaffold(
         topBar = {
             if (showGlobalTopBar) {
-        AppTopBar(
-            title = when(route){
-                "students" -> "Ученики"
-                "finance"  -> "Финансы"
-                else -> ""
-            },
-            onAddClick = when(route){
-                "students" -> ({ nav.navigate(ROUTE_STUDENT_NEW) })
-                else -> null
+                AppTopBar(
+                    title = when (route) {
+                        ROUTE_STUDENTS -> "Ученики"
+                        ROUTE_FINANCE -> "Финансы"
+                        else -> ""
+                    },
+                    onAddClick = when (route) {
+                        ROUTE_STUDENTS -> ({
+                            nav.navigate(ROUTE_STUDENT_NEW) {
+                                launchSingleTop = true
+                            }
+                        })
+                        else -> null
+                    }
+                )
             }
-        )
-    }
         },
         bottomBar = {
             AppBottomBar(
@@ -71,15 +78,23 @@ fun AppNavRoot() {
     ) { innerPadding ->
         NavHost(
             navController = nav,
-            startDestination = "calendar",
+            startDestination = ROUTE_CALENDAR,
             modifier = Modifier.padding(innerPadding)
         ) {
-            composable("calendar") { CalendarScreen() }   // сам рисует свой верх (месяц/табы/лента)
-            composable("today")    { TodayScreen() }      // сам рисует свой верх (заголовок + счетчики)
+            composable(ROUTE_CALENDAR) { CalendarScreen() }   // сам рисует свой верх (месяц/табы/лента)
+            composable(ROUTE_TODAY)    { TodayScreen() }      // сам рисует свой верх (заголовок + счетчики)
             composable(ROUTE_STUDENTS) {
                 StudentsScreen(
-                    onStudentClick = { id -> nav.navigate(studentDetailsRoute(id)) },
-                    onAddClick = { nav.navigate(ROUTE_STUDENT_NEW) }
+                    onStudentClick = { id ->
+                        nav.navigate(studentDetailsRoute(id)) {
+                            launchSingleTop = true
+                        }
+                    },
+                    onAddClick = {
+                        nav.navigate(ROUTE_STUDENT_NEW) {
+                            launchSingleTop = true
+                        }
+                    }
                 )
             }
             composable(ROUTE_STUDENT_NEW) {
@@ -104,7 +119,7 @@ fun AppNavRoot() {
                     }
                 )
             }
-            composable("finance")  { FinanceScreen() }
+            composable(ROUTE_FINANCE)  { FinanceScreen() }
         }
     }
 }

--- a/app/src/main/java/com/tutorly/ui/components/AppBottomBar.kt
+++ b/app/src/main/java/com/tutorly/ui/components/AppBottomBar.kt
@@ -5,13 +5,17 @@ import androidx.compose.material.icons.outlined.*
 import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
+import com.tutorly.navigation.ROUTE_CALENDAR
+import com.tutorly.navigation.ROUTE_FINANCE
+import com.tutorly.navigation.ROUTE_STUDENTS
+import com.tutorly.navigation.ROUTE_TODAY
 import com.tutorly.ui.theme.RoyalBlue
 
 enum class Tab(val route:String, val label:String, val icon: androidx.compose.ui.graphics.vector.ImageVector){
-    Calendar("calendar", "Календарь", Icons.Outlined.CalendarMonth),
-    Today("today", "Сегодня", Icons.Outlined.AssignmentTurnedIn),
-    Students("students", "Ученики", Icons.Outlined.People),
-    Finance("finance", "Финансы", Icons.Outlined.AttachMoney),
+    Calendar(ROUTE_CALENDAR, "Календарь", Icons.Outlined.CalendarMonth),
+    Today(ROUTE_TODAY, "Сегодня", Icons.Outlined.AssignmentTurnedIn),
+    Students(ROUTE_STUDENTS, "Ученики", Icons.Outlined.People),
+    Finance(ROUTE_FINANCE, "Финансы", Icons.Outlined.AttachMoney),
 }
 
 @Composable

--- a/app/src/main/java/com/tutorly/ui/screens/StudentsScreen.kt
+++ b/app/src/main/java/com/tutorly/ui/screens/StudentsScreen.kt
@@ -1,0 +1,133 @@
+package com.tutorly.ui.screens
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.tutorly.ui.components.PaymentBadge
+import com.tutorly.R
+
+@Composable
+fun StudentsScreen(
+    onStudentClick: (Long) -> Unit,
+    onAddClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    vm: StudentsViewModel = hiltViewModel(),
+) {
+    val query by vm.query.collectAsState()
+    val students by vm.students.collectAsState()
+
+    Scaffold(
+        floatingActionButton = {
+            FloatingActionButton(onClick = onAddClick) {
+                Icon(Icons.Default.Add, contentDescription = stringResource(id = R.string.add_student))
+            }
+        }
+    ) { innerPadding ->
+        Column(
+            modifier
+                .fillMaxSize()
+                .padding(innerPadding)
+                .padding(horizontal = 16.dp, vertical = 12.dp)
+        ) {
+            OutlinedTextField(
+                value = query,
+                onValueChange = vm::onQueryChange,
+                modifier = Modifier.fillMaxWidth(),
+                singleLine = true,
+                leadingIcon = { Icon(Icons.Default.Search, contentDescription = null) },
+                placeholder = { Text(text = stringResource(id = R.string.search_students_hint)) }
+            )
+
+            Spacer(Modifier.height(16.dp))
+
+            if (students.isEmpty()) {
+                EmptyStudentsState(Modifier.fillMaxSize())
+            } else {
+                LazyColumn(
+                    modifier = Modifier.fillMaxSize(),
+                    verticalArrangement = Arrangement.spacedBy(12.dp),
+                    contentPadding = PaddingValues(bottom = 88.dp)
+                ) {
+                    items(
+                        items = students,
+                        key = { it.student.id }
+                    ) { item ->
+                        StudentCard(
+                            item = item,
+                            onClick = { onStudentClick(item.student.id) }
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun EmptyStudentsState(modifier: Modifier = Modifier) {
+    Box(modifier, contentAlignment = Alignment.Center) {
+        Text(text = stringResource(id = R.string.students_empty_state), style = MaterialTheme.typography.bodyMedium)
+    }
+}
+
+@Composable
+private fun StudentCard(
+    item: StudentsViewModel.StudentListItem,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Card(
+        onClick = onClick,
+        modifier = modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface)
+    ) {
+        Column(Modifier.padding(16.dp)) {
+            Text(
+                text = item.student.name,
+                style = MaterialTheme.typography.titleMedium,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
+            )
+            item.student.phone?.takeIf { it.isNotBlank() }?.let { phone ->
+                Spacer(Modifier.height(6.dp))
+                Text(
+                    text = phone,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+            if (item.hasDebt) {
+                Spacer(Modifier.height(12.dp))
+                PaymentBadge(paid = false)
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/tutorly/ui/screens/StudentsViewModel.kt
+++ b/app/src/main/java/com/tutorly/ui/screens/StudentsViewModel.kt
@@ -1,0 +1,83 @@
+package com.tutorly.ui.screens
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.tutorly.domain.repo.StudentsRepository
+import com.tutorly.models.Student
+import dagger.hilt.android.lifecycle.HiltViewModel
+import jakarta.inject.Inject
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.flow.SharingStarted
+
+@HiltViewModel
+class StudentsViewModel @Inject constructor(
+    private val repo: StudentsRepository
+) : ViewModel() {
+
+    private val _query = MutableStateFlow("")
+    val query: StateFlow<String> = _query.asStateFlow()
+
+    private val debtObservers = mutableMapOf<Long, Job>()
+    private val _debts = MutableStateFlow<Map<Long, Boolean>>(emptyMap())
+
+    private val studentsStream = _query
+        .map { it.trim() }
+        .distinctUntilChanged()
+        .flatMapLatest { repo.observeStudents(it) }
+        .onEach { syncDebtObservers(it) }
+
+    val students: StateFlow<List<StudentListItem>> = combine(studentsStream, _debts) { students, debts ->
+        students.map { student ->
+            StudentListItem(student, debts[student.id] == true)
+        }
+    }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())
+
+    fun onQueryChange(value: String) {
+        _query.value = value
+    }
+
+    private fun syncDebtObservers(students: List<Student>) {
+        val ids = students.map { it.id }.toSet()
+        val existing = debtObservers.keys.toSet()
+
+        val toRemove = existing - ids
+        if (toRemove.isNotEmpty()) {
+            toRemove.forEach { id ->
+                debtObservers.remove(id)?.cancel()
+            }
+            _debts.update { debts -> debts - toRemove }
+        }
+
+        val toAdd = ids - existing
+        toAdd.forEach { id ->
+            debtObservers[id] = viewModelScope.launch {
+                repo.observeHasDebt(id).collect { hasDebt ->
+                    _debts.update { debts -> debts + (id to hasDebt) }
+                }
+            }
+        }
+    }
+
+    override fun onCleared() {
+        super.onCleared()
+        debtObservers.values.forEach { it.cancel() }
+        debtObservers.clear()
+    }
+
+    data class StudentListItem(
+        val student: Student,
+        val hasDebt: Boolean
+    )
+}

--- a/app/src/main/java/com/tutorly/ui/screens/StudentsViewModel.kt
+++ b/app/src/main/java/com/tutorly/ui/screens/StudentsViewModel.kt
@@ -5,7 +5,7 @@ import androidx.lifecycle.viewModelScope
 import com.tutorly.domain.repo.StudentsRepository
 import com.tutorly.models.Student
 import dagger.hilt.android.lifecycle.HiltViewModel
-import jakarta.inject.Inject
+import javax.inject.Inject
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,3 +1,6 @@
 <resources>
     <string name="app_name">Tutorly</string>
+    <string name="add_student">Добавить ученика</string>
+    <string name="search_students_hint">Поиск по имени или телефону</string>
+    <string name="students_empty_state">Добавьте первого ученика</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -3,4 +3,10 @@
     <string name="add_student">Добавить ученика</string>
     <string name="search_students_hint">Поиск по имени или телефону</string>
     <string name="students_empty_state">Добавьте первого ученика</string>
+    <string name="student_editor_title">Ученик</string>
+    <string name="student_editor_close">Закрыть</string>
+    <string name="student_editor_save">Сохранить ученика</string>
+    <string name="student_editor_name">Имя*</string>
+    <string name="student_editor_phone">Телефон</string>
+    <string name="student_editor_notes">Заметки</string>
 </resources>


### PR DESCRIPTION
## Summary
- add synchronous debt lookup and aggregation queries to `PaymentDao`
- surface the new helpers via the Room payments repository and domain interface

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e67b43f9e08320a21acae5da3985df