### PR TITLE
Add Today screen with payment tracking

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -56,6 +56,7 @@ dependencies {
     implementation(libs.androidx.compose.ui)
     implementation(libs.androidx.compose.ui.graphics)
     implementation(libs.androidx.compose.ui.tooling.preview)
+    implementation(libs.androidx.compose.foundation)
     implementation(libs.androidx.compose.material3)
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)

--- a/app/src/main/java/com/tutorly/data/db/AppDatabase.kt
+++ b/app/src/main/java/com/tutorly/data/db/AppDatabase.kt
@@ -15,7 +15,7 @@ import com.tutorly.models.*
         Payment::class,
         SubjectPreset::class
     ],
-    version = 5, // ↑ увеличь версию
+    version = 6, // ↑ увеличь версию
     exportSchema = true
 )
 @TypeConverters(InstantConverter::class, EnumConverters::class)

--- a/app/src/main/java/com/tutorly/data/db/dao/LessonDao.kt
+++ b/app/src/main/java/com/tutorly/data/db/dao/LessonDao.kt
@@ -62,8 +62,14 @@ interface LessonDao {
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun upsert(lesson: Lesson): Long
 
-    @Query("UPDATE lessons SET paymentStatus=:status, paidCents=:paid, updatedAt=:now WHERE id=:id")
-    suspend fun updatePayment(id: Long, status: PaymentStatus, paid: Int, now: Instant)
+    @Query("UPDATE lessons SET paymentStatus=:status, paidCents=:paid, markedAt=:markedAt, updatedAt=:now WHERE id=:id")
+    suspend fun updatePayment(
+        id: Long,
+        status: PaymentStatus,
+        paid: Int,
+        now: Instant,
+        markedAt: Instant?
+    )
 
     @Query("UPDATE lessons SET note=:note, updatedAt=:now WHERE id=:id")
     suspend fun updateNote(id: Long, note: String?, now: Instant)

--- a/app/src/main/java/com/tutorly/data/db/migrations/Migrations.kt
+++ b/app/src/main/java/com/tutorly/data/db/migrations/Migrations.kt
@@ -1,0 +1,10 @@
+package com.tutorly.data.db.migrations
+
+import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
+
+val MIGRATION_5_6 = object : Migration(5, 6) {
+    override fun migrate(database: SupportSQLiteDatabase) {
+        database.execSQL("ALTER TABLE lessons ADD COLUMN markedAt INTEGER")
+    }
+}

--- a/app/src/main/java/com/tutorly/data/db/projections/LessonWithStudent.kt
+++ b/app/src/main/java/com/tutorly/data/db/projections/LessonWithStudent.kt
@@ -3,6 +3,7 @@ package com.tutorly.data.db.projections
 import androidx.room.Embedded
 import androidx.room.Relation
 import com.tutorly.domain.model.LessonDetails
+import com.tutorly.domain.model.LessonForToday
 import com.tutorly.domain.model.asIcon
 import com.tutorly.domain.model.resolveDuration
 import com.tutorly.models.Lesson
@@ -53,6 +54,34 @@ fun LessonWithStudent.toLessonDetails(): LessonDetails {
         paidCents = lesson.paidCents,
         lessonTitle = lesson.title,
         lessonNote = lesson.note
+    )
+}
+
+fun LessonWithStudent.toLessonForToday(): LessonForToday {
+    val normalizedDuration = resolveDuration(
+        startAt = lesson.startAt,
+        endAt = lesson.endAt,
+        subjectDurationMinutes = subject?.durationMinutes
+    )
+    val normalizedEnd = lesson.startAt.plus(normalizedDuration)
+
+    val subjectName = subject?.name?.takeIf { it.isNotBlank() }?.trim()
+        ?: student.subject?.takeIf { it.isNotBlank() }?.trim()
+
+    return LessonForToday(
+        id = lesson.id,
+        studentId = lesson.studentId,
+        studentName = student.name,
+        subjectName = subjectName,
+        lessonTitle = lesson.title,
+        startAt = lesson.startAt,
+        endAt = normalizedEnd,
+        duration = normalizedDuration,
+        priceCents = lesson.priceCents,
+        studentRateCents = student.rateCents,
+        note = lesson.note,
+        paymentStatus = lesson.paymentStatus,
+        markedAt = lesson.markedAt
     )
 }
 

