### PR TITLE
Add lesson deletion flow to lesson card

### DIFF
--- a/app/src/main/java/com/tutorly/data/db/dao/LessonDao.kt
+++ b/app/src/main/java/com/tutorly/data/db/dao/LessonDao.kt
@@ -83,6 +83,9 @@ interface LessonDao {
 
     @Query("UPDATE lessons SET note=:note, updatedAt=:now WHERE id=:id")
     suspend fun updateNote(id: Long, note: String?, now: Instant)
+
+    @Query("DELETE FROM lessons WHERE id = :id")
+    suspend fun deleteById(id: Long)
 }
 
 data class LessonCountTuple(

--- a/app/src/main/java/com/tutorly/data/repo/memory/InMemoryLessonsRepository.kt
+++ b/app/src/main/java/com/tutorly/data/repo/memory/InMemoryLessonsRepository.kt
@@ -112,6 +112,12 @@ class InMemoryLessonsRepository : LessonsRepository {
             .maxByOrNull { it.startAt }
     }
 
+    override suspend fun delete(id: Long) {
+        store.remove(id)
+        payments.remove(id)
+        emit()
+    }
+
     override suspend fun markPaid(id: Long) {
         store[id]?.let { lesson ->
             val now = Instant.now()

--- a/app/src/main/java/com/tutorly/data/repo/room/RoomLessonsRepository.kt
+++ b/app/src/main/java/com/tutorly/data/repo/room/RoomLessonsRepository.kt
@@ -92,6 +92,11 @@ class RoomLessonsRepository(
     override suspend fun latestLessonForStudent(studentId: Long): Lesson? {
         return lessonDao.findLatestForStudent(studentId)?.lesson
     }
+
+    override suspend fun delete(id: Long) {
+        lessonDao.deleteById(id)
+    }
+
     override suspend fun markPaid(id: Long) {
         val lesson = lessonDao.findById(id) ?: return
         val now = Instant.now()

--- a/app/src/main/java/com/tutorly/domain/repo/LessonsRepository.kt
+++ b/app/src/main/java/com/tutorly/domain/repo/LessonsRepository.kt
@@ -20,6 +20,7 @@ interface LessonsRepository {
     suspend fun create(request: LessonCreateRequest): Long
     suspend fun findConflicts(start: Instant, end: Instant): List<LessonDetails>
     suspend fun latestLessonForStudent(studentId: Long): Lesson?
+    suspend fun delete(id: Long)
     suspend fun markPaid(id: Long)
     suspend fun markDue(id: Long)
     suspend fun resetPaymentStatus(id: Long)

--- a/app/src/main/java/com/tutorly/ui/lessoncard/LessonCardModels.kt
+++ b/app/src/main/java/com/tutorly/ui/lessoncard/LessonCardModels.kt
@@ -29,6 +29,7 @@ data class LessonCardUiState(
     val locale: Locale = Locale.getDefault(),
     val zoneId: ZoneId = ZoneId.systemDefault(),
     val isPaymentActionRunning: Boolean = false,
+    val isDeleting: Boolean = false,
 )
 
 data class LessonStudentOption(

--- a/app/src/main/java/com/tutorly/ui/lessoncard/LessonCardSheet.kt
+++ b/app/src/main/java/com/tutorly/ui/lessoncard/LessonCardSheet.kt
@@ -2,6 +2,7 @@ package com.tutorly.ui.lessoncard
 
 import android.app.DatePickerDialog
 import android.app.TimePickerDialog
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -25,6 +26,7 @@ import androidx.compose.material.icons.outlined.CalendarMonth
 import androidx.compose.material.icons.outlined.Schedule
 import androidx.compose.material.icons.outlined.Timelapse
 import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
@@ -33,6 +35,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
@@ -81,6 +84,7 @@ internal fun LessonCardSheet(
     onPriceChange: (Int) -> Unit,
     onStatusSelect: (PaymentStatus) -> Unit,
     onNoteChange: (String) -> Unit,
+    onDeleteLesson: () -> Unit,
     onSnackbarConsumed: () -> Unit,
 ) {
     if (!state.isVisible) return
@@ -94,6 +98,7 @@ internal fun LessonCardSheet(
     var showDurationDialog by remember { mutableStateOf(false) }
     var showPriceDialog by remember { mutableStateOf(false) }
     var showNoteDialog by remember { mutableStateOf(false) }
+    var showDeleteDialog by remember { mutableStateOf(false) }
     var statusMenuExpanded by remember { mutableStateOf(false) }
 
     val locale = state.locale
@@ -236,6 +241,28 @@ internal fun LessonCardSheet(
                         onClick = onNoteClick
                     )
 
+                    if (state.lessonId != null) {
+                        OutlinedButton(
+                            onClick = { showDeleteDialog = true },
+                            modifier = Modifier.fillMaxWidth(),
+                            enabled = !state.isSaving && !state.isDeleting && !state.isLoading,
+                            colors = ButtonDefaults.outlinedButtonColors(
+                                contentColor = MaterialTheme.colorScheme.error
+                            ),
+                            border = BorderStroke(1.dp, MaterialTheme.colorScheme.error)
+                        ) {
+                            if (state.isDeleting) {
+                                CircularProgressIndicator(
+                                    modifier = Modifier.size(18.dp),
+                                    strokeWidth = 2.dp,
+                                    color = MaterialTheme.colorScheme.error
+                                )
+                            } else {
+                                Text(text = stringResource(id = R.string.lesson_card_delete))
+                            }
+                        }
+                    }
+
                     Spacer(modifier = Modifier.height(8.dp))
                 }
             }
@@ -291,6 +318,16 @@ internal fun LessonCardSheet(
                 onNoteChange(it)
                 showNoteDialog = false
             }
+        )
+    }
+
+    if (showDeleteDialog) {
+        DeleteLessonDialog(
+            onConfirm = {
+                showDeleteDialog = false
+                onDeleteLesson()
+            },
+            onDismiss = { showDeleteDialog = false }
         )
     }
 }
@@ -751,6 +788,33 @@ private fun NoteDialog(
         confirmButton = {
             TextButton(onClick = { onConfirm(noteInput) }) {
                 Text(text = stringResource(id = R.string.lesson_details_save))
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text(text = stringResource(id = R.string.lesson_create_cancel))
+            }
+        }
+    )
+}
+
+@Composable
+private fun DeleteLessonDialog(
+    onConfirm: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(text = stringResource(id = R.string.lesson_card_delete_title)) },
+        text = { Text(text = stringResource(id = R.string.lesson_card_delete_message)) },
+        confirmButton = {
+            TextButton(
+                onClick = onConfirm,
+                colors = ButtonDefaults.textButtonColors(
+                    contentColor = MaterialTheme.colorScheme.error
+                )
+            ) {
+                Text(text = stringResource(id = R.string.lesson_card_delete_confirm))
             }
         },
         dismissButton = {

--- a/app/src/main/java/com/tutorly/ui/lessoncard/LessonCardViewModel.kt
+++ b/app/src/main/java/com/tutorly/ui/lessoncard/LessonCardViewModel.kt
@@ -65,6 +65,7 @@ class LessonCardViewModel @Inject constructor(
                 isVisible = true,
                 isLoading = true,
                 isSaving = false,
+                isDeleting = false,
                 lessonId = lessonId,
                 snackbarMessage = null,
             )
@@ -113,7 +114,27 @@ class LessonCardViewModel @Inject constructor(
                 isSaving = false,
                 isLoading = false,
                 isPaymentActionRunning = false,
+                isDeleting = false,
             )
+        }
+    }
+
+    fun deleteLesson() {
+        val lessonId = _uiState.value.lessonId ?: return
+        if (_uiState.value.isDeleting) return
+        _uiState.update { it.copy(isDeleting = true, snackbarMessage = null) }
+        viewModelScope.launch {
+            val result = runCatching { lessonsRepository.delete(lessonId) }
+            result.onSuccess {
+                dismiss()
+            }.onFailure { error ->
+                _uiState.update {
+                    it.copy(
+                        isDeleting = false,
+                        snackbarMessage = LessonCardMessage.Error(error.message)
+                    )
+                }
+            }
         }
     }
 

--- a/app/src/main/java/com/tutorly/ui/screens/CalendarScreen.kt
+++ b/app/src/main/java/com/tutorly/ui/screens/CalendarScreen.kt
@@ -102,6 +102,7 @@ fun CalendarScreen(
         onPriceChange = lessonCardViewModel::onPriceChanged,
         onStatusSelect = lessonCardViewModel::onPaymentStatusSelected,
         onNoteChange = lessonCardViewModel::onNoteChanged,
+        onDeleteLesson = lessonCardViewModel::deleteLesson,
         onSnackbarConsumed = lessonCardViewModel::consumeSnackbar
     )
 

--- a/app/src/main/java/com/tutorly/ui/screens/StudentDetailsScreen.kt
+++ b/app/src/main/java/com/tutorly/ui/screens/StudentDetailsScreen.kt
@@ -81,6 +81,7 @@ fun StudentDetailsScreen(
         onPriceChange = lessonCardViewModel::onPriceChanged,
         onStatusSelect = lessonCardViewModel::onPaymentStatusSelected,
         onNoteChange = lessonCardViewModel::onNoteChanged,
+        onDeleteLesson = lessonCardViewModel::deleteLesson,
         onSnackbarConsumed = lessonCardViewModel::consumeSnackbar
     )
 

--- a/app/src/main/java/com/tutorly/ui/screens/StudentsScreen.kt
+++ b/app/src/main/java/com/tutorly/ui/screens/StudentsScreen.kt
@@ -113,6 +113,7 @@ fun StudentsScreen(
         onPriceChange = lessonCardViewModel::onPriceChanged,
         onStatusSelect = lessonCardViewModel::onPaymentStatusSelected,
         onNoteChange = lessonCardViewModel::onNoteChanged,
+        onDeleteLesson = lessonCardViewModel::deleteLesson,
         onSnackbarConsumed = lessonCardViewModel::consumeSnackbar
     )
 

--- a/app/src/main/java/com/tutorly/ui/screens/TodayScreen.kt
+++ b/app/src/main/java/com/tutorly/ui/screens/TodayScreen.kt
@@ -92,6 +92,7 @@ fun TodayScreen(
         onPriceChange = lessonCardViewModel::onPriceChanged,
         onStatusSelect = lessonCardViewModel::onPaymentStatusSelected,
         onNoteChange = lessonCardViewModel::onNoteChanged,
+        onDeleteLesson = lessonCardViewModel::deleteLesson,
         onSnackbarConsumed = lessonCardViewModel::consumeSnackbar
     )
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -83,6 +83,10 @@
     <string name="lesson_card_student_picker_title">Выберите ученика</string>
     <string name="lesson_card_student_picker_empty">Нет доступных учеников</string>
     <string name="lesson_card_date_label">Дата</string>
+    <string name="lesson_card_delete">Удалить занятие</string>
+    <string name="lesson_card_delete_title">Удалить занятие?</string>
+    <string name="lesson_card_delete_message">Этот урок будет удалён без возможности восстановления. Продолжить?</string>
+    <string name="lesson_card_delete_confirm">Удалить</string>
     <string name="lesson_card_duration_title">Длительность занятия</string>
     <string name="lesson_card_duration_hint">Введите длительность</string>
     <string name="lesson_card_price_title">Изменить стоимость</string>


### PR DESCRIPTION
## Summary
- add a destructive action to the lesson card sheet with confirmation before removing a lesson
- extend the lessons repository implementations with explicit delete support and expose deletion progress in UI state
- localize new strings for the delete affordance

## Testing
- ./gradlew test *(fails: Android SDK is not available in the CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68eba22108dc83208d94491efa2b8c8c