### PR TITLE
Improve lesson creation student and pricing UI

### DIFF
--- a/app/src/main/java/com/tutorly/ui/lessoncreation/LessonCreationModels.kt
+++ b/app/src/main/java/com/tutorly/ui/lessoncreation/LessonCreationModels.kt
@@ -19,6 +19,7 @@ data class LessonCreationUiState(
     val time: LocalTime = LocalTime.now(),
     val durationMinutes: Int = 60,
     val priceCents: Int = 0,
+    val pricePresets: List<Int> = emptyList(),
     val note: String = "",
     val currencySymbol: String = "₽",
     val slotStepMinutes: Int = 30,


### PR DESCRIPTION
## Summary
- show student avatars alongside existing learners in the lesson creation sheet and restyle the time pickers with stacked icon/text
- keep duration presets in a single row under the duration field while syncing the text input with preset selections
- suggest price presets by scaling frequently used student rates to the chosen duration and persist them across submissions

## Testing
- ./gradlew test *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68eb8c4804ec832095bb2275b6702f44