### PR TITLE
Revamp Today screen with outstanding lesson sections

### DIFF
--- a/app/src/main/java/com/tutorly/data/db/dao/LessonDao.kt
+++ b/app/src/main/java/com/tutorly/data/db/dao/LessonDao.kt
@@ -13,6 +13,16 @@ interface LessonDao {
     @Query("SELECT * FROM lessons WHERE startAt >= :from AND startAt < :to ORDER BY startAt")
     fun observeInRange(from: Instant, to: Instant): Flow<List<LessonWithStudent>>
 
+    @Transaction
+    @Query(
+        """
+        SELECT * FROM lessons
+        WHERE startAt < :before AND paymentStatus IN (:statuses)
+        ORDER BY startAt
+        """
+    )
+    fun observeOutstanding(before: Instant, statuses: List<PaymentStatus>): Flow<List<LessonWithStudent>>
+
     @Query(
         """
         SELECT

--- a/app/src/main/java/com/tutorly/data/repo/memory/InMemoryLessonsRepository.kt
+++ b/app/src/main/java/com/tutorly/data/repo/memory/InMemoryLessonsRepository.kt
@@ -38,6 +38,13 @@ class InMemoryLessonsRepository : LessonsRepository {
                 .map { it.toTodayStub() }
         }
 
+    override fun observeOutstandingLessons(before: Instant): Flow<List<LessonForToday>> =
+        lessonsFlow.map { lessons ->
+            lessons.filter { it.startAt < before && it.paymentStatus in PaymentStatus.outstandingStatuses }
+                .sortedBy { it.startAt }
+                .map { it.toTodayStub() }
+        }
+
     override fun observeWeekStats(from: Instant, to: Instant): Flow<LessonsRangeStats> =
         lessonsFlow.map { lessons ->
             val relevant = lessons.filter { it.startAt >= from && it.startAt < to }

--- a/app/src/main/java/com/tutorly/data/repo/room/RoomLessonsRepository.kt
+++ b/app/src/main/java/com/tutorly/data/repo/room/RoomLessonsRepository.kt
@@ -29,6 +29,10 @@ class RoomLessonsRepository(
     override fun observeTodayLessons(dayStart: Instant, dayEnd: Instant): Flow<List<LessonForToday>> =
         lessonDao.observeInRange(dayStart, dayEnd).map { lessons -> lessons.map { it.toLessonForToday() } }
 
+    override fun observeOutstandingLessons(before: Instant): Flow<List<LessonForToday>> =
+        lessonDao.observeOutstanding(before, PaymentStatus.outstandingStatuses)
+            .map { lessons -> lessons.map { it.toLessonForToday() } }
+
     override fun observeWeekStats(from: Instant, to: Instant): Flow<LessonsRangeStats> =
         combine(
             lessonDao.observeLessonCounts(

--- a/app/src/main/java/com/tutorly/domain/repo/LessonsRepository.kt
+++ b/app/src/main/java/com/tutorly/domain/repo/LessonsRepository.kt
@@ -11,6 +11,7 @@ import java.time.Instant
 interface LessonsRepository {
     fun observeLessons(from: Instant, to: Instant): Flow<List<LessonDetails>>
     fun observeTodayLessons(dayStart: Instant, dayEnd: Instant): Flow<List<LessonForToday>>
+    fun observeOutstandingLessons(before: Instant): Flow<List<LessonForToday>>
     fun observeWeekStats(from: Instant, to: Instant): Flow<LessonsRangeStats>
     fun observeLessonDetails(id: Long): Flow<LessonDetails?>
     fun observeByStudent(studentId: Long): Flow<List<Lesson>>

--- a/app/src/main/java/com/tutorly/ui/screens/TodayScreen.kt
+++ b/app/src/main/java/com/tutorly/ui/screens/TodayScreen.kt
@@ -283,6 +283,16 @@ private fun TodayStatsRow(stats: TodayStats) {
     val paidAmount = remember(stats.paidAmountCents, currencyFormatter) {
         formatCurrency(stats.paidAmountCents, currencyFormatter)
     }
+    val incomeValue = stringResource(
+        R.string.today_stats_income_value,
+        paidAmount,
+        totalAmount
+    )
+    val lessonsValue = stringResource(
+        R.string.today_stats_lessons_value,
+        stats.paidLessons,
+        stats.totalLessons
+    )
     Row(
         modifier = Modifier
             .fillMaxWidth()
@@ -290,17 +300,13 @@ private fun TodayStatsRow(stats: TodayStats) {
         horizontalArrangement = Arrangement.spacedBy(12.dp)
     ) {
         TodayStatsCard(
-            title = stringResource(R.string.today_stats_total_amount_label),
-            titleValue = totalAmount,
-            subtitle = stringResource(R.string.today_stats_total_lessons_label),
-            subtitleValue = stats.totalLessons.toString(),
+            label = stringResource(R.string.today_stats_income_label),
+            value = incomeValue,
             modifier = Modifier.weight(1f)
         )
         TodayStatsCard(
-            title = stringResource(R.string.today_stats_paid_amount_label),
-            titleValue = paidAmount,
-            subtitle = stringResource(R.string.today_stats_paid_lessons_label),
-            subtitleValue = stats.paidLessons.toString(),
+            label = stringResource(R.string.today_stats_lessons_label),
+            value = lessonsValue,
             modifier = Modifier.weight(1f)
         )
     }
@@ -308,10 +314,8 @@ private fun TodayStatsRow(stats: TodayStats) {
 
 @Composable
 private fun TodayStatsCard(
-    title: String,
-    titleValue: String,
-    subtitle: String,
-    subtitleValue: String,
+    label: String,
+    value: String,
     modifier: Modifier = Modifier
 ) {
     Card(
@@ -325,33 +329,18 @@ private fun TodayStatsCard(
                 .padding(horizontal = 20.dp, vertical = 16.dp),
             verticalArrangement = Arrangement.spacedBy(12.dp)
         ) {
-            TodayStatsRowContent(label = title, value = titleValue)
-            TodayStatsRowContent(label = subtitle, value = subtitleValue)
+            Text(
+                text = label,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+            Text(
+                text = value,
+                style = MaterialTheme.typography.headlineSmall,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
+            )
         }
-    }
-}
-
-@Composable
-private fun TodayStatsRowContent(label: String, value: String) {
-    Row(
-        modifier = Modifier.fillMaxWidth(),
-        horizontalArrangement = Arrangement.SpaceBetween,
-        verticalAlignment = Alignment.CenterVertically
-    ) {
-        Text(
-            text = label,
-            style = MaterialTheme.typography.bodySmall,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-            modifier = Modifier.weight(1f)
-        )
-        Text(
-            text = value,
-            style = MaterialTheme.typography.titleMedium,
-            maxLines = 1,
-            overflow = TextOverflow.Ellipsis,
-            textAlign = TextAlign.End,
-            modifier = Modifier.padding(start = 12.dp)
-        )
     }
 }
 

--- a/app/src/main/java/com/tutorly/ui/screens/TodayScreen.kt
+++ b/app/src/main/java/com/tutorly/ui/screens/TodayScreen.kt
@@ -283,16 +283,9 @@ private fun TodayStatsRow(stats: TodayStats) {
     val paidAmount = remember(stats.paidAmountCents, currencyFormatter) {
         formatCurrency(stats.paidAmountCents, currencyFormatter)
     }
-    val incomeValue = stringResource(
-        R.string.today_stats_income_value,
-        paidAmount,
-        totalAmount
-    )
-    val lessonsValue = stringResource(
-        R.string.today_stats_lessons_value,
-        stats.paidLessons,
-        stats.totalLessons
-    )
+    val paidLessons = remember(stats.paidLessons) { stats.paidLessons.toString() }
+    val totalLessons = remember(stats.totalLessons) { stats.totalLessons.toString() }
+    val fromLabel = stringResource(R.string.today_stats_from)
     Row(
         modifier = Modifier
             .fillMaxWidth()
@@ -301,12 +294,16 @@ private fun TodayStatsRow(stats: TodayStats) {
     ) {
         TodayStatsCard(
             label = stringResource(R.string.today_stats_income_label),
-            value = incomeValue,
+            primaryValue = paidAmount,
+            secondaryValue = totalAmount,
+            fromLabel = fromLabel,
             modifier = Modifier.weight(1f)
         )
         TodayStatsCard(
             label = stringResource(R.string.today_stats_lessons_label),
-            value = lessonsValue,
+            primaryValue = paidLessons,
+            secondaryValue = totalLessons,
+            fromLabel = fromLabel,
             modifier = Modifier.weight(1f)
         )
     }
@@ -315,7 +312,9 @@ private fun TodayStatsRow(stats: TodayStats) {
 @Composable
 private fun TodayStatsCard(
     label: String,
-    value: String,
+    primaryValue: String,
+    secondaryValue: String,
+    fromLabel: String,
     modifier: Modifier = Modifier
 ) {
     Card(
@@ -334,12 +333,25 @@ private fun TodayStatsCard(
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant
             )
-            Text(
-                text = value,
-                style = MaterialTheme.typography.headlineSmall,
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis
-            )
+            Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                Text(
+                    text = primaryValue,
+                    style = MaterialTheme.typography.headlineMedium,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
+                Text(
+                    text = fromLabel,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+                Text(
+                    text = secondaryValue,
+                    style = MaterialTheme.typography.headlineMedium,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
+            }
         }
     }
 }

--- a/app/src/main/java/com/tutorly/ui/screens/TodayScreen.kt
+++ b/app/src/main/java/com/tutorly/ui/screens/TodayScreen.kt
@@ -190,6 +190,9 @@ private fun TodayContent(
         contentPadding = PaddingValues(horizontal = 16.dp, vertical = 24.dp),
         verticalArrangement = Arrangement.spacedBy(12.dp)
     ) {
+        item(key = "stats") {
+            TodayStatsRow(stats = state.stats)
+        }
         if (state.isAllMarked) {
             item(key = "all_done") {
                 AllMarkedMessage()
@@ -268,6 +271,87 @@ private fun DaySectionHeader(section: TodayLessonSection, addTopSpacing: Boolean
         if (section.isToday) {
             TodayBadge()
         }
+    }
+}
+
+@Composable
+private fun TodayStatsRow(stats: TodayStats) {
+    val currencyFormatter = rememberCurrencyFormatter()
+    val totalAmount = remember(stats.totalAmountCents, currencyFormatter) {
+        formatCurrency(stats.totalAmountCents, currencyFormatter)
+    }
+    val paidAmount = remember(stats.paidAmountCents, currencyFormatter) {
+        formatCurrency(stats.paidAmountCents, currencyFormatter)
+    }
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(bottom = 4.dp),
+        horizontalArrangement = Arrangement.spacedBy(12.dp)
+    ) {
+        TodayStatsCard(
+            title = stringResource(R.string.today_stats_total_amount_label),
+            titleValue = totalAmount,
+            subtitle = stringResource(R.string.today_stats_total_lessons_label),
+            subtitleValue = stats.totalLessons.toString(),
+            modifier = Modifier.weight(1f)
+        )
+        TodayStatsCard(
+            title = stringResource(R.string.today_stats_paid_amount_label),
+            titleValue = paidAmount,
+            subtitle = stringResource(R.string.today_stats_paid_lessons_label),
+            subtitleValue = stats.paidLessons.toString(),
+            modifier = Modifier.weight(1f)
+        )
+    }
+}
+
+@Composable
+private fun TodayStatsCard(
+    title: String,
+    titleValue: String,
+    subtitle: String,
+    subtitleValue: String,
+    modifier: Modifier = Modifier
+) {
+    Card(
+        modifier = modifier,
+        shape = MaterialTheme.shapes.large,
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceContainerLow)
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 20.dp, vertical = 16.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            TodayStatsRowContent(label = title, value = titleValue)
+            TodayStatsRowContent(label = subtitle, value = subtitleValue)
+        }
+    }
+}
+
+@Composable
+private fun TodayStatsRowContent(label: String, value: String) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Text(
+            text = label,
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.weight(1f)
+        )
+        Text(
+            text = value,
+            style = MaterialTheme.typography.titleMedium,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+            textAlign = TextAlign.End,
+            modifier = Modifier.padding(start = 12.dp)
+        )
     }
 }
 

--- a/app/src/main/java/com/tutorly/ui/screens/TodayScreen.kt
+++ b/app/src/main/java/com/tutorly/ui/screens/TodayScreen.kt
@@ -326,30 +326,38 @@ private fun TodayStatsCard(
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(horizontal = 20.dp, vertical = 16.dp),
-            verticalArrangement = Arrangement.spacedBy(12.dp)
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+            horizontalAlignment = Alignment.CenterHorizontally
         ) {
             Text(
                 text = label,
                 style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                textAlign = TextAlign.Center
             )
-            Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+            Column(
+                verticalArrangement = Arrangement.spacedBy(4.dp),
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
                 Text(
                     text = primaryValue,
                     style = MaterialTheme.typography.headlineMedium,
                     maxLines = 1,
-                    overflow = TextOverflow.Ellipsis
+                    overflow = TextOverflow.Ellipsis,
+                    textAlign = TextAlign.Center
                 )
                 Text(
                     text = fromLabel,
                     style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    textAlign = TextAlign.Center
                 )
                 Text(
                     text = secondaryValue,
                     style = MaterialTheme.typography.headlineMedium,
                     maxLines = 1,
-                    overflow = TextOverflow.Ellipsis
+                    overflow = TextOverflow.Ellipsis,
+                    textAlign = TextAlign.Center
                 )
             }
         }

--- a/app/src/main/java/com/tutorly/ui/screens/TodayViewModel.kt
+++ b/app/src/main/java/com/tutorly/ui/screens/TodayViewModel.kt
@@ -112,13 +112,12 @@ class TodayViewModel @Inject constructor(
             return TodayUiState.Empty
         }
 
-        val todaySorted = todayLessons.sortedWith(
-            compareBy<LessonForToday> {
-                if (it.endAt <= now && it.paymentStatus != PaymentStatus.UNPAID) 1 else 0
-            }.thenBy { it.startAt }
-        )
-        val todayPending = todaySorted.filterNot { it.endAt <= now && it.paymentStatus != PaymentStatus.UNPAID }
+        val todaySorted = todayLessons.sortedBy { it.startAt }
         val todayMarked = todaySorted.filter { it.endAt <= now && it.paymentStatus != PaymentStatus.UNPAID }
+        val todayUpcoming = todaySorted.filter { it.startAt > now }
+        val todayPending = todaySorted.filter { lesson ->
+            lesson !in todayMarked && lesson !in todayUpcoming
+        }
 
         val sections = buildList {
             if (outstandingLessons.isNotEmpty()) {
@@ -131,6 +130,7 @@ class TodayViewModel @Inject constructor(
                             date = date,
                             isToday = false,
                             pending = lessons.sortedBy { it.startAt },
+                            upcoming = emptyList(),
                             marked = emptyList()
                         )
                     )
@@ -142,6 +142,7 @@ class TodayViewModel @Inject constructor(
                         date = dayStart.atZone(zoneId).toLocalDate(),
                         isToday = true,
                         pending = todayPending,
+                        upcoming = todayUpcoming,
                         marked = todayMarked
                     )
                 )
@@ -184,5 +185,6 @@ data class TodayLessonSection(
     val date: LocalDate,
     val isToday: Boolean,
     val pending: List<LessonForToday>,
+    val upcoming: List<LessonForToday>,
     val marked: List<LessonForToday>
 )

--- a/app/src/main/java/com/tutorly/ui/screens/TodayViewModel.kt
+++ b/app/src/main/java/com/tutorly/ui/screens/TodayViewModel.kt
@@ -154,13 +154,27 @@ class TodayViewModel @Inject constructor(
         }
 
         val outstandingUnpaidCount = outstandingLessons.count { it.paymentStatus == PaymentStatus.UNPAID }
-        val todayUnpaidCount = todayPending.count { it.paymentStatus == PaymentStatus.UNPAID && it.endAt <= now }
+        val todayUnpaidCount = todayLessons.count { it.paymentStatus == PaymentStatus.UNPAID }
         val pendingCount = outstandingUnpaidCount + todayUnpaidCount
+
+        val todayStats = TodayStats(
+            totalAmountCents = todayLessons.sumOf { it.priceCents.toLong() },
+            totalLessons = todayLessons.size,
+            paidAmountCents = todayLessons
+                .filter { it.paymentStatus == PaymentStatus.PAID }
+                .sumOf { it.priceCents.toLong() },
+            paidLessons = todayLessons.count { it.paymentStatus == PaymentStatus.PAID }
+        )
+
+        val isAllMarked = todayLessons.isNotEmpty() && todayLessons.all {
+            it.paymentStatus == PaymentStatus.PAID || it.paymentStatus == PaymentStatus.DUE
+        }
 
         return TodayUiState.Content(
             sections = sections,
             pendingCount = pendingCount,
-            isAllMarked = pendingCount == 0
+            isAllMarked = isAllMarked,
+            stats = todayStats
         )
     }
 
@@ -172,7 +186,8 @@ sealed interface TodayUiState {
     data class Content(
         val sections: List<TodayLessonSection>,
         val pendingCount: Int,
-        val isAllMarked: Boolean
+        val isAllMarked: Boolean,
+        val stats: TodayStats
     ) : TodayUiState
 }
 
@@ -187,4 +202,11 @@ data class TodayLessonSection(
     val pending: List<LessonForToday>,
     val upcoming: List<LessonForToday>,
     val marked: List<LessonForToday>
+)
+
+data class TodayStats(
+    val totalAmountCents: Long,
+    val totalLessons: Int,
+    val paidAmountCents: Long,
+    val paidLessons: Int
 )

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -116,10 +116,9 @@
     <string name="today_section_upcoming">Предстоящие</string>
     <string name="today_all_marked_title">Все готово!</string>
     <string name="today_all_marked_subtitle">Вы отметили все занятия за сегодня</string>
-    <string name="today_stats_income_label">Доход за день (оплачено/всего)</string>
-    <string name="today_stats_income_value">%1$s / %2$s</string>
-    <string name="today_stats_lessons_label">Количество занятий (оплаченных/всего)</string>
-    <string name="today_stats_lessons_value">%1$d / %2$d</string>
+    <string name="today_stats_income_label">Доход</string>
+    <string name="today_stats_lessons_label">Занятий</string>
+    <string name="today_stats_from">из</string>
     <string name="today_duration_format">%1$d мин</string>
     <string name="today_snackbar_paid">Отмечено: оплачено</string>
     <string name="today_snackbar_due">Отмечено: долг</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -109,11 +109,13 @@
     <string name="lesson_create_conflict_proceed">Создать всё равно</string>
     <string name="lesson_create_conflict_back">Вернуться</string>
     <string name="today_title">Сегодня</string>
-    <string name="today_all_marked">Всё отмечено</string>
     <string name="today_remaining_count">Осталось: %1$d</string>
     <string name="today_empty_title">Сегодня прошедших занятий пока нет</string>
     <string name="today_empty_subtitle">Проверьте расписание или добавьте занятие</string>
     <string name="today_section_marked">Отмеченные</string>
+    <string name="today_section_upcoming">Предстоящие</string>
+    <string name="today_all_marked_title">Все готово!</string>
+    <string name="today_all_marked_subtitle">Вы отметили все занятия за сегодня</string>
     <string name="today_duration_format">%1$d мин</string>
     <string name="today_snackbar_paid">Отмечено: оплачено</string>
     <string name="today_snackbar_due">Отмечено: долг</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -116,10 +116,10 @@
     <string name="today_section_upcoming">Предстоящие</string>
     <string name="today_all_marked_title">Все готово!</string>
     <string name="today_all_marked_subtitle">Вы отметили все занятия за сегодня</string>
-    <string name="today_stats_total_amount_label">Доход за день</string>
-    <string name="today_stats_total_lessons_label">Количество уроков</string>
-    <string name="today_stats_paid_amount_label">Заработок за день (из того, что оплачено)</string>
-    <string name="today_stats_paid_lessons_label">Количество уроков</string>
+    <string name="today_stats_income_label">Доход за день (оплачено/всего)</string>
+    <string name="today_stats_income_value">%1$s / %2$s</string>
+    <string name="today_stats_lessons_label">Количество занятий (оплаченных/всего)</string>
+    <string name="today_stats_lessons_value">%1$d / %2$d</string>
     <string name="today_duration_format">%1$d мин</string>
     <string name="today_snackbar_paid">Отмечено: оплачено</string>
     <string name="today_snackbar_due">Отмечено: долг</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -116,6 +116,10 @@
     <string name="today_section_upcoming">Предстоящие</string>
     <string name="today_all_marked_title">Все готово!</string>
     <string name="today_all_marked_subtitle">Вы отметили все занятия за сегодня</string>
+    <string name="today_stats_total_amount_label">Доход за день</string>
+    <string name="today_stats_total_lessons_label">Количество уроков</string>
+    <string name="today_stats_paid_amount_label">Заработок за день (из того, что оплачено)</string>
+    <string name="today_stats_paid_lessons_label">Количество уроков</string>
     <string name="today_duration_format">%1$d мин</string>
     <string name="today_snackbar_paid">Отмечено: оплачено</string>
     <string name="today_snackbar_due">Отмечено: долг</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -119,11 +119,6 @@
     <string name="today_snackbar_due">Отмечено: долг</string>
     <string name="today_snackbar_marked">Статус обновлён</string>
     <string name="today_snackbar_action_undo">Отменить</string>
-    <string name="today_note_title">Заметка — %1$s</string>
-    <string name="today_note_time">%1$s</string>
-    <string name="today_note_placeholder">Добавьте заметку о занятии</string>
-    <string name="today_note_cancel">Отмена</string>
-    <string name="today_note_save">Сохранить</string>
     <string name="lesson_details_title">Занятие</string>
     <string name="lesson_details_not_found">Занятие не найдено</string>
     <string name="lesson_details_student_sheet_title">Выберите ученика</string>


### PR DESCRIPTION
## Summary
- extend lesson repositories/dao to expose outstanding lessons alongside today
- rework Today view model and screen to group lessons by day, keep marked items at the end, and open the lesson editor sheet
- remove the obsolete note sheet resources and update UI affordances for outstanding counts

## Testing
- ./gradlew :app:lintDebug *(fails: proxy returned HTTP 403)*

------
https://chatgpt.com/codex/tasks/task_e_68eb901b57d083208f7d38d7e04228a9