### PR TITLE
Update students tab with notes and lesson progress

### DIFF
--- a/app/src/main/java/com/tutorly/data/db/dao/StudentDao.kt
+++ b/app/src/main/java/com/tutorly/data/db/dao/StudentDao.kt
@@ -1,7 +1,12 @@
 package com.tutorly.data.db.dao
 
-import androidx.room.*
-import com.tutorly.models.*
+import androidx.room.Dao
+import androidx.room.Delete
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import androidx.room.Update
+import com.tutorly.models.Student
 import kotlinx.coroutines.flow.Flow
 
 @Dao
@@ -35,8 +40,11 @@ interface StudentDao {
     @Query("SELECT * FROM students WHERE id = :id")
     fun observeStudent(id: Long): Flow<Student?>
 
-    @Insert(onConflict = OnConflictStrategy.REPLACE)
-    suspend fun upsert(student: Student): Long
+    @Insert(onConflict = OnConflictStrategy.ABORT)
+    suspend fun insert(student: Student): Long
+
+    @Update
+    suspend fun update(student: Student)
 
     @Delete
     suspend fun delete(student: Student)

--- a/app/src/main/java/com/tutorly/data/repo/room/RoomStudentsRepository.kt
+++ b/app/src/main/java/com/tutorly/data/repo/room/RoomStudentsRepository.kt
@@ -78,8 +78,14 @@ class RoomStudentsRepository @Inject constructor(
         }.distinctUntilChanged()
     }
 
-    override suspend fun upsert(student: Student): Long =
-        studentDao.upsert(student)
+    override suspend fun upsert(student: Student): Long {
+        return if (student.id == 0L) {
+            studentDao.insert(student)
+        } else {
+            studentDao.update(student)
+            student.id
+        }
+    }
 
     override suspend fun delete(student: Student) =
         studentDao.delete(student)

--- a/app/src/main/java/com/tutorly/ui/screens/StudentsScreen.kt
+++ b/app/src/main/java/com/tutorly/ui/screens/StudentsScreen.kt
@@ -26,7 +26,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.Search
-import androidx.compose.material.icons.outlined.AttachMoney
+import androidx.compose.material.icons.outlined.CurrencyRuble
 import androidx.compose.material.icons.outlined.Email
 import androidx.compose.material.icons.outlined.Phone
 import androidx.compose.material.icons.outlined.StickyNote2
