### PR TITLE
Redesign student details screen with lesson history

### DIFF
--- a/app/src/main/java/com/tutorly/data/db/dao/LessonDao.kt
+++ b/app/src/main/java/com/tutorly/data/db/dao/LessonDao.kt
@@ -2,6 +2,7 @@ package com.tutorly.data.db.dao
 
 import androidx.room.*
 import com.tutorly.models.*
+import kotlinx.coroutines.flow.Flow
 import java.time.Instant
 
 @Dao
@@ -9,6 +10,9 @@ interface LessonDao {
     @Transaction
     @Query("SELECT * FROM lessons WHERE startAt >= :from AND startAt < :to ORDER BY startAt")
     suspend fun inRange(from: Instant, to: Instant): List<Lesson>
+
+    @Query("SELECT * FROM lessons WHERE studentId = :studentId ORDER BY startAt DESC")
+    fun observeByStudent(studentId: Long): Flow<List<Lesson>>
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun upsert(lesson: Lesson): Long

--- a/app/src/main/java/com/tutorly/data/repo/memory/InMemoryLessonsRepository.kt
+++ b/app/src/main/java/com/tutorly/data/repo/memory/InMemoryLessonsRepository.kt
@@ -1,8 +1,11 @@
 package com.tutorly.data.repo.memory
 
+import com.tutorly.domain.repo.LessonsRepository
 import com.tutorly.models.Lesson
 import com.tutorly.models.PaymentStatus
-import com.tutorly.domain.repo.LessonsRepository
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.map
 import java.time.Instant
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicLong
@@ -10,21 +13,36 @@ import java.util.concurrent.atomic.AtomicLong
 class InMemoryLessonsRepository : LessonsRepository {
     private val seq = AtomicLong(1)
     private val store = ConcurrentHashMap<Long, Lesson>()
+    private val lessonsFlow = MutableStateFlow<List<Lesson>>(emptyList())
 
     override suspend fun inRange(from: Instant, to: Instant) =
         store.values.filter { it.startAt >= from && it.startAt < to }.sortedBy { it.startAt }
 
+    override fun observeByStudent(studentId: Long): Flow<List<Lesson>> =
+        lessonsFlow.map { lessons -> lessons.filter { it.studentId == studentId } }
+
     override suspend fun upsert(lesson: Lesson): Long {
         val id = if (lesson.id == 0L) seq.getAndIncrement() else lesson.id
         store[id] = lesson.copy(id = id)
+        emit()
         return id
     }
 
     override suspend fun markPayment(id: Long, status: PaymentStatus, paidCents: Int) {
-        store[id]?.let { store[id] = it.copy(paymentStatus = status, paidCents = paidCents) }
+        store[id]?.let {
+            store[id] = it.copy(paymentStatus = status, paidCents = paidCents)
+            emit()
+        }
     }
 
     override suspend fun saveNote(id: Long, note: String?) {
-        store[id]?.let { store[id] = it.copy(note = note) }
+        store[id]?.let {
+            store[id] = it.copy(note = note)
+            emit()
+        }
+    }
+
+    private fun emit() {
+        lessonsFlow.value = store.values.sortedByDescending { it.startAt }
     }
 }

--- a/app/src/main/java/com/tutorly/data/repo/room/RoomLessonsRepository.kt
+++ b/app/src/main/java/com/tutorly/data/repo/room/RoomLessonsRepository.kt
@@ -1,15 +1,17 @@
 package com.tutorly.data.repo.room
 
+import com.tutorly.domain.repo.LessonsRepository
 import com.tutorly.data.db.dao.LessonDao
 import com.tutorly.models.Lesson
 import com.tutorly.models.PaymentStatus
-import com.tutorly.domain.repo.LessonsRepository
+import kotlinx.coroutines.flow.Flow
 import java.time.Instant
 
 class RoomLessonsRepository(
     private val dao: LessonDao
 ) : LessonsRepository {
     override suspend fun inRange(from: Instant, to: Instant): List<Lesson> = dao.inRange(from, to)
+    override fun observeByStudent(studentId: Long): Flow<List<Lesson>> = dao.observeByStudent(studentId)
     override suspend fun upsert(lesson: Lesson): Long = dao.upsert(lesson)
     override suspend fun markPayment(id: Long, status: PaymentStatus, paidCents: Int) =
         dao.updatePayment(id, status, paidCents, Instant.now())

--- a/app/src/main/java/com/tutorly/domain/repo/LessonsRepository.kt
+++ b/app/src/main/java/com/tutorly/domain/repo/LessonsRepository.kt
@@ -2,10 +2,12 @@ package com.tutorly.domain.repo
 
 import com.tutorly.models.Lesson
 import com.tutorly.models.PaymentStatus
+import kotlinx.coroutines.flow.Flow
 import java.time.Instant
 
 interface LessonsRepository {
     suspend fun inRange(from: Instant, to: Instant): List<Lesson>
+    fun observeByStudent(studentId: Long): Flow<List<Lesson>>
     suspend fun upsert(lesson: Lesson): Long
     suspend fun markPayment(id: Long, status: PaymentStatus, paidCents: Int)
     suspend fun saveNote(id: Long, note: String?)

--- a/app/src/main/java/com/tutorly/ui/screens/StudentDetailsScreen.kt
+++ b/app/src/main/java/com/tutorly/ui/screens/StudentDetailsScreen.kt
@@ -3,24 +3,32 @@ package com.tutorly.ui.screens
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material.icons.outlined.Message
+import androidx.compose.material.icons.outlined.Phone
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Divider
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
@@ -30,14 +38,20 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.tutorly.R
+import com.tutorly.models.Lesson
+import com.tutorly.models.PaymentStatus
 import com.tutorly.models.Student
 import com.tutorly.ui.components.PaymentBadge
 import java.text.NumberFormat
+import java.time.Duration
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
 import java.util.Locale
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -86,6 +100,19 @@ fun StudentDetailsScreen(
                 }
             }
             else -> {
+                val student = requireNotNull(state.student)
+                val lessons = remember(state.lessons) {
+                    state.lessons.sortedByDescending { it.startAt }
+                }
+                val locale = remember { Locale("ru", "RU") }
+                val currencyFormatter = remember(locale) { NumberFormat.getCurrencyInstance(locale) }
+                val totalEarnedCents = remember(lessons) { lessons.sumOf { it.paidCents.toLong() } }
+                val formattedTotalEarned = remember(totalEarnedCents) {
+                    currencyFormatter.format(totalEarnedCents / 100.0)
+                }
+                val formattedDebt = remember(state.totalDebtCents) {
+                    currencyFormatter.format(state.totalDebtCents / 100.0)
+                }
                 Column(
                     modifier = modifier
                         .fillMaxSize()
@@ -94,12 +121,27 @@ fun StudentDetailsScreen(
                         .padding(horizontal = 16.dp, vertical = 20.dp),
                     verticalArrangement = Arrangement.spacedBy(20.dp)
                 ) {
-                    StudentPaymentsCard(
+                    StudentSummaryCard(
+                        student = student,
                         hasDebt = state.hasDebt,
-                        totalDebtCents = state.totalDebtCents
+                        totalDebt = formattedDebt
                     )
-                    StudentContactCard(student = state.student)
-                    StudentNotesCard(note = state.student.note)
+                    StudentContactCard(student = student)
+                    StudentStatsRow(
+                        totalLessons = lessons.size,
+                        formattedTotalEarned = formattedTotalEarned,
+                        paidLessons = lessons.count { it.paymentStatus == PaymentStatus.PAID },
+                        hasDebt = state.hasDebt,
+                        formattedDebt = formattedDebt
+                    )
+                    if (!student.note.isNullOrBlank()) {
+                        StudentNotesCard(note = student.note!!)
+                    }
+                    LessonsHistoryCard(
+                        lessons = lessons,
+                        currencyFormatter = currencyFormatter,
+                        locale = locale
+                    )
                 }
             }
         }
@@ -124,7 +166,7 @@ private fun StudentDetailsTopBar(
         navigationIcon = {
             IconButton(onClick = onBack) {
                 Icon(
-                    imageVector = Icons.Default.ArrowBack,
+                    imageVector = Icons.Filled.ArrowBack,
                     contentDescription = stringResource(id = R.string.student_details_back)
                 )
             }
@@ -133,7 +175,7 @@ private fun StudentDetailsTopBar(
             onEdit?.let {
                 IconButton(onClick = it) {
                     Icon(
-                        imageVector = Icons.Default.Edit,
+                        imageVector = Icons.Filled.Edit,
                         contentDescription = stringResource(id = R.string.student_details_edit)
                     )
                 }
@@ -147,32 +189,51 @@ private fun StudentDetailsTopBar(
 }
 
 @Composable
-private fun StudentPaymentsCard(
+private fun StudentSummaryCard(
+    student: Student,
     hasDebt: Boolean,
-    totalDebtCents: Long,
+    totalDebt: String,
     modifier: Modifier = Modifier
 ) {
-    val formatter = remember { NumberFormat.getCurrencyInstance(Locale("ru", "RU")) }
-    val formattedDebt = remember(totalDebtCents) { formatter.format(totalDebtCents / 100.0) }
+    val subtitle = remember(student.note) {
+        student.note
+            ?.lineSequence()
+            ?.firstOrNull()
+            ?.takeIf { it.isNotBlank() }
+    }
     Card(
         modifier = modifier.fillMaxWidth(),
-        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant)
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.primaryContainer)
     ) {
-        Column(Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(12.dp)) {
+        Column(
+            modifier = Modifier.padding(20.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
             Text(
-                text = stringResource(id = R.string.student_details_payments_title),
-                style = MaterialTheme.typography.titleMedium
+                text = student.name,
+                style = MaterialTheme.typography.headlineSmall,
+                color = MaterialTheme.colorScheme.onPrimaryContainer
             )
-            PaymentBadge(paid = !hasDebt)
             Text(
-                text = if (hasDebt) {
-                    stringResource(id = R.string.student_details_debt_amount, formattedDebt)
-                } else {
-                    stringResource(id = R.string.student_details_no_debt)
-                },
+                text = subtitle ?: stringResource(id = R.string.student_details_header_placeholder),
                 style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant
+                color = MaterialTheme.colorScheme.onPrimaryContainer
             )
+            Row(
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                PaymentBadge(paid = !hasDebt)
+                Spacer(modifier = Modifier.width(12.dp))
+                Text(
+                    text = if (hasDebt) {
+                        stringResource(id = R.string.student_details_debt_amount, totalDebt)
+                    } else {
+                        stringResource(id = R.string.student_details_no_debt)
+                    },
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onPrimaryContainer
+                )
+            }
         }
     }
 }
@@ -183,17 +244,22 @@ private fun StudentContactCard(
     modifier: Modifier = Modifier
 ) {
     Card(modifier = modifier.fillMaxWidth()) {
-        Column(Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(12.dp)) {
+        Column(
+            modifier = Modifier.padding(20.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
             Text(
                 text = stringResource(id = R.string.student_details_contact_title),
                 style = MaterialTheme.typography.titleMedium
             )
-            InfoRow(
+            ContactInfoRow(
+                icon = Icons.Outlined.Phone,
                 label = stringResource(id = R.string.student_details_phone_label),
                 value = student.phone,
                 placeholder = stringResource(id = R.string.student_details_phone_placeholder)
             )
-            InfoRow(
+            ContactInfoRow(
+                icon = Icons.Outlined.Message,
                 label = stringResource(id = R.string.student_details_messenger_label),
                 value = student.messenger,
                 placeholder = stringResource(id = R.string.student_details_messenger_placeholder)
@@ -203,20 +269,106 @@ private fun StudentContactCard(
 }
 
 @Composable
-private fun StudentNotesCard(
-    note: String?,
+private fun ContactInfoRow(
+    icon: androidx.compose.ui.graphics.vector.ImageVector,
+    label: String,
+    value: String?,
+    placeholder: String,
     modifier: Modifier = Modifier
 ) {
-    Card(modifier = modifier.fillMaxWidth()) {
-        Column(Modifier.padding(16.dp)) {
-            Text(
-                text = stringResource(id = R.string.student_details_notes_title),
-                style = MaterialTheme.typography.titleMedium
+    Row(
+        modifier = modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(16.dp)
+    ) {
+        Surface(
+            color = MaterialTheme.colorScheme.primary.copy(alpha = 0.12f),
+            shape = CircleShape
+        ) {
+            Icon(
+                imageVector = icon,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.primary,
+                modifier = Modifier.padding(12.dp)
             )
-            Spacer(modifier = Modifier.height(8.dp))
+        }
+        Column(modifier = Modifier.weight(1f)) {
             Text(
-                text = note?.takeIf { it.isNotBlank() }
-                    ?: stringResource(id = R.string.student_details_notes_placeholder),
+                text = label,
+                style = MaterialTheme.typography.labelMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+            Text(
+                text = value?.takeIf { it.isNotBlank() } ?: placeholder,
+                style = MaterialTheme.typography.bodyLarge,
+                color = if (value.isNullOrBlank()) {
+                    MaterialTheme.colorScheme.onSurfaceVariant
+                } else {
+                    MaterialTheme.colorScheme.onSurface
+                },
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
+            )
+        }
+    }
+}
+
+@Composable
+private fun StudentStatsRow(
+    totalLessons: Int,
+    formattedTotalEarned: String,
+    paidLessons: Int,
+    hasDebt: Boolean,
+    formattedDebt: String,
+    modifier: Modifier = Modifier
+) {
+    Row(
+        modifier = modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(12.dp)
+    ) {
+        SummaryStatCard(
+            modifier = Modifier.weight(1f),
+            value = totalLessons.toString(),
+            label = stringResource(id = R.string.student_details_stats_lessons)
+        )
+        SummaryStatCard(
+            modifier = Modifier.weight(1f),
+            value = formattedTotalEarned,
+            label = stringResource(id = R.string.student_details_stats_earned)
+        )
+        val (thirdValue, thirdLabel) = if (hasDebt) {
+            formattedDebt to stringResource(id = R.string.student_details_stats_debt)
+        } else {
+            paidLessons.toString() to stringResource(id = R.string.student_details_stats_paid)
+        }
+        SummaryStatCard(
+            modifier = Modifier.weight(1f),
+            value = thirdValue,
+            label = thirdLabel
+        )
+    }
+}
+
+@Composable
+private fun SummaryStatCard(
+    value: String,
+    label: String,
+    modifier: Modifier = Modifier
+) {
+    Card(
+        modifier = modifier,
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface)
+    ) {
+        Column(
+            modifier = Modifier.padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            Text(
+                text = value,
+                style = MaterialTheme.typography.titleLarge
+            )
+            Text(
+                text = label,
                 style = MaterialTheme.typography.bodyMedium,
                 color = MaterialTheme.colorScheme.onSurfaceVariant
             )
@@ -225,27 +377,153 @@ private fun StudentNotesCard(
 }
 
 @Composable
-private fun InfoRow(
-    label: String,
-    value: String?,
-    placeholder: String,
+private fun StudentNotesCard(
+    note: String,
     modifier: Modifier = Modifier
 ) {
-    Column(modifier = modifier.fillMaxWidth()) {
-        Text(
-            text = label,
-            style = MaterialTheme.typography.labelMedium,
-            color = MaterialTheme.colorScheme.onSurfaceVariant
-        )
-        Spacer(modifier = Modifier.height(4.dp))
-        Text(
-            text = value?.takeIf { it.isNotBlank() } ?: placeholder,
-            style = MaterialTheme.typography.bodyLarge,
-            color = if (value.isNullOrBlank()) {
-                MaterialTheme.colorScheme.onSurfaceVariant
+    Card(modifier = modifier.fillMaxWidth()) {
+        Column(
+            modifier = Modifier.padding(20.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            Text(
+                text = stringResource(id = R.string.student_details_notes_title),
+                style = MaterialTheme.typography.titleMedium
+            )
+            Text(
+                text = note,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+    }
+}
+
+@Composable
+private fun LessonsHistoryCard(
+    lessons: List<Lesson>,
+    currencyFormatter: NumberFormat,
+    locale: Locale,
+    modifier: Modifier = Modifier
+) {
+    val dateFormatter = remember(locale) {
+        DateTimeFormatter.ofPattern("d MMMM", locale)
+    }
+    val timeFormatter = remember(locale) {
+        DateTimeFormatter.ofPattern("HH:mm", locale)
+    }
+    Card(modifier = modifier.fillMaxWidth()) {
+        Column(
+            modifier = Modifier.padding(20.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
+            Text(
+                text = stringResource(id = R.string.student_details_history_title),
+                style = MaterialTheme.typography.titleMedium
+            )
+            if (lessons.isEmpty()) {
+                Text(
+                    text = stringResource(id = R.string.student_details_history_empty),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
             } else {
-                MaterialTheme.colorScheme.onSurface
+                Column(verticalArrangement = Arrangement.spacedBy(16.dp)) {
+                    lessons.forEachIndexed { index, lesson ->
+                        LessonHistoryRow(
+                            lesson = lesson,
+                            currencyFormatter = currencyFormatter,
+                            dateFormatter = dateFormatter,
+                            timeFormatter = timeFormatter
+                        )
+                        if (index != lessons.lastIndex) {
+                            Divider()
+                        }
+                    }
+                }
             }
+        }
+    }
+}
+
+@Composable
+private fun LessonHistoryRow(
+    lesson: Lesson,
+    currencyFormatter: NumberFormat,
+    dateFormatter: DateTimeFormatter,
+    timeFormatter: DateTimeFormatter,
+    modifier: Modifier = Modifier
+) {
+    val zoneId = remember { ZoneId.systemDefault() }
+    val start = remember(lesson.startAt) { lesson.startAt.atZone(zoneId) }
+    val end = remember(lesson.endAt) { lesson.endAt.atZone(zoneId) }
+    val durationMinutes = remember(lesson.startAt, lesson.endAt) {
+        Duration.between(lesson.startAt, lesson.endAt).toMinutes().toInt().coerceAtLeast(0)
+    }
+    Row(
+        modifier = modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = dateFormatter.format(start),
+                style = MaterialTheme.typography.titleSmall
+            )
+            Spacer(modifier = Modifier.height(4.dp))
+            Text(
+                text = stringResource(
+                    id = R.string.student_details_history_time_range,
+                    timeFormatter.format(start),
+                    timeFormatter.format(end),
+                    durationMinutes
+                ),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+        Column(horizontalAlignment = Alignment.End) {
+            Text(
+                text = currencyFormatter.format(lesson.priceCents / 100.0),
+                style = MaterialTheme.typography.titleSmall
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+            LessonPaymentStatusBadge(status = lesson.paymentStatus)
+        }
+    }
+}
+
+@Composable
+private fun LessonPaymentStatusBadge(
+    status: PaymentStatus,
+    modifier: Modifier = Modifier
+) {
+    val (labelRes, container, content) = when (status) {
+        PaymentStatus.PAID -> Triple(
+            R.string.lesson_status_paid,
+            Color(0xFFE6F4EA),
+            Color(0xFF2E7D32)
+        )
+        PaymentStatus.DUE, PaymentStatus.UNPAID -> Triple(
+            R.string.lesson_status_due,
+            Color(0xFFFFF3E0),
+            Color(0xFFEF6C00)
+        )
+        PaymentStatus.CANCELLED -> Triple(
+            R.string.lesson_status_cancelled,
+            Color(0xFFE0E0E0),
+            Color(0xFF5F6368)
+        )
+    }
+    Surface(
+        modifier = modifier,
+        color = container,
+        contentColor = content,
+        shape = RoundedCornerShape(999.dp)
+    ) {
+        Text(
+            text = stringResource(id = labelRes),
+            style = MaterialTheme.typography.labelMedium,
+            modifier = Modifier.padding(horizontal = 12.dp, vertical = 6.dp)
         )
     }
 }

--- a/app/src/main/java/com/tutorly/ui/screens/StudentDetailsViewModel.kt
+++ b/app/src/main/java/com/tutorly/ui/screens/StudentDetailsViewModel.kt
@@ -3,8 +3,10 @@ package com.tutorly.ui.screens
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.tutorly.domain.repo.LessonsRepository
 import com.tutorly.domain.repo.PaymentsRepository
 import com.tutorly.domain.repo.StudentsRepository
+import com.tutorly.models.Lesson
 import com.tutorly.models.Student
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
@@ -17,7 +19,8 @@ import kotlinx.coroutines.flow.stateIn
 class StudentDetailsViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
     studentsRepository: StudentsRepository,
-    paymentsRepository: PaymentsRepository
+    paymentsRepository: PaymentsRepository,
+    lessonsRepository: LessonsRepository
 ) : ViewModel() {
 
     private val studentId: Long = savedStateHandle.get<Long>("studentId")
@@ -26,17 +29,20 @@ class StudentDetailsViewModel @Inject constructor(
     private val studentFlow = studentsRepository.observeStudent(studentId)
     private val hasDebtFlow = paymentsRepository.observeHasDebt(studentId)
     private val totalDebtFlow = paymentsRepository.observeTotalDebt(studentId)
+    private val lessonsFlow = lessonsRepository.observeByStudent(studentId)
 
     val uiState: StateFlow<UiState> = combine(
         studentFlow,
         hasDebtFlow,
-        totalDebtFlow
-    ) { student, hasDebt, totalDebt ->
+        totalDebtFlow,
+        lessonsFlow
+    ) { student, hasDebt, totalDebt, lessons ->
         UiState(
             isLoading = false,
             student = student,
             hasDebt = hasDebt,
-            totalDebtCents = totalDebt
+            totalDebtCents = totalDebt,
+            lessons = lessons
         )
     }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), UiState())
 
@@ -44,6 +50,7 @@ class StudentDetailsViewModel @Inject constructor(
         val isLoading: Boolean = true,
         val student: Student? = null,
         val hasDebt: Boolean = false,
-        val totalDebtCents: Long = 0L
+        val totalDebtCents: Long = 0L,
+        val lessons: List<Lesson> = emptyList()
     )
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -16,6 +16,7 @@
     <string name="student_details_payments_title">Платежи</string>
     <string name="student_details_debt_amount">Долг: %1$s</string>
     <string name="student_details_no_debt">Долгов нет</string>
+    <string name="student_details_header_placeholder">Дополнительная информация не указана</string>
     <string name="student_details_contact_title">Контакты</string>
     <string name="student_details_phone_label">Телефон</string>
     <string name="student_details_phone_placeholder">Не указан</string>
@@ -23,4 +24,14 @@
     <string name="student_details_messenger_placeholder">Не указан</string>
     <string name="student_details_notes_title">Заметки</string>
     <string name="student_details_notes_placeholder">Нет заметок</string>
+    <string name="student_details_stats_lessons">Занятий</string>
+    <string name="student_details_stats_earned">Получено</string>
+    <string name="student_details_stats_paid">Оплачено</string>
+    <string name="student_details_stats_debt">Долг</string>
+    <string name="student_details_history_title">История занятий</string>
+    <string name="student_details_history_empty">Пока нет занятий</string>
+    <string name="student_details_history_time_range">%1$s — %2$s · %3$d мин</string>
+    <string name="lesson_status_paid">Оплачено</string>
+    <string name="lesson_status_due">Долг</string>
+    <string name="lesson_status_cancelled">Отменено</string>
 </resources>


### PR DESCRIPTION
## Summary
- redesign the student details screen to show a header summary, contacts, stats, notes, and a lesson history list
- extend the view model to stream lessons together with debt info and compute display data
- expose lesson-by-student observers across repositories to back the new UI

## Testing
- `bash gradlew test` *(fails: Gradle wrapper download blocked by proxy 403)*

------
https://chatgpt.com/codex/tasks/task_e_68e7ac1aa1f0832086f8612920b59dd5