### PR TITLE
Add grade selection UI and surface class info in student views

### DIFF
--- a/app/src/main/java/com/tutorly/data/db/AppDatabase.kt
+++ b/app/src/main/java/com/tutorly/data/db/AppDatabase.kt
@@ -15,7 +15,7 @@ import com.tutorly.models.*
         Payment::class,
         SubjectPreset::class
     ],
-    version = 4, // ↑ увеличь версию
+    version = 5, // ↑ увеличь версию
     exportSchema = true
 )
 @TypeConverters(InstantConverter::class, EnumConverters::class)

--- a/app/src/main/java/com/tutorly/data/db/AppDatabase.kt
+++ b/app/src/main/java/com/tutorly/data/db/AppDatabase.kt
@@ -15,7 +15,7 @@ import com.tutorly.models.*
         Payment::class,
         SubjectPreset::class
     ],
-    version = 3, // ↑ увеличь версию
+    version = 4, // ↑ увеличь версию
     exportSchema = true
 )
 @TypeConverters(InstantConverter::class, EnumConverters::class)

--- a/app/src/main/java/com/tutorly/data/db/projections/LessonWithStudent.kt
+++ b/app/src/main/java/com/tutorly/data/db/projections/LessonWithStudent.kt
@@ -34,6 +34,9 @@ fun LessonWithStudent.toLessonDetails(): LessonDetails {
     )
     val normalizedEnd = lesson.startAt.plus(normalizedDuration)
 
