### PR TITLE
Adopt Material 3 styling across student UI

### DIFF
--- a/app/src/main/java/com/tutorly/navigation/AppNav.kt
+++ b/app/src/main/java/com/tutorly/navigation/AppNav.kt
@@ -4,6 +4,7 @@ import android.net.Uri
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.systemBars
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -101,6 +102,7 @@ fun AppNavRoot() {
                 }
             )
         },
+        containerColor = MaterialTheme.colorScheme.surface,
         // чтобы контент корректно учитывал статус/навигационные панели
         contentWindowInsets = WindowInsets.systemBars
     ) { innerPadding ->

--- a/app/src/main/java/com/tutorly/ui/components/AppBottomBar.kt
+++ b/app/src/main/java/com/tutorly/ui/components/AppBottomBar.kt
@@ -2,14 +2,18 @@ package com.tutorly.ui.components
 
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.*
-import androidx.compose.material3.*
+import androidx.compose.material3.Icon
+import androidx.compose.material3.NavigationBar
+import androidx.compose.material3.NavigationBarDefaults
+import androidx.compose.material3.NavigationBarItem
+import androidx.compose.material3.NavigationBarItemDefaults
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.graphics.Color
+import androidx.compose.material3.MaterialTheme
 import com.tutorly.navigation.ROUTE_CALENDAR
 import com.tutorly.navigation.ROUTE_FINANCE
 import com.tutorly.navigation.ROUTE_STUDENTS
 import com.tutorly.navigation.ROUTE_TODAY
-import com.tutorly.ui.theme.RoyalBlue
 
 enum class Tab(val route:String, val label:String, val icon: androidx.compose.ui.graphics.vector.ImageVector){
     Calendar(ROUTE_CALENDAR, "Календарь", Icons.Outlined.CalendarMonth),
@@ -20,7 +24,10 @@ enum class Tab(val route:String, val label:String, val icon: androidx.compose.ui
 
 @Composable
 fun AppBottomBar(currentRoute: String, onSelect:(String)->Unit) {
-    NavigationBar(containerColor = Color.White) {
+    NavigationBar(
+        containerColor = MaterialTheme.colorScheme.surface,
+        tonalElevation = NavigationBarDefaults.Elevation
+    ) {
         Tab.entries.forEach { tab ->
             val selected = tab.route == currentRoute
             NavigationBarItem(
@@ -29,9 +36,11 @@ fun AppBottomBar(currentRoute: String, onSelect:(String)->Unit) {
                 icon = { Icon(tab.icon, contentDescription = tab.label) },
                 label = { Text(tab.label) },
                 colors = NavigationBarItemDefaults.colors(
-                    selectedIconColor = RoyalBlue,
-                    selectedTextColor = RoyalBlue,
-                    indicatorColor = RoyalBlue.copy(alpha = 0.08f)
+                    selectedIconColor = MaterialTheme.colorScheme.onPrimaryContainer,
+                    selectedTextColor = MaterialTheme.colorScheme.onPrimaryContainer,
+                    unselectedIconColor = MaterialTheme.colorScheme.onSurfaceVariant,
+                    unselectedTextColor = MaterialTheme.colorScheme.onSurfaceVariant,
+                    indicatorColor = MaterialTheme.colorScheme.primaryContainer
                 )
             )
         }

--- a/app/src/main/java/com/tutorly/ui/components/PaymentBadge.kt
+++ b/app/src/main/java/com/tutorly/ui/components/PaymentBadge.kt
@@ -1,21 +1,41 @@
 package com.tutorly.ui.components
 
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 
 @Composable
 fun PaymentBadge(paid: Boolean) {
-    val (txt, bg, fg) = if (paid)
-        Triple("Оплачено", Color(0xFFE6F4EA), Color(0xFF2E7D32))
-    else
-        Triple("Долг", Color(0xFFFFF3E0), Color(0xFFEF6C00))
-    Surface(color = bg, shape = androidx.compose.foundation.shape.RoundedCornerShape(999.dp)) {
-        Text(txt, color = fg, fontSize = 12.sp, modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp))
+    val colorScheme = MaterialTheme.colorScheme
+    val (txt, container, content) = if (paid) {
+        Triple(
+            "Оплачено",
+            colorScheme.tertiaryContainer,
+            colorScheme.onTertiaryContainer
+        )
+    } else {
+        Triple(
+            "Долг",
+            colorScheme.errorContainer,
+            colorScheme.onErrorContainer
+        )
+    }
+    Surface(
+        color = container,
+        contentColor = content,
+        shape = RoundedCornerShape(999.dp),
+        tonalElevation = 1.dp
+    ) {
+        Text(
+            txt,
+            fontSize = 12.sp,
+            modifier = Modifier.padding(horizontal = 10.dp, vertical = 4.dp)
+        )
     }
 }

--- a/app/src/main/java/com/tutorly/ui/components/TopBar.kt
+++ b/app/src/main/java/com/tutorly/ui/components/TopBar.kt
@@ -3,35 +3,41 @@ package com.tutorly.ui.components
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.FilledIconButton
+import androidx.compose.material3.FilledTonalIconButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButtonDefaults
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.res.stringResource
 import com.tutorly.R
-import com.tutorly.ui.theme.RoyalBlue
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun AppTopBar(title: String, onAddClick: (() -> Unit)? = null) {
     TopAppBar(
-        title = { Text(title, maxLines = 1, overflow = TextOverflow.Ellipsis, color = Color.White) },
+        title = {
+            Text(
+                title,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                color = MaterialTheme.colorScheme.onSurface
+            )
+        },
         colors = TopAppBarDefaults.topAppBarColors(
-            containerColor = RoyalBlue,
-            titleContentColor = Color.White
+            containerColor = MaterialTheme.colorScheme.surface,
+            titleContentColor = MaterialTheme.colorScheme.onSurface
         ),
         actions = {
             onAddClick?.let {
-                FilledIconButton(
+                FilledTonalIconButton(
                     onClick = it,
-                    colors = IconButtonDefaults.filledIconButtonColors(
-                        containerColor = Color.White,
-                        contentColor = RoyalBlue
+                    colors = IconButtonDefaults.filledTonalIconButtonColors(
+                        containerColor = MaterialTheme.colorScheme.primaryContainer,
+                        contentColor = MaterialTheme.colorScheme.onPrimaryContainer
                     )
                 ) {
                     Icon(Icons.Default.Add, contentDescription = stringResource(id = R.string.add_student))

--- a/app/src/main/java/com/tutorly/ui/screens/StudentDetailsScreen.kt
+++ b/app/src/main/java/com/tutorly/ui/screens/StudentDetailsScreen.kt
@@ -41,7 +41,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -119,7 +118,8 @@ fun StudentDetailsScreen(
                 onBack = onBack,
                 onEdit = if (state.student != null) onEdit else null
             )
-        }
+        },
+        containerColor = MaterialTheme.colorScheme.surface
     ) { innerPadding ->
         when {
             state.isLoading -> {
@@ -257,7 +257,9 @@ private fun StudentSummaryCard(
     }
     Card(
         modifier = modifier.fillMaxWidth(),
-        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.primaryContainer)
+        shape = MaterialTheme.shapes.extraLarge,
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.primaryContainer),
+        elevation = CardDefaults.cardElevation(defaultElevation = 4.dp)
     ) {
         Column(
             modifier = Modifier.padding(20.dp),
@@ -297,7 +299,12 @@ private fun StudentContactCard(
     student: Student,
     modifier: Modifier = Modifier
 ) {
-    Card(modifier = modifier.fillMaxWidth()) {
+    Card(
+        modifier = modifier.fillMaxWidth(),
+        shape = MaterialTheme.shapes.large,
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceContainerLow),
+        elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
+    ) {
         Column(
             modifier = Modifier.padding(20.dp),
             verticalArrangement = Arrangement.spacedBy(16.dp)
@@ -336,13 +343,14 @@ private fun ContactInfoRow(
         horizontalArrangement = Arrangement.spacedBy(16.dp)
     ) {
         Surface(
-            color = MaterialTheme.colorScheme.primary.copy(alpha = 0.12f),
-            shape = CircleShape
+            color = MaterialTheme.colorScheme.primaryContainer,
+            contentColor = MaterialTheme.colorScheme.onPrimaryContainer,
+            shape = CircleShape,
+            tonalElevation = 2.dp
         ) {
             Icon(
                 imageVector = icon,
                 contentDescription = null,
-                tint = MaterialTheme.colorScheme.primary,
                 modifier = Modifier.padding(12.dp)
             )
         }
@@ -411,7 +419,9 @@ private fun SummaryStatCard(
 ) {
     Card(
         modifier = modifier,
-        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface)
+        shape = MaterialTheme.shapes.large,
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceContainer),
+        elevation = CardDefaults.cardElevation(defaultElevation = 1.dp)
     ) {
         Column(
             modifier = Modifier.padding(16.dp),
@@ -435,7 +445,12 @@ private fun StudentNotesCard(
     note: String,
     modifier: Modifier = Modifier
 ) {
-    Card(modifier = modifier.fillMaxWidth()) {
+    Card(
+        modifier = modifier.fillMaxWidth(),
+        shape = MaterialTheme.shapes.large,
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceContainerLow),
+        elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
+    ) {
         Column(
             modifier = Modifier.padding(20.dp),
             verticalArrangement = Arrangement.spacedBy(8.dp)
@@ -467,7 +482,12 @@ private fun LessonsHistoryCard(
     val timeFormatter = remember(locale) {
         DateTimeFormatter.ofPattern("HH:mm", locale)
     }
-    Card(modifier = modifier.fillMaxWidth()) {
+    Card(
+        modifier = modifier.fillMaxWidth(),
+        shape = MaterialTheme.shapes.large,
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceContainerLow),
+        elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
+    ) {
         Column(
             modifier = Modifier.padding(20.dp),
             verticalArrangement = Arrangement.spacedBy(16.dp)
@@ -493,7 +513,7 @@ private fun LessonsHistoryCard(
                             onClick = onLessonClick
                         )
                         if (index != lessons.lastIndex) {
-                            Divider()
+                            Divider(color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.6f))
                         }
                     }
                 }
@@ -556,28 +576,30 @@ private fun LessonPaymentStatusBadge(
     status: PaymentStatus,
     modifier: Modifier = Modifier
 ) {
+    val colorScheme = MaterialTheme.colorScheme
     val (labelRes, container, content) = when (status) {
         PaymentStatus.PAID -> Triple(
             R.string.lesson_status_paid,
-            Color(0xFFE6F4EA),
-            Color(0xFF2E7D32)
+            colorScheme.tertiaryContainer,
+            colorScheme.onTertiaryContainer
         )
         PaymentStatus.DUE, PaymentStatus.UNPAID -> Triple(
             R.string.lesson_status_due,
-            Color(0xFFFFF3E0),
-            Color(0xFFEF6C00)
+            colorScheme.errorContainer,
+            colorScheme.onErrorContainer
         )
         PaymentStatus.CANCELLED -> Triple(
             R.string.lesson_status_cancelled,
-            Color(0xFFE0E0E0),
-            Color(0xFF5F6368)
+            colorScheme.surfaceVariant,
+            colorScheme.onSurfaceVariant
         )
     }
     Surface(
         modifier = modifier,
         color = container,
         contentColor = content,
-        shape = RoundedCornerShape(999.dp)
+        shape = RoundedCornerShape(999.dp),
+        tonalElevation = 1.dp
     ) {
         Text(
             text = stringResource(id = labelRes),

--- a/app/src/main/java/com/tutorly/ui/screens/StudentsScreen.kt
+++ b/app/src/main/java/com/tutorly/ui/screens/StudentsScreen.kt
@@ -18,7 +18,6 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Close
@@ -47,7 +46,6 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.TileMode
@@ -133,8 +131,13 @@ fun StudentsScreen(
     Scaffold(
         modifier = modifier,
         snackbarHost = { SnackbarHost(hostState = snackbarHostState) },
+        containerColor = MaterialTheme.colorScheme.surface,
         floatingActionButton = {
-            FloatingActionButton(onClick = { openEditor(StudentEditorOrigin.STUDENTS) }) {
+            FloatingActionButton(
+                onClick = { openEditor(StudentEditorOrigin.STUDENTS) },
+                containerColor = MaterialTheme.colorScheme.primary,
+                contentColor = MaterialTheme.colorScheme.onPrimary
+            ) {
                 Icon(imageVector = Icons.Default.Add, contentDescription = stringResource(id = R.string.add_student))
             }
         }
@@ -151,7 +154,8 @@ fun StudentsScreen(
                 modifier = Modifier.fillMaxWidth(),
                 singleLine = true,
                 leadingIcon = { Icon(Icons.Default.Search, contentDescription = null) },
-                placeholder = { Text(text = stringResource(id = R.string.search_students_hint)) }
+                placeholder = { Text(text = stringResource(id = R.string.search_students_hint)) },
+                shape = MaterialTheme.shapes.large
             )
 
             Spacer(Modifier.height(16.dp))
@@ -301,24 +305,18 @@ private fun StudentCard(
     val accentColors = remember(item.student.name) { studentAccentColors(item.student.name) }
     Card(
         onClick = onClick,
-        modifier = modifier
-            .fillMaxWidth()
-            .shadow(
-                elevation = 10.dp,
-                spotColor = accentColors.primary.copy(alpha = 0.18f),
-                ambientColor = accentColors.primary.copy(alpha = 0.12f),
-                shape = RoundedCornerShape(24.dp)
-            ),
-        shape = RoundedCornerShape(24.dp),
+        modifier = modifier.fillMaxWidth(),
+        shape = MaterialTheme.shapes.extraLarge,
         colors = CardDefaults.cardColors(
-            containerColor = MaterialTheme.colorScheme.surface,
+            containerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
         ),
+        elevation = CardDefaults.cardElevation(defaultElevation = 6.dp),
         border = BorderStroke(
             width = 1.dp,
             brush = Brush.linearGradient(
                 colors = listOf(
-                    accentColors.primary.copy(alpha = 0.35f),
-                    accentColors.secondary.copy(alpha = 0.35f)
+                    accentColors.primary.copy(alpha = 0.25f),
+                    accentColors.secondary.copy(alpha = 0.25f)
                 )
             )
         )

--- a/app/src/main/java/com/tutorly/ui/theme/Color.kt
+++ b/app/src/main/java/com/tutorly/ui/theme/Color.kt
@@ -10,8 +10,63 @@ val Purple40 = Color(0xFF6650a4)
 val PurpleGrey40 = Color(0xFF625b71)
 val Pink40 = Color(0xFF7D5260)
 
+// App specific palette tuned for Material 3 tonal hierarchy
+val PrimaryBlue = Color(0xFF3D50F4)
+val OnPrimaryBlue = Color(0xFFFFFFFF)
+val PrimaryBlueContainer = Color(0xFFE0E5FF)
+val OnPrimaryBlueContainer = Color(0xFF001169)
 
-val RoyalBlue = Color(0xFF0A2463) // фирменный
+val SecondaryIndigo = Color(0xFF585FE0)
+val OnSecondaryIndigo = Color(0xFFFFFFFF)
+val SecondaryIndigoContainer = Color(0xFFE1E1FF)
+val OnSecondaryIndigoContainer = Color(0xFF121366)
+
+val TertiaryTeal = Color(0xFF006A63)
+val OnTertiaryTeal = Color(0xFFFFFFFF)
+val TertiaryTealContainer = Color(0xFF71F7E7)
+val OnTertiaryTealContainer = Color(0xFF00201D)
+
+val NeutralBackground = Color(0xFFFBFCFF)
+val NeutralOnBackground = Color(0xFF10131F)
+val NeutralSurfaceVariant = Color(0xFFE0E2F1)
+val NeutralOnSurfaceVariant = Color(0xFF45495C)
+val NeutralOutline = Color(0xFF74788C)
+val NeutralOutlineVariant = Color(0xFFC4C6D7)
+
+val SurfaceContainerLowest = Color(0xFFFFFFFF)
+val SurfaceContainerLow = Color(0xFFF4F5FF)
+val SurfaceContainer = Color(0xFFE8EAFF)
+val SurfaceContainerHigh = Color(0xFFDBDDF4)
+val SurfaceContainerHighest = Color(0xFFCFD2EE)
+
+val ErrorRed = Color(0xFFBA1A1A)
+val OnErrorRed = Color(0xFFFFFFFF)
+val ErrorRedContainer = Color(0xFFFFDAD6)
+val OnErrorRedContainer = Color(0xFF410002)
+
+val DarkPrimaryContainer = Color(0xFF1D2CB5)
+val DarkOnPrimaryContainer = Color(0xFFE0E5FF)
+val DarkSecondaryContainer = Color(0xFF21236F)
+val DarkOnSecondaryContainer = Color(0xFFE1E1FF)
+val DarkTertiaryContainer = Color(0xFF005049)
+val DarkOnTertiaryContainer = Color(0xFF71F7E7)
+
+val DarkBackground = Color(0xFF0F111B)
+val DarkOnBackground = Color(0xFFE0E2FF)
+val DarkSurface = Color(0xFF0F111B)
+val DarkOnSurface = Color(0xFFE0E2FF)
+val DarkSurfaceVariant = Color(0xFF44495C)
+val DarkOnSurfaceVariant = Color(0xFFC4C7DA)
+val DarkOutline = Color(0xFF8E91A6)
+val DarkOutlineVariant = Color(0xFF44495C)
+
+val DarkSurfaceContainerLowest = Color(0xFF090B14)
+val DarkSurfaceContainerLow = Color(0xFF121421)
+val DarkSurfaceContainer = Color(0xFF1A1D2C)
+val DarkSurfaceContainerHigh = Color(0xFF23273A)
+val DarkSurfaceContainerHighest = Color(0xFF2E3145)
+
+val RoyalBlue = Color(0xFF0A2463) // legacy references
 val OnRoyal = Color.White
 
 val RailBlue = Color(0xFF2D7FF9)  // вертикальная рейка слота

--- a/app/src/main/java/com/tutorly/ui/theme/Shape.kt
+++ b/app/src/main/java/com/tutorly/ui/theme/Shape.kt
@@ -1,0 +1,13 @@
+package com.tutorly.ui.theme
+
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Shapes
+import androidx.compose.ui.unit.dp
+
+val Shapes = Shapes(
+    extraSmall = RoundedCornerShape(8.dp),
+    small = RoundedCornerShape(12.dp),
+    medium = RoundedCornerShape(16.dp),
+    large = RoundedCornerShape(20.dp),
+    extraLarge = RoundedCornerShape(28.dp)
+)

--- a/app/src/main/java/com/tutorly/ui/theme/Theme.kt
+++ b/app/src/main/java/com/tutorly/ui/theme/Theme.kt
@@ -13,25 +13,75 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 
 private val DarkColorScheme = darkColorScheme(
-    primary = Purple80,
-    secondary = PurpleGrey80,
-    tertiary = Pink80
+    primary = PrimaryBlue,
+    onPrimary = OnPrimaryBlue,
+    primaryContainer = DarkPrimaryContainer,
+    onPrimaryContainer = DarkOnPrimaryContainer,
+    secondary = SecondaryIndigo,
+    onSecondary = OnSecondaryIndigo,
+    secondaryContainer = DarkSecondaryContainer,
+    onSecondaryContainer = DarkOnSecondaryContainer,
+    tertiary = TertiaryTeal,
+    onTertiary = OnTertiaryTeal,
+    tertiaryContainer = DarkTertiaryContainer,
+    onTertiaryContainer = DarkOnTertiaryContainer,
+    background = DarkBackground,
+    onBackground = DarkOnBackground,
+    surface = DarkSurface,
+    onSurface = DarkOnSurface,
+    surfaceTint = PrimaryBlue,
+    surfaceVariant = DarkSurfaceVariant,
+    onSurfaceVariant = DarkOnSurfaceVariant,
+    outline = DarkOutline,
+    outlineVariant = DarkOutlineVariant,
+    surfaceContainerLowest = DarkSurfaceContainerLowest,
+    surfaceContainerLow = DarkSurfaceContainerLow,
+    surfaceContainer = DarkSurfaceContainer,
+    surfaceContainerHigh = DarkSurfaceContainerHigh,
+    surfaceContainerHighest = DarkSurfaceContainerHighest,
+    error = ErrorRed,
+    onError = OnErrorRed,
+    errorContainer = ErrorRedContainer,
+    onErrorContainer = OnErrorRedContainer,
+    inverseSurface = Color(0xFFE0E2FF),
+    inverseOnSurface = Color(0xFF1B1E2B),
+    inversePrimary = PrimaryBlue
 )
 
 private val LightColorScheme = lightColorScheme(
-    primary = Purple40,
-    secondary = PurpleGrey40,
-    tertiary = Pink40
-
-    /* Other default colors to override
-    background = Color(0xFFFFFBFE),
-    surface = Color(0xFFFFFBFE),
-    onPrimary = Color.White,
-    onSecondary = Color.White,
-    onTertiary = Color.White,
-    onBackground = Color(0xFF1C1B1F),
-    onSurface = Color(0xFF1C1B1F),
-    */
+    primary = PrimaryBlue,
+    onPrimary = OnPrimaryBlue,
+    primaryContainer = PrimaryBlueContainer,
+    onPrimaryContainer = OnPrimaryBlueContainer,
+    secondary = SecondaryIndigo,
+    onSecondary = OnSecondaryIndigo,
+    secondaryContainer = SecondaryIndigoContainer,
+    onSecondaryContainer = OnSecondaryIndigoContainer,
+    tertiary = TertiaryTeal,
+    onTertiary = OnTertiaryTeal,
+    tertiaryContainer = TertiaryTealContainer,
+    onTertiaryContainer = OnTertiaryTealContainer,
+    background = NeutralBackground,
+    onBackground = NeutralOnBackground,
+    surface = NeutralBackground,
+    onSurface = NeutralOnBackground,
+    surfaceTint = PrimaryBlue,
+    surfaceVariant = NeutralSurfaceVariant,
+    onSurfaceVariant = NeutralOnSurfaceVariant,
+    outline = NeutralOutline,
+    outlineVariant = NeutralOutlineVariant,
+    surfaceContainerLowest = SurfaceContainerLowest,
+    surfaceContainerLow = SurfaceContainerLow,
+    surfaceContainer = SurfaceContainer,
+    surfaceContainerHigh = SurfaceContainerHigh,
+    surfaceContainerHighest = SurfaceContainerHighest,
+    error = ErrorRed,
+    onError = OnErrorRed,
+    errorContainer = ErrorRedContainer,
+    onErrorContainer = OnErrorRedContainer,
+    inverseSurface = Color(0xFF2F3144),
+    inverseOnSurface = Color(0xFFF1F1FF),
+    inversePrimary = PrimaryBlue
 )
 
 @Composable
@@ -71,6 +121,7 @@ fun AppTheme(content: @Composable () -> Unit) {
     MaterialTheme(
         colorScheme = LightColors,
         typography = Typography,
+        shapes = Shapes,
         content = content
     )
 }


### PR DESCRIPTION
## Summary
- retheme the app with a Material 3 color scheme and shared rounded shapes
- refresh the global top/bottom bars and badges to use tonal surfaces
- restyle the students list and detail cards with elevated containers and softer accents

## Testing
- Unable to run `bash ./gradlew :app:compileDebugKotlin` (Gradle wrapper download blocked by proxy)


------
https://chatgpt.com/codex/tasks/task_e_68e814f7781c8320a20cdd35ae5d921f