### PR TITLE
Fix save button text in student editor

### DIFF
--- a/app/src/main/java/com/tutorly/ui/screens/StudentsScreen.kt
+++ b/app/src/main/java/com/tutorly/ui/screens/StudentsScreen.kt
@@ -14,6 +14,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -301,6 +302,7 @@ private fun StudentEditorSheet(
         modifier = Modifier
             .fillMaxWidth()
             .navigationBarsPadding()
+            .imePadding()
             .padding(horizontal = 24.dp, vertical = 16.dp),
         verticalArrangement = Arrangement.spacedBy(20.dp)
     ) {
@@ -334,6 +336,9 @@ private fun StudentEditorSheet(
             onNoteChange = onNoteChange,
             onArchivedChange = onArchivedChange,
             onActiveChange = onActiveChange,
+            modifier = Modifier
+                .weight(1f, fill = false)
+                .fillMaxWidth(),
             focusOnStart = true,
             enabled = !state.isSaving,
             onSubmit = onSave

--- a/app/src/main/java/com/tutorly/ui/screens/StudentsScreen.kt
+++ b/app/src/main/java/com/tutorly/ui/screens/StudentsScreen.kt
@@ -363,9 +363,7 @@ private fun StudentEditorSheet(
                     )
                 } else {
                     Text(
-                        text = stringResource(
-                            id = if (isEditing) R.string.student_editor_save else R.string.add_student
-                        )
+                        text = stringResource(id = R.string.student_editor_save)
                     )
                 }
             }


### PR DESCRIPTION
## Summary
- update the student editor bottom sheet so the primary action always shows the "Сохранить ученика" label

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e8ecbef4188320ba578403608fcd76