+    val subjectName = subject?.name?.takeIf { it.isNotBlank() }?.trim()
+        ?: student.subject?.takeIf { it.isNotBlank() }?.trim()
+
     return LessonDetails(
         id = lesson.id,
         studentId = lesson.studentId,
@@ -42,7 +45,7 @@ fun LessonWithStudent.toLessonDetails(): LessonDetails {
         duration = normalizedDuration,
         studentName = student.name,
         studentNote = student.note,
-        subjectName = subject?.name,
+        subjectName = subjectName,
         subjectColorArgb = subject?.colorArgb,
         paymentStatus = lesson.paymentStatus,
         paymentStatusIcon = lesson.paymentStatus.asIcon(),

--- a/app/src/main/java/com/tutorly/models/Student.kt
+++ b/app/src/main/java/com/tutorly/models/Student.kt
@@ -14,6 +14,7 @@ data class Student(
     val name: String,
     val phone: String? = null,
     val messenger: String? = null,   // "Telegram: @user" (по желанию)
+    val subject: String? = null,
     val grade: String? = null,
     val note: String? = null,
     val isArchived: Boolean = false,

--- a/app/src/main/java/com/tutorly/models/Student.kt
+++ b/app/src/main/java/com/tutorly/models/Student.kt
@@ -14,6 +14,7 @@ data class Student(
     val name: String,
     val phone: String? = null,
     val messenger: String? = null,   // "Telegram: @user" (по желанию)
+    val rateCents: Int? = null,
     val subject: String? = null,
     val grade: String? = null,
     val note: String? = null,

--- a/app/src/main/java/com/tutorly/ui/lessoncard/LessonCardSheet.kt
+++ b/app/src/main/java/com/tutorly/ui/lessoncard/LessonCardSheet.kt
@@ -263,7 +263,7 @@ private fun LessonMetadataBlock(state: LessonCardUiState, zoneId: ZoneId) {
     val start = remember(details.startAt, zoneId) { ZonedDateTime.ofInstant(details.startAt, zoneId) }
     val end = remember(details.endAt, zoneId) { ZonedDateTime.ofInstant(details.endAt, zoneId) }
 
-    val subject = details.subjectName?.takeIf { it.isNotBlank() }
+    val subject = details.subjectName?.takeIf { it.isNotBlank() }?.trim()
         ?: stringResource(R.string.lesson_card_subject_placeholder)
 
     Card(

--- a/app/src/main/java/com/tutorly/ui/lessoncreation/LessonCreationSheet.kt
+++ b/app/src/main/java/com/tutorly/ui/lessoncreation/LessonCreationSheet.kt
@@ -296,7 +296,9 @@ private fun DurationPriceSection(
     var durationInput by remember(state.durationMinutes) {
         mutableStateOf(state.durationMinutes.takeIf { it > 0 }?.toString() ?: "")
     }
-    var priceInput by remember(state.priceCents) { mutableStateOf(state.priceCents.takeIf { it >= 0 }?.toString() ?: "") }
+    var priceInput by remember(state.priceCents) {
+        mutableStateOf(state.priceCents.takeIf { it >= 0 }?.let { (it / 100).toString() } ?: "")
+    }
 
     Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
         OutlinedTextField(
@@ -319,7 +321,7 @@ private fun DurationPriceSection(
             onValueChange = { value ->
                 val digits = value.filter { it.isDigit() }
                 priceInput = digits
-                onPriceChange(digits.toIntOrNull() ?: 0)
+                onPriceChange((digits.toIntOrNull() ?: 0) * 100)
             },
             label = { Text(text = stringResource(id = R.string.lesson_create_price_label, state.currencySymbol)) },
             keyboardOptions = KeyboardOptions.Default.copy(keyboardType = androidx.compose.ui.text.input.KeyboardType.Number),

--- a/app/src/main/java/com/tutorly/ui/screens/CalendarScreen.kt
+++ b/app/src/main/java/com/tutorly/ui/screens/CalendarScreen.kt
@@ -692,7 +692,7 @@ private fun LessonBlock(
 
 private fun CalendarLesson.subtitleText(): String? {
     val parts = listOfNotNull(
-        subjectName?.takeIf { it.isNotBlank() },
+        subjectName?.takeIf { it.isNotBlank() }?.trim(),
         lessonNote?.takeIf { it.isNotBlank() },
         studentNote?.takeIf { it.isNotBlank() },
         lessonTitle?.takeIf { it.isNotBlank() }

--- a/app/src/main/java/com/tutorly/ui/screens/StudentDetailsScreen.kt
+++ b/app/src/main/java/com/tutorly/ui/screens/StudentDetailsScreen.kt
@@ -253,9 +253,9 @@ private fun StudentSummaryCard(
     grade: String?,
     modifier: Modifier = Modifier
 ) {
-    val subjectText = subject?.takeIf { it.isNotBlank() }
+    val subjectText = subject?.takeIf { it.isNotBlank() }?.trim()
         ?: stringResource(id = R.string.students_subject_placeholder)
-    val gradeText = grade?.takeIf { it.isNotBlank() }
+    val gradeText = grade?.takeIf { it.isNotBlank() }?.trim()
         ?: stringResource(id = R.string.students_grade_placeholder)
     Card(
         modifier = modifier.fillMaxWidth(),

--- a/app/src/main/java/com/tutorly/ui/screens/StudentDetailsScreen.kt
+++ b/app/src/main/java/com/tutorly/ui/screens/StudentDetailsScreen.kt
@@ -171,7 +171,9 @@ fun StudentDetailsScreen(
                     StudentSummaryCard(
                         student = student,
                         hasDebt = state.hasDebt,
-                        totalDebt = formattedDebt
+                        totalDebt = formattedDebt,
+                        subject = state.subject,
+                        grade = state.grade
                     )
                     Button(
                         onClick = { onCreateLesson(student) },
@@ -247,14 +249,14 @@ private fun StudentSummaryCard(
     student: Student,
     hasDebt: Boolean,
     totalDebt: String,
+    subject: String?,
+    grade: String?,
     modifier: Modifier = Modifier
 ) {
-    val subtitle = remember(student.note) {
-        student.note
-            ?.lineSequence()
-            ?.firstOrNull()
-            ?.takeIf { it.isNotBlank() }
-    }
+    val subjectText = subject?.takeIf { it.isNotBlank() }
+        ?: stringResource(id = R.string.students_subject_placeholder)
+    val gradeText = grade?.takeIf { it.isNotBlank() }
+        ?: stringResource(id = R.string.students_grade_placeholder)
     Card(
         modifier = modifier.fillMaxWidth(),
         shape = MaterialTheme.shapes.extraLarge,
@@ -270,11 +272,18 @@ private fun StudentSummaryCard(
                 style = MaterialTheme.typography.headlineSmall,
                 color = MaterialTheme.colorScheme.onPrimaryContainer
             )
-            Text(
-                text = subtitle ?: stringResource(id = R.string.student_details_header_placeholder),
-                style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.onPrimaryContainer
-            )
+            Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                Text(
+                    text = stringResource(id = R.string.students_subject_label) + ": " + subjectText,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onPrimaryContainer
+                )
+                Text(
+                    text = stringResource(id = R.string.students_grade_label) + ": " + gradeText,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onPrimaryContainer
+                )
+            }
             Row(
                 verticalAlignment = Alignment.CenterVertically
             ) {

--- a/app/src/main/java/com/tutorly/ui/screens/StudentDetailsViewModel.kt
+++ b/app/src/main/java/com/tutorly/ui/screens/StudentDetailsViewModel.kt
@@ -46,7 +46,8 @@ class StudentDetailsViewModel @Inject constructor(
             hasDebt = hasDebt,
             totalDebtCents = totalDebt,
             lessons = lessons,
-            subject = profile?.subject,
+            subject = profile?.subject?.takeIf { it.isNotBlank() }?.trim()
+                ?: resolvedStudent?.subject?.takeIf { it.isNotBlank() }?.trim(),
             grade = profile?.grade ?: resolvedStudent?.grade
         )
     }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), UiState())

--- a/app/src/main/java/com/tutorly/ui/screens/StudentDetailsViewModel.kt
+++ b/app/src/main/java/com/tutorly/ui/screens/StudentDetailsViewModel.kt
@@ -27,6 +27,7 @@ class StudentDetailsViewModel @Inject constructor(
         ?: error("studentId is required")
 
     private val studentFlow = studentsRepository.observeStudent(studentId)
+    private val profileFlow = studentsRepository.observeStudentProfile(studentId)
     private val hasDebtFlow = paymentsRepository.observeHasDebt(studentId)
     private val totalDebtFlow = paymentsRepository.observeTotalDebt(studentId)
     private val lessonsFlow = lessonsRepository.observeByStudent(studentId)
@@ -35,14 +36,18 @@ class StudentDetailsViewModel @Inject constructor(
         studentFlow,
         hasDebtFlow,
         totalDebtFlow,
-        lessonsFlow
-    ) { student, hasDebt, totalDebt, lessons ->
+        lessonsFlow,
+        profileFlow
+    ) { student, hasDebt, totalDebt, lessons, profile ->
+        val resolvedStudent = student ?: profile?.student
         UiState(
             isLoading = false,
-            student = student,
+            student = resolvedStudent,
             hasDebt = hasDebt,
             totalDebtCents = totalDebt,
-            lessons = lessons
+            lessons = lessons,
+            subject = profile?.subject,
+            grade = profile?.grade ?: resolvedStudent?.grade
         )
     }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), UiState())
 
@@ -51,6 +56,8 @@ class StudentDetailsViewModel @Inject constructor(
         val student: Student? = null,
         val hasDebt: Boolean = false,
         val totalDebtCents: Long = 0L,
-        val lessons: List<Lesson> = emptyList()
+        val lessons: List<Lesson> = emptyList(),
+        val subject: String? = null,
+        val grade: String? = null
     )
 }

--- a/app/src/main/java/com/tutorly/ui/screens/StudentEditorForm.kt
+++ b/app/src/main/java/com/tutorly/ui/screens/StudentEditorForm.kt
@@ -39,6 +39,7 @@ fun StudentEditorForm(
     onNameChange: (String) -> Unit,
     onPhoneChange: (String) -> Unit,
     onMessengerChange: (String) -> Unit,
+    onSubjectChange: (String) -> Unit,
     onGradeChange: (String) -> Unit,
     onNoteChange: (String) -> Unit,
     onArchivedChange: (Boolean) -> Unit,
@@ -102,6 +103,16 @@ fun StudentEditorForm(
             value = state.messenger,
             onValueChange = onMessengerChange,
             label = { Text(text = stringResource(id = R.string.student_editor_messenger)) },
+            modifier = Modifier.fillMaxWidth(),
+            singleLine = true,
+            enabled = enabled,
+            keyboardOptions = KeyboardOptions.Default.copy(imeAction = ImeAction.Next)
+        )
+
+        OutlinedTextField(
+            value = state.subject,
+            onValueChange = onSubjectChange,
+            label = { Text(text = stringResource(id = R.string.student_editor_subject)) },
             modifier = Modifier.fillMaxWidth(),
             singleLine = true,
             enabled = enabled,

--- a/app/src/main/java/com/tutorly/ui/screens/StudentEditorForm.kt
+++ b/app/src/main/java/com/tutorly/ui/screens/StudentEditorForm.kt
@@ -29,6 +29,7 @@ import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import com.tutorly.R
 
@@ -39,6 +40,7 @@ fun StudentEditorForm(
     onNameChange: (String) -> Unit,
     onPhoneChange: (String) -> Unit,
     onMessengerChange: (String) -> Unit,
+    onRateChange: (String) -> Unit,
     onSubjectChange: (String) -> Unit,
     onGradeChange: (String) -> Unit,
     onNoteChange: (String) -> Unit,
@@ -88,26 +90,6 @@ fun StudentEditorForm(
                 color = MaterialTheme.colorScheme.error
             )
         }
-
-        OutlinedTextField(
-            value = state.phone,
-            onValueChange = onPhoneChange,
-            label = { Text(text = stringResource(id = R.string.student_editor_phone)) },
-            modifier = Modifier.fillMaxWidth(),
-            singleLine = true,
-            enabled = enabled,
-            keyboardOptions = KeyboardOptions.Default.copy(imeAction = ImeAction.Next)
-        )
-
-        OutlinedTextField(
-            value = state.messenger,
-            onValueChange = onMessengerChange,
-            label = { Text(text = stringResource(id = R.string.student_editor_messenger)) },
-            modifier = Modifier.fillMaxWidth(),
-            singleLine = true,
-            enabled = enabled,
-            keyboardOptions = KeyboardOptions.Default.copy(imeAction = ImeAction.Next)
-        )
 
         OutlinedTextField(
             value = state.subject,
@@ -167,6 +149,39 @@ fun StudentEditorForm(
                 }
             }
         }
+
+        OutlinedTextField(
+            value = state.rate,
+            onValueChange = onRateChange,
+            label = { Text(text = stringResource(id = R.string.student_editor_rate)) },
+            modifier = Modifier.fillMaxWidth(),
+            singleLine = true,
+            enabled = enabled,
+            keyboardOptions = KeyboardOptions.Default.copy(
+                keyboardType = KeyboardType.Decimal,
+                imeAction = ImeAction.Next
+            )
+        )
+
+        OutlinedTextField(
+            value = state.phone,
+            onValueChange = onPhoneChange,
+            label = { Text(text = stringResource(id = R.string.student_editor_phone)) },
+            modifier = Modifier.fillMaxWidth(),
+            singleLine = true,
+            enabled = enabled,
+            keyboardOptions = KeyboardOptions.Default.copy(imeAction = ImeAction.Next)
+        )
+
+        OutlinedTextField(
+            value = state.messenger,
+            onValueChange = onMessengerChange,
+            label = { Text(text = stringResource(id = R.string.student_editor_messenger)) },
+            modifier = Modifier.fillMaxWidth(),
+            singleLine = true,
+            enabled = enabled,
+            keyboardOptions = KeyboardOptions.Default.copy(imeAction = ImeAction.Next)
+        )
 
         OutlinedTextField(
             value = state.note,

--- a/app/src/main/java/com/tutorly/ui/screens/StudentEditorScreen.kt
+++ b/app/src/main/java/com/tutorly/ui/screens/StudentEditorScreen.kt
@@ -56,6 +56,7 @@ class StudentEditorVM @Inject constructor(
                             name = s.name,
                             phone = s.phone.orEmpty(),
                             messenger = s.messenger.orEmpty(),
+                            subject = s.subject.orEmpty(),
                             grade = s.grade.orEmpty(),
                             note = s.note.orEmpty(),
                             isArchived = s.isArchived,
@@ -77,6 +78,10 @@ class StudentEditorVM @Inject constructor(
 
     fun onMessengerChange(value: String) {
         formState = formState.copy(messenger = value)
+    }
+
+    fun onSubjectChange(value: String) {
+        formState = formState.copy(subject = value)
     }
 
     fun onGradeChange(value: String) {
@@ -107,6 +112,7 @@ class StudentEditorVM @Inject constructor(
 
         val trimmedPhone = formState.phone.trim().ifBlank { null }
         val trimmedMessenger = formState.messenger.trim().ifBlank { null }
+        val trimmedSubject = formState.subject.trim().ifBlank { null }
         val trimmedGrade = formState.grade.trim().ifBlank { null }
         val trimmedNote = formState.note.trim().ifBlank { null }
 
@@ -116,6 +122,7 @@ class StudentEditorVM @Inject constructor(
                 name = trimmedName,
                 phone = trimmedPhone.orEmpty(),
                 messenger = trimmedMessenger.orEmpty(),
+                subject = trimmedSubject.orEmpty(),
                 grade = trimmedGrade.orEmpty(),
                 note = trimmedNote.orEmpty(),
                 nameError = false
@@ -124,6 +131,7 @@ class StudentEditorVM @Inject constructor(
                 name = trimmedName,
                 phone = trimmedPhone,
                 messenger = trimmedMessenger,
+                subject = trimmedSubject,
                 grade = trimmedGrade,
                 note = trimmedNote,
                 isArchived = formState.isArchived,
@@ -132,6 +140,7 @@ class StudentEditorVM @Inject constructor(
                 name = trimmedName,
                 phone = trimmedPhone,
                 messenger = trimmedMessenger,
+                subject = trimmedSubject,
                 grade = trimmedGrade,
                 note = trimmedNote,
                 isArchived = formState.isArchived,
@@ -211,6 +220,7 @@ fun StudentEditorScreen(
             onNameChange = vm::onNameChange,
             onPhoneChange = vm::onPhoneChange,
             onMessengerChange = vm::onMessengerChange,
+            onSubjectChange = vm::onSubjectChange,
             onGradeChange = vm::onGradeChange,
             onNoteChange = vm::onNoteChange,
             onArchivedChange = vm::onArchivedChange,

--- a/app/src/main/java/com/tutorly/ui/screens/StudentEditorScreen.kt
+++ b/app/src/main/java/com/tutorly/ui/screens/StudentEditorScreen.kt
@@ -53,6 +53,7 @@ class StudentEditorVM @Inject constructor(
                     if (s != null) {
                         loadedStudent = s
                         formState = StudentEditorFormState(
+                            studentId = s.id,
                             name = s.name,
                             phone = s.phone.orEmpty(),
                             messenger = s.messenger.orEmpty(),

--- a/app/src/main/java/com/tutorly/ui/screens/StudentEditorScreen.kt
+++ b/app/src/main/java/com/tutorly/ui/screens/StudentEditorScreen.kt
@@ -57,6 +57,7 @@ class StudentEditorVM @Inject constructor(
                             name = s.name,
                             phone = s.phone.orEmpty(),
                             messenger = s.messenger.orEmpty(),
+                            rate = formatRateInput(s.rateCents),
                             subject = s.subject.orEmpty(),
                             grade = s.grade.orEmpty(),
                             note = s.note.orEmpty(),
@@ -79,6 +80,10 @@ class StudentEditorVM @Inject constructor(
 
     fun onMessengerChange(value: String) {
         formState = formState.copy(messenger = value)
+    }
+
+    fun onRateChange(value: String) {
+        formState = formState.copy(rate = value)
     }
 
     fun onSubjectChange(value: String) {
@@ -113,6 +118,13 @@ class StudentEditorVM @Inject constructor(
 
         val trimmedPhone = formState.phone.trim().ifBlank { null }
         val trimmedMessenger = formState.messenger.trim().ifBlank { null }
+        val rateInput = formState.rate.trim()
+        val parsedRate = parseRateInput(rateInput)
+        val normalizedRate = if (rateInput.isNotEmpty() && parsedRate != null) {
+            formatRateInput(parsedRate)
+        } else {
+            rateInput
+        }
         val trimmedSubject = formState.subject.trim().ifBlank { null }
         val trimmedGrade = formState.grade.trim().ifBlank { null }
         val trimmedNote = formState.note.trim().ifBlank { null }
@@ -123,6 +135,7 @@ class StudentEditorVM @Inject constructor(
                 name = trimmedName,
                 phone = trimmedPhone.orEmpty(),
                 messenger = trimmedMessenger.orEmpty(),
+                rate = normalizedRate,
                 subject = trimmedSubject.orEmpty(),
                 grade = trimmedGrade.orEmpty(),
                 note = trimmedNote.orEmpty(),
@@ -132,6 +145,7 @@ class StudentEditorVM @Inject constructor(
                 name = trimmedName,
                 phone = trimmedPhone,
                 messenger = trimmedMessenger,
+                rateCents = parsedRate,
                 subject = trimmedSubject,
                 grade = trimmedGrade,
                 note = trimmedNote,
@@ -141,6 +155,7 @@ class StudentEditorVM @Inject constructor(
                 name = trimmedName,
                 phone = trimmedPhone,
                 messenger = trimmedMessenger,
+                rateCents = parsedRate,
                 subject = trimmedSubject,
                 grade = trimmedGrade,
                 note = trimmedNote,
@@ -221,6 +236,7 @@ fun StudentEditorScreen(
             onNameChange = vm::onNameChange,
             onPhoneChange = vm::onPhoneChange,
             onMessengerChange = vm::onMessengerChange,
+            onRateChange = vm::onRateChange,
             onSubjectChange = vm::onSubjectChange,
             onGradeChange = vm::onGradeChange,
             onNoteChange = vm::onNoteChange,

--- a/app/src/main/java/com/tutorly/ui/screens/StudentEditorUiState.kt
+++ b/app/src/main/java/com/tutorly/ui/screens/StudentEditorUiState.kt
@@ -5,6 +5,7 @@ data class StudentEditorFormState(
     val name: String = "",
     val phone: String = "",
     val messenger: String = "",
+    val rate: String = "",
     val subject: String = "",
     val grade: String = "",
     val note: String = "",
@@ -13,3 +14,25 @@ data class StudentEditorFormState(
     val nameError: Boolean = false,
     val isSaving: Boolean = false,
 )
+
+internal fun formatRateInput(cents: Int?): String {
+    if (cents == null) return ""
+    val decimal = java.math.BigDecimal(cents)
+        .divide(java.math.BigDecimal(100))
+        .stripTrailingZeros()
+    val separator = java.text.DecimalFormatSymbols.getInstance().decimalSeparator
+    return decimal.toPlainString().replace('.', separator)
+}
+
+internal fun parseRateInput(input: String): Int? {
+    val raw = input.trim()
+    if (raw.isEmpty()) return null
+    val normalized = raw.replace(',', '.')
+    val decimal = runCatching { java.math.BigDecimal(normalized) }.getOrNull() ?: return null
+    if (decimal < java.math.BigDecimal.ZERO) return null
+    val cents = decimal.multiply(java.math.BigDecimal(100)).setScale(0, java.math.RoundingMode.HALF_UP)
+    val bigInt = runCatching { cents.toBigIntegerExact() }.getOrNull() ?: return null
+    val max = java.math.BigInteger.valueOf(Int.MAX_VALUE.toLong())
+    if (bigInt > max) return null
+    return bigInt.toInt()
+}

--- a/app/src/main/java/com/tutorly/ui/screens/StudentEditorUiState.kt
+++ b/app/src/main/java/com/tutorly/ui/screens/StudentEditorUiState.kt
@@ -1,6 +1,7 @@
 package com.tutorly.ui.screens
 
 data class StudentEditorFormState(
+    val studentId: Long? = null,
     val name: String = "",
     val phone: String = "",
     val messenger: String = "",

--- a/app/src/main/java/com/tutorly/ui/screens/StudentEditorUiState.kt
+++ b/app/src/main/java/com/tutorly/ui/screens/StudentEditorUiState.kt
@@ -4,6 +4,7 @@ data class StudentEditorFormState(
     val name: String = "",
     val phone: String = "",
     val messenger: String = "",
+    val subject: String = "",
     val grade: String = "",
     val note: String = "",
     val isArchived: Boolean = false,

--- a/app/src/main/java/com/tutorly/ui/screens/StudentsScreen.kt
+++ b/app/src/main/java/com/tutorly/ui/screens/StudentsScreen.kt
@@ -349,7 +349,7 @@ private fun StudentCard(
     val subject = item.profile.subject?.takeIf { it.isNotBlank() }?.trim()
     val grade = item.profile.grade?.takeIf { it.isNotBlank() }?.trim()
     val subtitle = listOfNotNull(subject, grade)
-        .joinToString(separator = " · ")
+        .joinToString(separator = " • ")
         .takeIf { it.isNotBlank() }
 
     val phone = item.student.phone?.takeIf { it.isNotBlank() }?.trim()
@@ -593,12 +593,16 @@ private fun StudentProfileHeader(
             val subject = profile.subject?.takeIf { it.isNotBlank() }
                 ?: stringResource(id = R.string.students_subject_placeholder)
             val grade = profile.grade?.takeIf { it.isNotBlank() }
-            val subtitle = buildList {
-                add(subject)
-                grade?.let { add(it) }
-            }.joinToString(separator = " · ")
+                ?: stringResource(id = R.string.students_grade_placeholder)
             Text(
-                text = subtitle,
+                text = stringResource(id = R.string.students_subject_label) + ": " + subject,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis
+            )
+            Text(
+                text = stringResource(id = R.string.students_grade_label) + ": " + grade,
                 style = MaterialTheme.typography.bodyMedium,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                 maxLines = 2,

--- a/app/src/main/java/com/tutorly/ui/screens/StudentsScreen.kt
+++ b/app/src/main/java/com/tutorly/ui/screens/StudentsScreen.kt
@@ -32,7 +32,9 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExtendedFloatingActionButton
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
@@ -163,13 +165,16 @@ fun StudentsScreen(
         snackbarHost = { SnackbarHost(hostState = snackbarHostState) },
         containerColor = MaterialTheme.colorScheme.surface,
         floatingActionButton = {
-            ExtendedFloatingActionButton(
+            FloatingActionButton(
                 onClick = { openCreationEditor(StudentEditorOrigin.STUDENTS) },
                 containerColor = MaterialTheme.colorScheme.primary,
-                contentColor = MaterialTheme.colorScheme.onPrimary,
-                icon = { Icon(imageVector = Icons.Default.Add, contentDescription = null) },
-                text = { Text(text = stringResource(id = R.string.add_student)) }
-            )
+                contentColor = MaterialTheme.colorScheme.onPrimary
+            ) {
+                Icon(
+                    imageVector = Icons.Default.Add,
+                    contentDescription = stringResource(id = R.string.add_student)
+                )
+            }
         }
     ) { innerPadding ->
         Column(

--- a/app/src/main/java/com/tutorly/ui/screens/StudentsScreen.kt
+++ b/app/src/main/java/com/tutorly/ui/screens/StudentsScreen.kt
@@ -32,7 +32,6 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
-import androidx.compose.material3.ExtendedFloatingActionButton
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -64,7 +63,6 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.Dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.compose.material3.BottomSheetDefaults
-import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
@@ -165,13 +163,13 @@ fun StudentsScreen(
         snackbarHost = { SnackbarHost(hostState = snackbarHostState) },
         containerColor = MaterialTheme.colorScheme.surface,
         floatingActionButton = {
-            FloatingActionButton(
+            ExtendedFloatingActionButton(
                 onClick = { openCreationEditor(StudentEditorOrigin.STUDENTS) },
                 containerColor = MaterialTheme.colorScheme.primary,
-                contentColor = MaterialTheme.colorScheme.onPrimary
-            ) {
-                Icon(imageVector = Icons.Default.Add, contentDescription = stringResource(id = R.string.add_student))
-            }
+                contentColor = MaterialTheme.colorScheme.onPrimary,
+                icon = { Icon(imageVector = Icons.Default.Add, contentDescription = null) },
+                text = { Text(text = stringResource(id = R.string.add_student)) }
+            )
         }
     ) { innerPadding ->
         Column(
@@ -230,6 +228,7 @@ fun StudentsScreen(
                 onNameChange = vm::onEditorNameChange,
                 onPhoneChange = vm::onEditorPhoneChange,
                 onMessengerChange = vm::onEditorMessengerChange,
+                onRateChange = vm::onEditorRateChange,
                 onSubjectChange = vm::onEditorSubjectChange,
                 onGradeChange = vm::onEditorGradeChange,
                 onNoteChange = vm::onEditorNoteChange,
@@ -283,6 +282,7 @@ private fun StudentEditorSheet(
     onNameChange: (String) -> Unit,
     onPhoneChange: (String) -> Unit,
     onMessengerChange: (String) -> Unit,
+    onRateChange: (String) -> Unit,
     onSubjectChange: (String) -> Unit,
     onGradeChange: (String) -> Unit,
     onNoteChange: (String) -> Unit,
@@ -323,6 +323,7 @@ private fun StudentEditorSheet(
             onNameChange = onNameChange,
             onPhoneChange = onPhoneChange,
             onMessengerChange = onMessengerChange,
+            onRateChange = onRateChange,
             onSubjectChange = onSubjectChange,
             onGradeChange = onGradeChange,
             onNoteChange = onNoteChange,
@@ -383,9 +384,15 @@ private fun StudentCard(
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    val currencyFormatter = remember {
+        NumberFormat.getCurrencyInstance(Locale("ru", "RU")).apply {
+            currency = Currency.getInstance("RUB")
+        }
+    }
     val subject = item.profile.subject?.takeIf { it.isNotBlank() }?.trim()
     val grade = item.profile.grade?.takeIf { it.isNotBlank() }?.trim()
-    val subtitle = listOfNotNull(subject, grade)
+    val rate = item.profile.rate?.let { formatCurrency(it.priceCents.toLong(), currencyFormatter) }
+    val subtitle = listOfNotNull(subject, grade, rate)
         .joinToString(separator = " • ")
         .takeIf { it.isNotBlank() }
 
@@ -967,6 +974,7 @@ private fun formatCurrency(amountCents: Long, formatter: NumberFormat): String {
 @Composable
 private fun rateLabelForDuration(rate: StudentProfileLessonRate): String {
     return when (rate.durationMinutes) {
+        0 -> stringResource(id = R.string.students_rate_label_generic)
         60 -> stringResource(id = R.string.students_rate_label_hour)
         90 -> stringResource(id = R.string.students_rate_label_hour_half)
         else -> stringResource(id = R.string.students_rate_label_custom, rate.durationMinutes)

--- a/app/src/main/java/com/tutorly/ui/screens/StudentsViewModel.kt
+++ b/app/src/main/java/com/tutorly/ui/screens/StudentsViewModel.kt
@@ -116,6 +116,7 @@ class StudentsViewModel @Inject constructor(
         name: String = "",
         phone: String = "",
         messenger: String = "",
+        subject: String = "",
         grade: String = "",
         note: String = "",
         isArchived: Boolean = false,
@@ -125,6 +126,7 @@ class StudentsViewModel @Inject constructor(
             name = name,
             phone = phone,
             messenger = messenger,
+            subject = subject,
             grade = grade,
             note = note,
             isArchived = isArchived,
@@ -146,6 +148,10 @@ class StudentsViewModel @Inject constructor(
 
     fun onEditorMessengerChange(value: String) {
         _editorFormState.update { it.copy(messenger = value) }
+    }
+
+    fun onEditorSubjectChange(value: String) {
+        _editorFormState.update { it.copy(subject = value) }
     }
 
     fun onEditorGradeChange(value: String) {
@@ -177,6 +183,7 @@ class StudentsViewModel @Inject constructor(
 
         val trimmedPhone = state.phone.trim().ifBlank { null }
         val trimmedMessenger = state.messenger.trim().ifBlank { null }
+        val trimmedSubject = state.subject.trim().ifBlank { null }
         val trimmedGrade = state.grade.trim().ifBlank { null }
         val trimmedNote = state.note.trim().ifBlank { null }
 
@@ -186,6 +193,7 @@ class StudentsViewModel @Inject constructor(
                     name = trimmedName,
                     phone = trimmedPhone.orEmpty(),
                     messenger = trimmedMessenger.orEmpty(),
+                    subject = trimmedSubject.orEmpty(),
                     grade = trimmedGrade.orEmpty(),
                     note = trimmedNote.orEmpty(),
                     nameError = false,
@@ -197,6 +205,7 @@ class StudentsViewModel @Inject constructor(
                 name = trimmedName,
                 phone = trimmedPhone,
                 messenger = trimmedMessenger,
+                subject = trimmedSubject,
                 grade = trimmedGrade,
                 note = trimmedNote,
                 isArchived = state.isArchived,
@@ -318,15 +327,20 @@ class StudentsViewModel @Inject constructor(
         snapshot: LessonSnapshot?,
         subjects: Map<Long, SubjectPreset>
     ): StudentCardProfile {
-        val subject = snapshot?.subjectId?.let { subjectId ->
-            subjects[subjectId]?.name
-        } ?: student.note
-            ?.lineSequence()
-            ?.firstOrNull { it.isNotBlank() }
+        val subject = student.subject
+            ?.takeIf { it.isNotBlank() }
             ?.trim()
+            ?: snapshot?.subjectId?.let { subjectId ->
+                subjects[subjectId]?.name?.takeIf { it.isNotBlank() }?.trim()
+            }
+            ?: student.note
+                ?.lineSequence()
+                ?.firstOrNull { it.isNotBlank() }
+                ?.trim()
 
         val grade = student.grade
             ?.takeIf { it.isNotBlank() }
+            ?.trim()
             ?: student.note.extractGrade()
         val rate = snapshot?.takeIf { it.priceCents > 0 && it.durationMinutes > 0 }?.let {
             LessonRate(durationMinutes = it.durationMinutes, priceCents = it.priceCents)

--- a/app/src/main/java/com/tutorly/ui/screens/StudentsViewModel.kt
+++ b/app/src/main/java/com/tutorly/ui/screens/StudentsViewModel.kt
@@ -117,6 +117,7 @@ class StudentsViewModel @Inject constructor(
         name: String = "",
         phone: String = "",
         messenger: String = "",
+        rate: String = "",
         subject: String = "",
         grade: String = "",
         note: String = "",
@@ -129,6 +130,7 @@ class StudentsViewModel @Inject constructor(
             name = name,
             phone = phone,
             messenger = messenger,
+            rate = rate,
             subject = subject,
             grade = grade,
             note = note,
@@ -144,6 +146,7 @@ class StudentsViewModel @Inject constructor(
             name = student.name,
             phone = student.phone.orEmpty(),
             messenger = student.messenger.orEmpty(),
+            rate = formatRateInput(student.rateCents),
             subject = student.subject.orEmpty(),
             grade = student.grade.orEmpty(),
             note = student.note.orEmpty(),
@@ -167,6 +170,10 @@ class StudentsViewModel @Inject constructor(
 
     fun onEditorMessengerChange(value: String) {
         _editorFormState.update { it.copy(messenger = value) }
+    }
+
+    fun onEditorRateChange(value: String) {
+        _editorFormState.update { it.copy(rate = value) }
     }
 
     fun onEditorSubjectChange(value: String) {
@@ -205,6 +212,13 @@ class StudentsViewModel @Inject constructor(
         val trimmedSubject = state.subject.trim().ifBlank { null }
         val trimmedGrade = state.grade.trim().ifBlank { null }
         val trimmedNote = state.note.trim().ifBlank { null }
+        val rateInput = state.rate.trim()
+        val parsedRate = parseRateInput(rateInput)
+        val normalizedRate = if (rateInput.isNotEmpty() && parsedRate != null) {
+            formatRateInput(parsedRate)
+        } else {
+            rateInput
+        }
 
         val isEditing = editingStudent != null || state.studentId != null
 
@@ -214,6 +228,7 @@ class StudentsViewModel @Inject constructor(
                     name = trimmedName,
                     phone = trimmedPhone.orEmpty(),
                     messenger = trimmedMessenger.orEmpty(),
+                    rate = normalizedRate,
                     subject = trimmedSubject.orEmpty(),
                     grade = trimmedGrade.orEmpty(),
                     note = trimmedNote.orEmpty(),
@@ -237,6 +252,7 @@ class StudentsViewModel @Inject constructor(
                     name = trimmedName,
                     phone = trimmedPhone,
                     messenger = trimmedMessenger,
+                    rateCents = parsedRate,
                     subject = trimmedSubject,
                     grade = trimmedGrade,
                     note = trimmedNote,
@@ -260,6 +276,7 @@ class StudentsViewModel @Inject constructor(
                     name = trimmedName,
                     phone = trimmedPhone,
                     messenger = trimmedMessenger,
+                    rateCents = parsedRate,
                     subject = trimmedSubject,
                     grade = trimmedGrade,
                     note = trimmedNote,
@@ -400,6 +417,8 @@ class StudentsViewModel @Inject constructor(
             ?: student.note.extractGrade()
         val rate = snapshot?.takeIf { it.priceCents > 0 && it.durationMinutes > 0 }?.let {
             LessonRate(durationMinutes = it.durationMinutes, priceCents = it.priceCents)
+        } ?: student.rateCents?.takeIf { it > 0 }?.let {
+            LessonRate(durationMinutes = 0, priceCents = it)
         }
 
         return StudentCardProfile(subject = subject, grade = grade, rate = rate)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -15,6 +15,7 @@
     <string name="students_rate_label_custom">Ставка за %1$d мин</string>
     <string name="students_rate_placeholder">Нет данных</string>
     <string name="student_editor_title">Ученик</string>
+    <string name="student_editor_edit_title">Редактировать ученика</string>
     <string name="student_editor_close">Закрыть</string>
     <string name="student_editor_save">Сохранить ученика</string>
     <string name="student_editor_name">Имя*</string>
@@ -29,6 +30,7 @@
     <string name="student_editor_cancel">Отмена</string>
     <string name="student_editor_save_error">Не удалось сохранить ученика</string>
     <string name="student_added_message">Ученик «%1$s» добавлен</string>
+    <string name="student_updated_message">Данные ученика «%1$s» обновлены</string>
     <string name="student_profile_error">Не удалось загрузить профиль</string>
     <string name="student_profile_contact_call">Позвонить</string>
     <string name="student_profile_contact_message">Написать</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -22,6 +22,7 @@
     <string name="student_editor_name_required">Имя обязательно</string>
     <string name="student_editor_phone">Телефон</string>
     <string name="student_editor_messenger">Мессенджер</string>
+    <string name="student_editor_rate">Ставка</string>
     <string name="student_editor_subject">Предмет</string>
     <string name="student_editor_grade">Класс</string>
     <string name="student_editor_notes">Заметки</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -21,6 +21,7 @@
     <string name="student_editor_name_required">Имя обязательно</string>
     <string name="student_editor_phone">Телефон</string>
     <string name="student_editor_messenger">Мессенджер</string>
+    <string name="student_editor_subject">Предмет</string>
     <string name="student_editor_grade">Класс</string>
     <string name="student_editor_notes">Заметки</string>
     <string name="student_editor_is_archived">Архивирован</string>
@@ -34,6 +35,7 @@
     <string name="student_profile_contact_placeholder">Не указано</string>
     <string name="student_profile_metrics_title">Показатели</string>
     <string name="student_profile_metrics_average">Средняя ставка</string>
+    <string name="student_profile_close">Закрыть профиль ученика</string>
     <string name="student_details_title_placeholder">Ученик</string>
     <string name="student_details_back">Назад</string>
     <string name="student_details_edit">Редактировать ученика</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -7,6 +7,8 @@
     <string name="students_subject_placeholder">Не указан</string>
     <string name="students_grade_label">Класс</string>
     <string name="students_grade_placeholder">Не указан</string>
+    <string name="student_editor_grade_option">%1$d класс</string>
+    <string name="student_editor_grade_other">Другое</string>
     <string name="students_rate_label_generic">Ставка</string>
     <string name="students_rate_label_hour">Ставка за час</string>
     <string name="students_rate_label_hour_half">Ставка за 1,5 часа</string>


### PR DESCRIPTION
## Summary
- add dropdown suggestions to the student editor class field while keeping manual input
- show subject and class labels in student profile and details headers
- include the class in student list subtitles and expose profile data in the details view model

## Testing
- ./gradlew lint *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68e8d983e1508320bb937dac7cd4f923