@@ -501,7 +501,7 @@ private fun StudentCard(
                         horizontalArrangement = Arrangement.spacedBy(8.dp)
                     ) {
                         Icon(
-                            imageVector = Icons.Outlined.AttachMoney,
+                            imageVector = Icons.Outlined.CurrencyRuble,
                             contentDescription = null,
                             modifier = Modifier.size(16.dp)
                         )

--- a/app/src/main/java/com/tutorly/ui/screens/StudentsScreen.kt
+++ b/app/src/main/java/com/tutorly/ui/screens/StudentsScreen.kt
@@ -412,20 +412,15 @@ private fun StudentCard(
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    val currencyFormatter = remember {
-        NumberFormat.getCurrencyInstance(Locale("ru", "RU")).apply {
-            currency = Currency.getInstance("RUB")
-        }
-    }
     val subject = item.profile.subject?.takeIf { it.isNotBlank() }?.trim()
     val grade = item.profile.grade?.takeIf { it.isNotBlank() }?.trim()
-    val rate = item.profile.rate?.let { formatCurrency(it.priceCents.toLong(), currencyFormatter) }
-    val subtitle = listOfNotNull(subject, grade, rate)
+    val subtitle = listOfNotNull(subject, grade)
         .joinToString(separator = " • ")
         .takeIf { it.isNotBlank() }
 
     val phone = item.student.phone?.takeIf { it.isNotBlank() }?.trim()
     val email = item.student.messenger?.takeIf { it.isNotBlank() }?.trim()
+    val note = item.student.note?.takeIf { it.isNotBlank() }?.trim()
     val showTrailingRow = phone != null || email != null || item.hasDebt
 
     Card(
@@ -464,6 +459,24 @@ private fun StudentCard(
                         overflow = TextOverflow.Ellipsis
                     )
                 }
+                note?.let {
+                    Text(
+                        text = it,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        maxLines = 2,
+                        overflow = TextOverflow.Ellipsis
+                    )
+                }
+                Text(
+                    text = stringResource(
+                        id = R.string.student_card_progress,
+                        item.progress.paidLessons,
+                        item.progress.completedLessons
+                    ),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
                 if (showTrailingRow) {
                     Row(
                         modifier = Modifier
@@ -606,8 +619,7 @@ private fun StudentProfileContent(
             item {
                 StudentProfileHeader(
                     profile = profile,
-                    onEdit = onEdit,
-                    currencyFormatter = currencyFormatter
+                    onEdit = onEdit
                 )
             }
             item {
@@ -683,7 +695,6 @@ private fun StudentProfileContent(
 private fun StudentProfileHeader(
     profile: StudentProfile,
     onEdit: (Long) -> Unit,
-    currencyFormatter: NumberFormat,
     modifier: Modifier = Modifier
 ) {
     Row(
@@ -712,23 +723,6 @@ private fun StudentProfileHeader(
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                     maxLines = 2,
                     overflow = TextOverflow.Ellipsis
-                )
-            }
-            val rateText = profile.rate?.let { rate ->
-                val price = formatCurrency(rate.priceCents.toLong(), currencyFormatter)
-                if (rate.durationMinutes > 0) {
-                    "$price • ${rate.durationMinutes} мин"
-                } else {
-                    price
-                }
-            } ?: profile.student.rateCents?.takeIf { it > 0 }?.let { cents ->
-                formatCurrency(cents.toLong(), currencyFormatter)
-            }
-            if (!rateText.isNullOrBlank()) {
-                Text(
-                    text = rateText,
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant
                 )
             }
         }

--- a/app/src/main/java/com/tutorly/ui/screens/StudentsScreen.kt
+++ b/app/src/main/java/com/tutorly/ui/screens/StudentsScreen.kt
@@ -26,8 +26,10 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.Search
+import androidx.compose.material.icons.outlined.AttachMoney
 import androidx.compose.material.icons.outlined.Email
 import androidx.compose.material.icons.outlined.Phone
+import androidx.compose.material.icons.outlined.StickyNote2
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
@@ -460,23 +462,62 @@ private fun StudentCard(
                     )
                 }
                 note?.let {
-                    Text(
-                        text = it,
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        maxLines = 2,
-                        overflow = TextOverflow.Ellipsis
-                    )
+                    Surface(
+                        color = MaterialTheme.colorScheme.surfaceVariant,
+                        contentColor = MaterialTheme.colorScheme.onSurfaceVariant,
+                        shape = MaterialTheme.shapes.small
+                    ) {
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(horizontal = 12.dp, vertical = 8.dp),
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.spacedBy(8.dp)
+                        ) {
+                            Icon(
+                                imageVector = Icons.Outlined.StickyNote2,
+                                contentDescription = null,
+                                modifier = Modifier.size(16.dp)
+                            )
+                            Text(
+                                text = it,
+                                style = MaterialTheme.typography.bodySmall,
+                                maxLines = 2,
+                                overflow = TextOverflow.Ellipsis
+                            )
+                        }
+                    }
                 }
-                Text(
-                    text = stringResource(
-                        id = R.string.student_card_progress,
-                        item.progress.paidLessons,
-                        item.progress.completedLessons
-                    ),
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant
-                )
+                Surface(
+                    color = MaterialTheme.colorScheme.primary.copy(alpha = 0.08f),
+                    contentColor = MaterialTheme.colorScheme.primary,
+                    shape = MaterialTheme.shapes.small
+                ) {
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 12.dp, vertical = 8.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(8.dp)
+                    ) {
+                        Icon(
+                            imageVector = Icons.Outlined.AttachMoney,
+                            contentDescription = null,
+                            modifier = Modifier.size(16.dp)
+                        )
+                        Text(
+                            text = stringResource(
+                                id = R.string.student_card_progress,
+                                item.progress.paidLessons,
+                                item.progress.completedLessons
+                            ),
+                            style = MaterialTheme.typography.bodySmall,
+                            fontWeight = FontWeight.Medium,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis
+                        )
+                    }
+                }
                 if (showTrailingRow) {
                     Row(
                         modifier = Modifier

--- a/app/src/main/java/com/tutorly/ui/screens/StudentsViewModel.kt
+++ b/app/src/main/java/com/tutorly/ui/screens/StudentsViewModel.kt
@@ -402,10 +402,18 @@ class StudentsViewModel @Inject constructor(
             return LessonProgress(paidLessons = 0, completedLessons = 0)
         }
 
-        val completed = lessons.count { it.status == LessonStatus.DONE }
-        val paid = lessons.count { it.paymentStatus == PaymentStatus.PAID }
+        val now = Instant.now()
+        val completedLessons = lessons.filter { lesson ->
+            lesson.startAt <= now &&
+                lesson.status != LessonStatus.CANCELED &&
+                lesson.paymentStatus != PaymentStatus.CANCELLED
+        }
+        val paidLessons = completedLessons.count { it.paymentStatus == PaymentStatus.PAID }
 
-        return LessonProgress(paidLessons = paid, completedLessons = completed)
+        return LessonProgress(
+            paidLessons = paidLessons,
+            completedLessons = completedLessons.size
+        )
     }
 
     private fun buildProfile(

--- a/app/src/main/java/com/tutorly/ui/screens/StudentsViewModel.kt
+++ b/app/src/main/java/com/tutorly/ui/screens/StudentsViewModel.kt
@@ -403,9 +403,7 @@ class StudentsViewModel @Inject constructor(
         }
 
         val completed = lessons.count { it.status == LessonStatus.DONE }
-        val paid = lessons.count {
-            it.status == LessonStatus.DONE && it.paymentStatus == PaymentStatus.PAID
-        }
+        val paid = lessons.count { it.paymentStatus == PaymentStatus.PAID }
 
         return LessonProgress(paidLessons = paid, completedLessons = completed)
     }

--- a/app/src/main/java/com/tutorly/ui/screens/StudentsViewModel.kt
+++ b/app/src/main/java/com/tutorly/ui/screens/StudentsViewModel.kt
@@ -6,12 +6,13 @@ import com.tutorly.domain.model.StudentProfile
 import com.tutorly.domain.repo.LessonsRepository
 import com.tutorly.domain.repo.StudentsRepository
 import com.tutorly.domain.repo.SubjectPresetsRepository
+import com.tutorly.models.LessonStatus
+import com.tutorly.models.PaymentStatus
 import com.tutorly.models.Student
 import com.tutorly.models.SubjectPreset
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 import java.time.Instant
-import java.time.Duration
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -46,7 +47,7 @@ class StudentsViewModel @Inject constructor(
     private val debtObservers = mutableMapOf<Long, Job>()
     private val _debts = MutableStateFlow<Map<Long, Boolean>>(emptyMap())
     private val lessonObservers = mutableMapOf<Long, Job>()
-    private val _latestLessons = MutableStateFlow<Map<Long, LessonSnapshot?>>(emptyMap())
+    private val _lessonSummaries = MutableStateFlow<Map<Long, LessonSummary>>(emptyMap())
     private val _subjects = MutableStateFlow<Map<Long, SubjectPreset>>(emptyMap())
     private val _selectedStudentId = MutableStateFlow<Long?>(null)
     private var editingStudent: Student? = null
@@ -63,15 +64,16 @@ class StudentsViewModel @Inject constructor(
     val students: StateFlow<List<StudentListItem>> = combine(
         studentsStream,
         _debts,
-        _latestLessons,
+        _lessonSummaries,
         _subjects
-    ) { students, debts, lessons, subjects ->
+    ) { students, debts, summaries, subjects ->
         students.map { student ->
-            val snapshot = lessons[student.id]
+            val summary = summaries[student.id]
             StudentListItem(
                 student = student,
                 hasDebt = debts[student.id] == true,
-                profile = buildProfile(student, snapshot, subjects)
+                profile = buildProfile(student, summary?.snapshot, subjects),
+                progress = summary?.progress ?: LessonProgress(paidLessons = 0, completedLessons = 0)
             )
         }
     }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())
@@ -329,7 +331,7 @@ class StudentsViewModel @Inject constructor(
             toRemove.forEach { id ->
                 lessonObservers.remove(id)?.cancel()
             }
-            _latestLessons.update { lessons -> lessons - toRemove }
+            _lessonSummaries.update { summaries -> summaries - toRemove }
         }
 
         val toAdd = ids - existing
@@ -338,18 +340,14 @@ class StudentsViewModel @Inject constructor(
                 lessonsRepository.observeByStudent(id).collect { lessons ->
                     val latest = lessons.maxByOrNull { it.startAt }
                     val snapshot = latest?.let {
-                        val durationMinutes = Duration.between(it.startAt, it.endAt)
-                            .toMinutes()
-                            .toInt()
-                            .coerceAtLeast(0)
                         LessonSnapshot(
-                            lessonId = it.id,
-                            subjectId = it.subjectId,
-                            durationMinutes = durationMinutes,
-                            priceCents = it.priceCents
+                            subjectId = it.subjectId
                         )
                     }
-                    _latestLessons.update { existingMap -> existingMap + (id to snapshot) }
+                    val progress = buildProgress(lessons)
+                    _lessonSummaries.update { existingMap ->
+                        existingMap + (id to LessonSummary(snapshot = snapshot, progress = progress))
+                    }
 
                     val subjectId = latest?.subjectId
                     if (subjectId != null && _subjects.value[subjectId] == null) {
@@ -374,26 +372,43 @@ class StudentsViewModel @Inject constructor(
     data class StudentListItem(
         val student: Student,
         val hasDebt: Boolean,
-        val profile: StudentCardProfile
+        val profile: StudentCardProfile,
+        val progress: LessonProgress
     )
 
     data class StudentCardProfile(
         val subject: String?,
-        val grade: String?,
-        val rate: LessonRate?
+        val grade: String?
     )
 
-    data class LessonRate(
-        val durationMinutes: Int,
-        val priceCents: Int
+    data class LessonProgress(
+        val paidLessons: Int,
+        val completedLessons: Int
+    )
+
+    private data class LessonSummary(
+        val snapshot: LessonSnapshot?,
+        val progress: LessonProgress
     )
 
     private data class LessonSnapshot(
-        val lessonId: Long,
-        val subjectId: Long?,
-        val durationMinutes: Int,
-        val priceCents: Int
+        val subjectId: Long?
     )
+
+    private fun buildProgress(
+        lessons: List<com.tutorly.models.Lesson>
+    ): LessonProgress {
+        if (lessons.isEmpty()) {
+            return LessonProgress(paidLessons = 0, completedLessons = 0)
+        }
+
+        val completed = lessons.count { it.status == LessonStatus.DONE }
+        val paid = lessons.count {
+            it.status == LessonStatus.DONE && it.paymentStatus == PaymentStatus.PAID
+        }
+
+        return LessonProgress(paidLessons = paid, completedLessons = completed)
+    }
 
     private fun buildProfile(
         student: Student,
@@ -415,13 +430,8 @@ class StudentsViewModel @Inject constructor(
             ?.takeIf { it.isNotBlank() }
             ?.trim()
             ?: student.note.extractGrade()
-        val rate = snapshot?.takeIf { it.priceCents > 0 && it.durationMinutes > 0 }?.let {
-            LessonRate(durationMinutes = it.durationMinutes, priceCents = it.priceCents)
-        } ?: student.rateCents?.takeIf { it > 0 }?.let {
-            LessonRate(durationMinutes = 0, priceCents = it)
-        }
 
-        return StudentCardProfile(subject = subject, grade = grade, rate = rate)
+        return StudentCardProfile(subject = subject, grade = grade)
     }
 }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -60,6 +60,7 @@
     <string name="student_details_stats_paid_lessons">Оплаченных занятий</string>
     <string name="student_details_stats_debt">Долг</string>
     <string name="student_details_history_title">История занятий</string>
+    <string name="student_card_progress">Оплачено %1$d/%2$d</string>
     <string name="student_details_history_empty">Пока нет занятий</string>
     <string name="student_details_history_time_range">%1$s — %2$s · %3$d мин</string>
     <string name="student_details_create_lesson">Создать занятие</string>


### PR DESCRIPTION
## Summary
- show student notes and paid/past lesson progress on the students list cards
- stop displaying lesson rate information on the students tab
- fix student updates so existing lessons are preserved when editing a student

## Testing
- ./gradlew test *(fails: Android SDK not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68eb9cb04e5c83209628fa6dcb26d39d