### PR TITLE
Fix Kotlin toolchain mismatch and handle nullable status icon

### DIFF
--- a/app/src/main/java/com/tutorly/ui/lessoncard/LessonCardSheet.kt
+++ b/app/src/main/java/com/tutorly/ui/lessoncard/LessonCardSheet.kt
@@ -426,10 +426,12 @@ private fun StatusChip(chip: PaymentStatusChip) {
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.spacedBy(6.dp)
         ) {
-            when (chip.icon) {
-                PaymentStatusIcon.PAID -> Icon(imageVector = Icons.Default.Check, contentDescription = null, modifier = Modifier.size(16.dp))
-                PaymentStatusIcon.OUTSTANDING -> Icon(imageVector = Icons.Default.Warning, contentDescription = null, modifier = Modifier.size(16.dp))
-                PaymentStatusIcon.CANCELLED -> Icon(imageVector = Icons.Default.Close, contentDescription = null, modifier = Modifier.size(16.dp))
+            chip.icon?.let { icon ->
+                when (icon) {
+                    PaymentStatusIcon.PAID -> Icon(imageVector = Icons.Default.Check, contentDescription = null, modifier = Modifier.size(16.dp))
+                    PaymentStatusIcon.OUTSTANDING -> Icon(imageVector = Icons.Default.Warning, contentDescription = null, modifier = Modifier.size(16.dp))
+                    PaymentStatusIcon.CANCELLED -> Icon(imageVector = Icons.Default.Close, contentDescription = null, modifier = Modifier.size(16.dp))
+                }
             }
             Text(text = stringResource(chip.labelRes), style = MaterialTheme.typography.labelMedium)
         }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 agp = "8.13.0"
-kotlin = "2.2.20"
+kotlin = "2.0.21"
 coreKtx = "1.17.0"
 junit = "4.13.2"
 junitVersion = "1.3.0"
@@ -54,6 +54,6 @@ hilt-navigation-compose = {module = "androidx.hilt:hilt-navigation-compose", ver
 android-application = { id = "com.android.application", version.ref = "agp" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
-ksp = { id = "com.google.devtools.ksp", version = "2.2.20-2.0.3" }
+ksp = { id = "com.google.devtools.ksp", version = "2.0.21-1.0.27" }
 hilt = { id = "com.google.dagger.hilt.android", version.ref = "hilt" }
 


### PR DESCRIPTION
## Summary
- align the project with Kotlin 2.0.21 and the matching KSP plugin to restore access to Compose weight modifiers
- guard rendering of the payment status icon so the nullable property no longer breaks exhaustiveness checks

## Testing
- not run (Gradle wrapper download blocked by proxy in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68e80e36a96c8320a6a381eab1bce450