--- a/app/src/main/java/com/tutorly/di/DatabaseModule.kt
+++ b/app/src/main/java/com/tutorly/di/DatabaseModule.kt
@@ -5,6 +5,7 @@ import android.content.Context
 import androidx.room.Room
 import com.tutorly.data.db.AppDatabase
 import com.tutorly.data.db.dao.*
+import com.tutorly.data.db.migrations.MIGRATION_5_6
 import com.tutorly.data.repo.memory.StaticUserSettingsRepository
 import com.tutorly.data.repo.room.RoomLessonsRepository
 import com.tutorly.data.repo.room.RoomPaymentsRepository
@@ -29,6 +30,7 @@ object DatabaseModule {
     @Provides @Singleton
     fun provideDb(@ApplicationContext ctx: Context): AppDatabase =
         Room.databaseBuilder(ctx, AppDatabase::class.java, "tutorly.db")
+            .addMigrations(MIGRATION_5_6)
             .fallbackToDestructiveMigration() // на MVP ок
             .build()
 

--- a/app/src/main/java/com/tutorly/domain/model/LessonForToday.kt
+++ b/app/src/main/java/com/tutorly/domain/model/LessonForToday.kt
@@ -1,0 +1,25 @@
+package com.tutorly.domain.model
+
+import com.tutorly.models.PaymentStatus
+import java.time.Duration
+import java.time.Instant
+
+/**
+ * Lightweight payload for the "Сегодня" summary screen. Combines lesson, student and
+ * payment fields required to render swipe actions and the note editor.
+ */
+data class LessonForToday(
+    val id: Long,
+    val studentId: Long,
+    val studentName: String,
+    val subjectName: String?,
+    val lessonTitle: String?,
+    val startAt: Instant,
+    val endAt: Instant,
+    val duration: Duration,
+    val priceCents: Int,
+    val studentRateCents: Int?,
+    val note: String?,
+    val paymentStatus: PaymentStatus,
+    val markedAt: Instant?
+)

--- a/app/src/main/java/com/tutorly/domain/repo/LessonsRepository.kt
+++ b/app/src/main/java/com/tutorly/domain/repo/LessonsRepository.kt
@@ -2,6 +2,7 @@ package com.tutorly.domain.repo
 
 import com.tutorly.domain.model.LessonCreateRequest
 import com.tutorly.domain.model.LessonDetails
+import com.tutorly.domain.model.LessonForToday
 import com.tutorly.domain.model.LessonsRangeStats
 import com.tutorly.models.Lesson
 import kotlinx.coroutines.flow.Flow
@@ -9,6 +10,7 @@ import java.time.Instant
 
 interface LessonsRepository {
     fun observeLessons(from: Instant, to: Instant): Flow<List<LessonDetails>>
+    fun observeTodayLessons(dayStart: Instant, dayEnd: Instant): Flow<List<LessonForToday>>
     fun observeWeekStats(from: Instant, to: Instant): Flow<LessonsRangeStats>
     fun observeLessonDetails(id: Long): Flow<LessonDetails?>
     fun observeByStudent(studentId: Long): Flow<List<Lesson>>
@@ -18,5 +20,6 @@ interface LessonsRepository {
     suspend fun latestLessonForStudent(studentId: Long): Lesson?
     suspend fun markPaid(id: Long)
     suspend fun markDue(id: Long)
+    suspend fun resetPaymentStatus(id: Long)
     suspend fun saveNote(id: Long, note: String?)
 }

--- a/app/src/main/java/com/tutorly/models/Lesson.kt
+++ b/app/src/main/java/com/tutorly/models/Lesson.kt
@@ -31,6 +31,7 @@ data class Lesson(
     val priceCents: Int,                 // цена по факту для этого занятия
     val paidCents: Int = 0,              // сколько уже оплачено
     val paymentStatus: PaymentStatus = PaymentStatus.UNPAID,
+    val markedAt: Instant? = null,
     val status: LessonStatus = LessonStatus.PLANNED,
     val note: String? = null,            // заметка урока (тема/замечания)
     val createdAt: Instant = Instant.now(),

--- a/app/src/main/java/com/tutorly/ui/screens/TodayScreen.kt
+++ b/app/src/main/java/com/tutorly/ui/screens/TodayScreen.kt
@@ -1,5 +1,6 @@
 package com.tutorly.ui.screens
 
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -14,11 +15,10 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.animateItemPlacement
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.foundation.ExperimentalFoundationApi
-import androidx.compose.foundation.animateItemPlacement
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.DoneAll
@@ -77,7 +77,7 @@ import java.time.format.DateTimeFormatter
 import java.util.Currency
 import java.util.Locale
 
-@OptIn(ExperimentalMaterial3Api::class)
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalFoundationApi::class)
 @Composable
 fun TodayScreen(
     modifier: Modifier = Modifier,

--- a/app/src/main/java/com/tutorly/ui/screens/TodayScreen.kt
+++ b/app/src/main/java/com/tutorly/ui/screens/TodayScreen.kt
@@ -18,7 +18,7 @@ import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.ExperimentalFoundationApi
-import androidx.compose.foundation.lazy.animateItemPlacement
+import androidx.compose.foundation.animateItemPlacement
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.DoneAll
@@ -259,7 +259,7 @@ private fun TodayLessonRow(
     onSwipeLeft: (Long) -> Unit,
     onClick: () -> Unit
 ) {
-    val dismissState = rememberSwipeToDismissBoxState { value ->
+    val dismissState = rememberSwipeToDismissBoxState(confirmValueChange = { value ->
         when (value) {
             SwipeToDismissBoxValue.StartToEnd -> {
                 onSwipeRight(lesson.id)
@@ -271,7 +271,7 @@ private fun TodayLessonRow(
             }
             else -> false
         }
-    }
+    })
 
     SwipeToDismissBox(
         state = dismissState,

--- a/app/src/main/java/com/tutorly/ui/screens/TodayScreen.kt
+++ b/app/src/main/java/com/tutorly/ui/screens/TodayScreen.kt
@@ -1,0 +1,553 @@
+package com.tutorly.ui.screens
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.lazy.animateItemPlacement
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.DoneAll
+import androidx.compose.material.icons.outlined.CalendarMonth
+import androidx.compose.material.icons.outlined.StickyNote2
+import androidx.compose.material.icons.outlined.WarningAmber
+import androidx.compose.material3.AssistChip
+import androidx.compose.material3.AssistChipDefaults
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarDuration
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.SnackbarResult
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.material3.rememberSwipeToDismissBoxState
+import androidx.compose.material3.SwipeToDismissBox
+import androidx.compose.material3.SwipeToDismissBoxValue
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.tutorly.R
+import com.tutorly.domain.model.LessonForToday
+import com.tutorly.models.PaymentStatus
+import java.text.NumberFormat
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+import java.util.Currency
+import java.util.Locale
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun TodayScreen(
+    modifier: Modifier = Modifier,
+    viewModel: TodayViewModel = hiltViewModel()
+) {
+    val uiState by viewModel.uiState.collectAsState()
+    val snackbarMessage by viewModel.snackbarMessage.collectAsState()
+    val snackbarHostState = remember { SnackbarHostState() }
+    val context = LocalContext.current
+
+    var noteLesson by remember { mutableStateOf<LessonForToday?>(null) }
+    var noteDraft by rememberSaveable(noteLesson?.id) { mutableStateOf("") }
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+
+    LaunchedEffect(snackbarMessage) {
+        val message = snackbarMessage ?: return@LaunchedEffect
+        val text = when (message.status) {
+            PaymentStatus.PAID -> context.getString(R.string.today_snackbar_paid)
+            PaymentStatus.DUE -> context.getString(R.string.today_snackbar_due)
+            else -> context.getString(R.string.today_snackbar_marked)
+        }
+        val action = context.getString(R.string.today_snackbar_action_undo)
+        val result = snackbarHostState.showSnackbar(
+            message = text,
+            actionLabel = action,
+            duration = SnackbarDuration.Short,
+            withDismissAction = true
+        )
+        viewModel.onSnackbarShown()
+        if (result == SnackbarResult.ActionPerformed) {
+            viewModel.onUndo(message.lessonId)
+        }
+    }
+
+    Scaffold(
+        modifier = modifier,
+        topBar = { TodayTopBar(state = uiState) },
+        snackbarHost = { SnackbarHost(hostState = snackbarHostState) }
+    ) { innerPadding ->
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(innerPadding)
+        ) {
+            when (val state = uiState) {
+                TodayUiState.Loading -> LoadingState()
+                TodayUiState.Empty -> EmptyState()
+                is TodayUiState.Content -> TodayContent(
+                    state = state,
+                    onSwipeRight = viewModel::onSwipeRight,
+                    onSwipeLeft = viewModel::onSwipeLeft,
+                    onLessonClick = { lesson ->
+                        noteLesson = lesson
+                        noteDraft = lesson.note.orEmpty()
+                    }
+                )
+            }
+        }
+    }
+
+    noteLesson?.let { lesson ->
+        ModalBottomSheet(
+            onDismissRequest = { noteLesson = null },
+            sheetState = sheetState
+        ) {
+            LessonNoteSheet(
+                lesson = lesson,
+                text = noteDraft,
+                onTextChange = { noteDraft = it },
+                onCancel = { noteLesson = null },
+                onSave = { value ->
+                    viewModel.onNoteSave(lesson.id, value.ifBlank { null })
+                    noteLesson = null
+                }
+            )
+        }
+    }
+}
+
+@Composable
+private fun LoadingState() {
+    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+        CircularProgressIndicator()
+    }
+}
+
+@Composable
+private fun EmptyState() {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(horizontal = 32.dp, vertical = 64.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(16.dp)
+    ) {
+        Icon(
+            imageVector = Icons.Outlined.CalendarMonth,
+            contentDescription = null,
+            modifier = Modifier.size(64.dp),
+            tint = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+        Text(
+            text = stringResource(R.string.today_empty_title),
+            style = MaterialTheme.typography.titleMedium,
+            textAlign = TextAlign.Center
+        )
+        Text(
+            text = stringResource(R.string.today_empty_subtitle),
+            style = MaterialTheme.typography.bodyMedium,
+            textAlign = TextAlign.Center,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+    }
+}
+
+@OptIn(ExperimentalFoundationApi::class, ExperimentalMaterial3Api::class)
+@Composable
+private fun TodayContent(
+    state: TodayUiState.Content,
+    onSwipeRight: (Long) -> Unit,
+    onSwipeLeft: (Long) -> Unit,
+    onLessonClick: (LessonForToday) -> Unit
+) {
+    val listState = rememberLazyListState()
+    LazyColumn(
+        modifier = Modifier.fillMaxSize(),
+        state = listState,
+        contentPadding = PaddingValues(horizontal = 16.dp, vertical = 24.dp),
+        verticalArrangement = Arrangement.spacedBy(16.dp)
+    ) {
+        itemsIndexed(state.lessons, key = { _, item -> item.id }) { index, lesson ->
+            if (state.remainingCount > 0 && index == state.remainingCount) {
+                MarkedSectionHeader()
+            }
+            TodayLessonRow(
+                lesson = lesson,
+                onSwipeRight = onSwipeRight,
+                onSwipeLeft = onSwipeLeft,
+                onClick = { onLessonClick(lesson) }
+            )
+        }
+    }
+}
+
+@Composable
+private fun MarkedSectionHeader() {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(top = 4.dp, bottom = 4.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Spacer(
+            modifier = Modifier
+                .weight(1f)
+                .height(1.dp)
+                .background(MaterialTheme.colorScheme.outlineVariant)
+        )
+        Text(
+            text = stringResource(R.string.today_section_marked),
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.padding(horizontal = 12.dp)
+        )
+        Spacer(
+            modifier = Modifier
+                .weight(1f)
+                .height(1.dp)
+                .background(MaterialTheme.colorScheme.outlineVariant)
+        )
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun TodayLessonRow(
+    lesson: LessonForToday,
+    onSwipeRight: (Long) -> Unit,
+    onSwipeLeft: (Long) -> Unit,
+    onClick: () -> Unit
+) {
+    val dismissState = rememberSwipeToDismissBoxState { value ->
+        when (value) {
+            SwipeToDismissBoxValue.StartToEnd -> {
+                onSwipeRight(lesson.id)
+                false
+            }
+            SwipeToDismissBoxValue.EndToStart -> {
+                onSwipeLeft(lesson.id)
+                false
+            }
+            else -> false
+        }
+    }
+
+    SwipeToDismissBox(
+        state = dismissState,
+        modifier = Modifier
+            .fillMaxWidth()
+            .animateItemPlacement(),
+        backgroundContent = { DismissBackground(state = dismissState) }
+    ) {
+        LessonCard(
+            lesson = lesson,
+            modifier = Modifier
+                .fillMaxWidth()
+                .clickable(onClick = onClick)
+        )
+    }
+}
+
+@Composable
+private fun DismissBackground(state: androidx.compose.material3.SwipeToDismissBoxState) {
+    val target = state.targetValue
+    if (target == SwipeToDismissBoxValue.Settled) {
+        return
+    }
+    val color: Color
+    val icon: ImageVector
+    val tint: Color
+    val alignment: Alignment
+    if (target == SwipeToDismissBoxValue.StartToEnd) {
+        color = MaterialTheme.colorScheme.tertiaryContainer
+        icon = Icons.Filled.Check
+        tint = MaterialTheme.colorScheme.onTertiaryContainer
+        alignment = Alignment.CenterStart
+    } else {
+        color = MaterialTheme.colorScheme.errorContainer
+        icon = Icons.Outlined.WarningAmber
+        tint = MaterialTheme.colorScheme.onErrorContainer
+        alignment = Alignment.CenterEnd
+    }
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(color),
+        contentAlignment = alignment
+    ) {
+        Icon(
+            imageVector = icon,
+            contentDescription = null,
+            tint = tint,
+            modifier = Modifier
+                .padding(horizontal = 24.dp)
+                .size(28.dp)
+        )
+    }
+}
+
+@Composable
+private fun LessonCard(
+    lesson: LessonForToday,
+    modifier: Modifier = Modifier
+) {
+    val zoneId = remember { ZoneId.systemDefault() }
+    val timeFormatter = remember { DateTimeFormatter.ofPattern("HH:mm") }
+    val currencyFormatter = rememberCurrencyFormatter()
+    val startTime = remember(lesson.startAt) { lesson.startAt.atZone(zoneId).toLocalTime() }
+    val timeText = remember(startTime) { timeFormatter.format(startTime) }
+    val durationMinutes = remember(lesson.duration) { lesson.duration.toMinutes().toInt().coerceAtLeast(0) }
+    val amount = remember(lesson.priceCents) { formatCurrency(lesson.priceCents.toLong(), currencyFormatter) }
+    val subjectTitle = lesson.lessonTitle?.takeIf { it.isNotBlank() }?.trim()
+        ?: lesson.subjectName?.takeIf { it.isNotBlank() }?.trim()
+        ?: stringResource(id = R.string.lesson_card_subject_placeholder)
+    val durationLabel = stringResource(R.string.today_duration_format, durationMinutes)
+    val metaParts = listOf(subjectTitle, timeText, durationLabel, amount)
+
+    Card(
+        modifier = modifier,
+        shape = MaterialTheme.shapes.large,
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceContainerLow),
+        elevation = CardDefaults.cardElevation(defaultElevation = 1.dp)
+    ) {
+        Column(
+            modifier = Modifier.padding(horizontal = 20.dp, vertical = 18.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(
+                    text = lesson.studentName,
+                    style = MaterialTheme.typography.titleMedium,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
+                PaymentStatusChip(status = lesson.paymentStatus)
+            }
+            Text(
+                text = metaParts.joinToString(separator = " • "),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis
+            )
+            val note = lesson.note?.takeIf { it.isNotBlank() }
+            if (note != null) {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
+                    Icon(
+                        imageVector = Icons.Outlined.StickyNote2,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.size(18.dp)
+                    )
+                    Text(
+                        text = note,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        maxLines = 2,
+                        overflow = TextOverflow.Ellipsis
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun PaymentStatusChip(status: PaymentStatus) {
+    if (status == PaymentStatus.UNPAID) return
+    val (label, container, content) = when (status) {
+        PaymentStatus.PAID -> Triple(
+            stringResource(R.string.lesson_status_paid),
+            MaterialTheme.colorScheme.tertiaryContainer,
+            MaterialTheme.colorScheme.onTertiaryContainer
+        )
+        PaymentStatus.DUE -> Triple(
+            stringResource(R.string.lesson_status_due),
+            MaterialTheme.colorScheme.errorContainer,
+            MaterialTheme.colorScheme.onErrorContainer
+        )
+        PaymentStatus.CANCELLED -> Triple(
+            stringResource(R.string.lesson_status_cancelled),
+            MaterialTheme.colorScheme.surfaceVariant,
+            MaterialTheme.colorScheme.onSurfaceVariant
+        )
+        else -> Triple(
+            stringResource(R.string.lesson_status_unpaid),
+            MaterialTheme.colorScheme.surfaceVariant,
+            MaterialTheme.colorScheme.onSurfaceVariant
+        )
+    }
+    Surface(
+        color = container,
+        shape = RoundedCornerShape(12.dp)
+    ) {
+        Text(
+            text = label,
+            color = content,
+            style = MaterialTheme.typography.labelSmall,
+            modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp)
+        )
+    }
+}
+
+@Composable
+private fun LessonNoteSheet(
+    lesson: LessonForToday,
+    text: String,
+    onTextChange: (String) -> Unit,
+    onCancel: () -> Unit,
+    onSave: (String) -> Unit
+) {
+    val zoneId = remember { ZoneId.systemDefault() }
+    val timeFormatter = remember { DateTimeFormatter.ofPattern("HH:mm") }
+    val start = remember(lesson.startAt) { lesson.startAt.atZone(zoneId).toLocalTime() }
+    val durationMinutes = remember(lesson.duration) { lesson.duration.toMinutes().toInt().coerceAtLeast(0) }
+    val subtitleParts = buildList {
+        add(stringResource(R.string.today_note_time, timeFormatter.format(start)))
+        add(stringResource(R.string.today_duration_format, durationMinutes))
+        lesson.subjectName?.takeIf { it.isNotBlank() }?.trim()?.let { add(it) }
+    }
+
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 20.dp, vertical = 24.dp),
+        verticalArrangement = Arrangement.spacedBy(16.dp)
+    ) {
+        Text(
+            text = stringResource(R.string.today_note_title, lesson.studentName),
+            style = MaterialTheme.typography.titleMedium
+        )
+        Text(
+            text = subtitleParts.joinToString(separator = " • "),
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+        OutlinedTextField(
+            value = text,
+            onValueChange = onTextChange,
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(160.dp),
+            placeholder = { Text(stringResource(R.string.today_note_placeholder)) }
+        )
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            TextButton(onClick = onCancel, modifier = Modifier.weight(1f)) {
+                Text(text = stringResource(R.string.today_note_cancel))
+            }
+            Button(onClick = { onSave(text) }, modifier = Modifier.weight(1f)) {
+                Text(text = stringResource(R.string.today_note_save))
+            }
+        }
+    }
+}
+
+@Composable
+private fun TodayTopBar(state: TodayUiState) {
+    TopAppBar(
+        title = { Text(text = stringResource(R.string.today_title)) },
+        actions = {
+            if (state is TodayUiState.Content) {
+                if (state.isAllMarked) {
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(4.dp),
+                        modifier = Modifier.padding(end = 16.dp)
+                    ) {
+                        Icon(
+                            imageVector = Icons.Filled.DoneAll,
+                            contentDescription = null,
+                            tint = MaterialTheme.colorScheme.primary
+                        )
+                        Text(
+                            text = stringResource(R.string.today_all_marked),
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.primary
+                        )
+                    }
+                } else {
+                    AssistChip(
+                        onClick = {},
+                        label = {
+                            Text(text = stringResource(R.string.today_remaining_count, state.remainingCount))
+                        },
+                        colors = AssistChipDefaults.assistChipColors(
+                            containerColor = MaterialTheme.colorScheme.surfaceVariant,
+                            labelColor = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    )
+                }
+            }
+        },
+        colors = TopAppBarDefaults.topAppBarColors(
+            containerColor = MaterialTheme.colorScheme.surface,
+            titleContentColor = MaterialTheme.colorScheme.onSurface
+        )
+    )
+}
+
+@Composable
+private fun rememberCurrencyFormatter(): NumberFormat {
+    return remember {
+        NumberFormat.getCurrencyInstance(Locale.getDefault()).apply {
+            currency = Currency.getInstance("RUB")
+            maximumFractionDigits = 0
+        }
+    }
+}
+
+private fun formatCurrency(amountCents: Long, formatter: NumberFormat): String {
+    return formatter.format(amountCents / 100.0)
+}

--- a/app/src/main/java/com/tutorly/ui/screens/TodayViewModel.kt
+++ b/app/src/main/java/com/tutorly/ui/screens/TodayViewModel.kt
@@ -1,0 +1,146 @@
+package com.tutorly.ui.screens
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.tutorly.domain.model.LessonForToday
+import com.tutorly.domain.repo.LessonsRepository
+import com.tutorly.models.PaymentStatus
+import dagger.hilt.android.lifecycle.HiltViewModel
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneId
+import javax.inject.Inject
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+
+@HiltViewModel
+class TodayViewModel @Inject constructor(
+    private val lessonsRepository: LessonsRepository
+) : ViewModel() {
+
+    private val zoneId: ZoneId = ZoneId.systemDefault()
+    private val dayBounds: Pair<Instant, Instant> = run {
+        val today = LocalDate.now(zoneId)
+        val start = today.atStartOfDay(zoneId).toInstant()
+        val end = today.plusDays(1).atStartOfDay(zoneId).toInstant()
+        start to end
+    }
+    private val dayStart: Instant = dayBounds.first
+    private val dayEnd: Instant = dayBounds.second
+
+    private val nowState = MutableStateFlow(Instant.now())
+    private val snackbarState = MutableStateFlow<TodaySnackbarMessage?>(null)
+
+    private val lessonsFlow = lessonsRepository.observeTodayLessons(
+        dayStart = dayStart,
+        dayEnd = dayEnd
+    )
+
+    val uiState: StateFlow<TodayUiState> = combine(lessonsFlow, nowState) { lessons, now ->
+        buildUiState(lessons, now)
+    }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), TodayUiState.Loading)
+
+    val snackbarMessage: StateFlow<TodaySnackbarMessage?> = snackbarState.asStateFlow()
+
+    init {
+        refreshNow()
+        viewModelScope.launch {
+            while (isActive) {
+                delay(60_000L)
+                refreshNow()
+            }
+        }
+    }
+
+    fun onSwipeRight(lessonId: Long) {
+        markLesson(lessonId, PaymentStatus.PAID)
+    }
+
+    fun onSwipeLeft(lessonId: Long) {
+        markLesson(lessonId, PaymentStatus.DUE)
+    }
+
+    fun onUndo(lessonId: Long) {
+        viewModelScope.launch {
+            runCatching { lessonsRepository.resetPaymentStatus(lessonId) }
+            refreshNow()
+        }
+    }
+
+    fun onNoteSave(lessonId: Long, text: String?) {
+        viewModelScope.launch {
+            runCatching { lessonsRepository.saveNote(lessonId, text) }
+        }
+    }
+
+    fun onSnackbarShown() {
+        snackbarState.value = null
+    }
+
+    private fun markLesson(lessonId: Long, status: PaymentStatus) {
+        viewModelScope.launch {
+            val result = runCatching {
+                when (status) {
+                    PaymentStatus.PAID -> lessonsRepository.markPaid(lessonId)
+                    PaymentStatus.DUE -> lessonsRepository.markDue(lessonId)
+                    else -> Unit
+                }
+            }
+            if (result.isSuccess) {
+                snackbarState.value = TodaySnackbarMessage(lessonId, status)
+                refreshNow()
+            }
+        }
+    }
+
+    private fun refreshNow() {
+        nowState.value = Instant.now()
+    }
+
+    private fun buildUiState(
+        lessons: List<LessonForToday>,
+        now: Instant
+    ): TodayUiState {
+        val pastLessons = lessons.filter { it.endAt <= now }
+        if (pastLessons.isEmpty()) {
+            return TodayUiState.Empty
+        }
+
+        val (pending, marked) = pastLessons.partition { it.paymentStatus == PaymentStatus.UNPAID }
+        val sortedPending = pending.sortedBy { it.startAt }
+        val sortedMarked = marked.sortedWith(
+            compareByDescending<LessonForToday> { it.markedAt ?: Instant.EPOCH }
+                .thenBy { it.startAt }
+        )
+
+        val allItems = sortedPending + sortedMarked
+        return TodayUiState.Content(
+            lessons = allItems,
+            remainingCount = sortedPending.size,
+            isAllMarked = sortedPending.isEmpty()
+        )
+    }
+
+}
+
+sealed interface TodayUiState {
+    data object Loading : TodayUiState
+    data object Empty : TodayUiState
+    data class Content(
+        val lessons: List<LessonForToday>,
+        val remainingCount: Int,
+        val isAllMarked: Boolean
+    ) : TodayUiState
+}
+
+data class TodaySnackbarMessage(
+    val lessonId: Long,
+    val status: PaymentStatus
+)

--- a/app/src/main/java/com/tutorly/ui/screens/ToodayScreen.kt
+++ b/app/src/main/java/com/tutorly/ui/screens/ToodayScreen.kt
@@ -1,6 +1,0 @@
-package com.tutorly.ui.screens
-
-import androidx.compose.runtime.Composable
-import androidx.compose.material3.Text
-
-@Composable fun TodayScreen() { Text("Сегодня: отметки, оплаты, заметки") }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -110,4 +110,20 @@
     <string name="lesson_create_conflict_body">В выбранное время уже есть занятия:</string>
     <string name="lesson_create_conflict_proceed">Создать всё равно</string>
     <string name="lesson_create_conflict_back">Вернуться</string>
+    <string name="today_title">Сегодня</string>
+    <string name="today_all_marked">Всё отмечено</string>
+    <string name="today_remaining_count">Осталось: %1$d</string>
+    <string name="today_empty_title">Сегодня прошедших занятий пока нет</string>
+    <string name="today_empty_subtitle">Проверьте расписание или добавьте занятие</string>
+    <string name="today_section_marked">Отмеченные</string>
+    <string name="today_duration_format">%1$d мин</string>
+    <string name="today_snackbar_paid">Отмечено: оплачено</string>
+    <string name="today_snackbar_due">Отмечено: долг</string>
+    <string name="today_snackbar_marked">Статус обновлён</string>
+    <string name="today_snackbar_action_undo">Отменить</string>
+    <string name="today_note_title">Заметка — %1$s</string>
+    <string name="today_note_time">%1$s</string>
+    <string name="today_note_placeholder">Добавьте заметку о занятии</string>
+    <string name="today_note_cancel">Отмена</string>
+    <string name="today_note_save">Сохранить</string>
 </resources>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -34,6 +34,7 @@ androidx-compose-ui-tooling = { group = "androidx.compose.ui", name = "ui-toolin
 androidx-compose-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-tooling-preview" }
 androidx-compose-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
 androidx-compose-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
+androidx-compose-foundation = { group = "androidx.compose.foundation", name = "foundation" }
 androidx-compose-material3 = { group = "androidx.compose.material3", name = "material3" }
 androidx-navigation-compose = { module = "androidx.navigation:navigation-compose", version.ref = "navigation" }
 kotlinx-coroutines-android = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version.ref = "coroutines" }


### PR DESCRIPTION
## Summary
- add Room migration and lesson repository support for payment mark timestamps
- introduce Today view model and domain payload that surfaces completed lessons for the new screen
- implement the Today screen UI with swipe actions, grouped sorting, snackbar undo, and a note editor sheet

## Testing
- ./gradlew :app:assembleDebug *(fails: Unable to download Gradle distribution due to proxy 403)*

------
https://chatgpt.com/codex/tasks/task_e_68e91d11b69483209c2b9fe947ec60c9