### PR TITLE
Fix missing import for Room projection

### DIFF
--- a/app/src/main/java/com/tutorly/data/db/dao/LessonDao.kt
+++ b/app/src/main/java/com/tutorly/data/db/dao/LessonDao.kt
@@ -2,6 +2,7 @@ package com.tutorly.data.db.dao
 
 import androidx.room.*
 import com.tutorly.data.db.projections.LessonWithStudent
+import com.tutorly.data.db.projections.LessonWithSubject
 import com.tutorly.models.*
 import kotlinx.coroutines.flow.Flow
 import java.time.Instant


### PR DESCRIPTION
## Summary
- import the LessonWithSubject projection in LessonDao so Room can resolve the type

## Testing
- not run (Gradle wrapper download blocked in execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68e8d74471a883209d40df1cac1c5af6