### PR TITLE
Convert student profile to dedicated screen

### DIFF
--- a/app/src/main/java/com/tutorly/navigation/AppNav.kt
+++ b/app/src/main/java/com/tutorly/navigation/AppNav.kt
@@ -15,10 +15,8 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
-import androidx.navigation.compose.dialog
 import androidx.navigation.navArgument
 import androidx.hilt.navigation.compose.hiltViewModel
-import androidx.compose.ui.window.DialogProperties
 import com.tutorly.ui.CalendarMode
 import com.tutorly.ui.CalendarScreen
 import com.tutorly.ui.CalendarViewModel
@@ -207,7 +205,7 @@ fun AppNavRoot() {
                     }
                 )
             }
-            dialog(
+            composable(
                 route = ROUTE_STUDENT_EDIT,
                 arguments = listOf(
                     navArgument("studentId") { type = NavType.LongType },
@@ -215,15 +213,10 @@ fun AppNavRoot() {
                         type = NavType.StringType
                         defaultValue = StudentEditTarget.PROFILE.name
                     }
-                ),
-                dialogProperties = DialogProperties(
-                    usePlatformDefaultWidth = false,
-                    dismissOnBackPress = false,
-                    dismissOnClickOutside = false
                 )
             ) {
-                StudentEditorScreen(
-                    onClose = { nav.popBackStack() },
+                StudentEditorDialog(
+                    onDismiss = { nav.popBackStack() },
                     onSaved = {
                         nav.popBackStack()
                     }

--- a/app/src/main/java/com/tutorly/navigation/AppNav.kt
+++ b/app/src/main/java/com/tutorly/navigation/AppNav.kt
@@ -149,6 +149,11 @@ fun AppNavRoot() {
                             restoreState = true
                         }
                     },
+                    onStudentOpen = { id ->
+                        nav.navigate(studentDetailsRoute(id)) {
+                            launchSingleTop = true
+                        }
+                    },
                     onStudentCreatedFromLesson = { newId ->
                         val reopened = creationViewModel.onStudentCreated(newId)
                         nav.navigate(calendarRoute(nav)) {
@@ -176,10 +181,10 @@ fun AppNavRoot() {
                             launchSingleTop = true
                         }
                     },
-                    onCreateLesson = { student ->
+                    onAddLesson = { id ->
                         creationViewModel.start(
                             LessonCreationConfig(
-                                studentId = student.id,
+                                studentId = id,
                                 zoneId = ZonedDateTime.now().zone,
                                 origin = LessonCreationOrigin.STUDENT
                             )

--- a/app/src/main/java/com/tutorly/navigation/AppNav.kt
+++ b/app/src/main/java/com/tutorly/navigation/AppNav.kt
@@ -37,9 +37,18 @@ private const val ARG_STUDENT_EDITOR_ORIGIN = "studentEditorOrigin"
 private const val ROUTE_STUDENTS_PATTERN = "$ROUTE_STUDENTS?$ARG_STUDENT_EDITOR_ORIGIN={$ARG_STUDENT_EDITOR_ORIGIN}"
 const val ROUTE_FINANCE = "finance"
 const val ROUTE_STUDENT_DETAILS = "student/{studentId}"
-const val ROUTE_STUDENT_EDIT = "student/{studentId}/edit"
+private const val ROUTE_STUDENT_EDIT_BASE = "student/{studentId}/edit"
+private const val ARG_STUDENT_EDIT_TARGET = "editTarget"
+const val ROUTE_STUDENT_EDIT = "$ROUTE_STUDENT_EDIT_BASE?$ARG_STUDENT_EDIT_TARGET={$ARG_STUDENT_EDIT_TARGET}"
 private fun studentDetailsRoute(studentId: Long) = ROUTE_STUDENT_DETAILS.replace("{studentId}", studentId.toString())
-private fun studentEditRoute(studentId: Long) = ROUTE_STUDENT_EDIT.replace("{studentId}", studentId.toString())
+private fun studentEditRoute(studentId: Long, target: StudentEditTarget? = null): String {
+    val base = ROUTE_STUDENT_EDIT_BASE.replace("{studentId}", studentId.toString())
+    return if (target != null) {
+        "$base?$ARG_STUDENT_EDIT_TARGET=${target.name}"
+    } else {
+        base
+    }
+}
 
 @Composable
 fun AppNavRoot() {
@@ -176,8 +185,8 @@ fun AppNavRoot() {
                 val creationViewModel: LessonCreationViewModel = hiltViewModel(calendarEntry)
                 StudentDetailsScreen(
                     onBack = { nav.popBackStack() },
-                    onEdit = {
-                        nav.navigate(studentEditRoute(studentId)) {
+                    onEdit = { id, target ->
+                        nav.navigate(studentEditRoute(id, target)) {
                             launchSingleTop = true
                         }
                     },
@@ -198,7 +207,13 @@ fun AppNavRoot() {
             }
             composable(
                 route = ROUTE_STUDENT_EDIT,
-                arguments = listOf(navArgument("studentId") { type = NavType.LongType })
+                arguments = listOf(
+                    navArgument("studentId") { type = NavType.LongType },
+                    navArgument(ARG_STUDENT_EDIT_TARGET) {
+                        type = NavType.StringType
+                        defaultValue = StudentEditTarget.PROFILE.name
+                    }
+                )
             ) {
                 StudentEditorScreen(
                     onClose = { nav.popBackStack() },

--- a/app/src/main/java/com/tutorly/navigation/AppNav.kt
+++ b/app/src/main/java/com/tutorly/navigation/AppNav.kt
@@ -15,8 +15,10 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
+import androidx.navigation.compose.dialog
 import androidx.navigation.navArgument
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.compose.ui.window.DialogProperties
 import com.tutorly.ui.CalendarMode
 import com.tutorly.ui.CalendarScreen
 import com.tutorly.ui.CalendarViewModel
@@ -205,7 +207,7 @@ fun AppNavRoot() {
                     }
                 )
             }
-            composable(
+            dialog(
                 route = ROUTE_STUDENT_EDIT,
                 arguments = listOf(
                     navArgument("studentId") { type = NavType.LongType },
@@ -213,6 +215,11 @@ fun AppNavRoot() {
                         type = NavType.StringType
                         defaultValue = StudentEditTarget.PROFILE.name
                     }
+                ),
+                dialogProperties = DialogProperties(
+                    usePlatformDefaultWidth = false,
+                    dismissOnBackPress = false,
+                    dismissOnClickOutside = false
                 )
             ) {
                 StudentEditorScreen(

--- a/app/src/main/java/com/tutorly/ui/screens/StudentDetailsScreen.kt
+++ b/app/src/main/java/com/tutorly/ui/screens/StudentDetailsScreen.kt
@@ -1,31 +1,40 @@
 package com.tutorly.ui.screens
 
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.ArrowBack
-import androidx.compose.material.icons.filled.Edit
-import androidx.compose.material.icons.outlined.Message
+import androidx.compose.material.icons.outlined.CalendarToday
+import androidx.compose.material.icons.outlined.CurrencyRuble
+import androidx.compose.material.icons.outlined.Email
 import androidx.compose.material.icons.outlined.Phone
+import androidx.compose.material.icons.outlined.Schedule
+import androidx.compose.material.icons.outlined.StickyNote2
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
-import androidx.compose.material3.Divider
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -35,40 +44,44 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.tutorly.R
-import com.tutorly.models.Lesson
+import com.tutorly.domain.model.StudentProfile
+import com.tutorly.domain.model.StudentProfileLesson
 import com.tutorly.models.PaymentStatus
-import com.tutorly.models.Student
 import com.tutorly.ui.components.PaymentBadge
 import com.tutorly.ui.lessoncard.LessonCardSheet
 import com.tutorly.ui.lessoncard.LessonCardViewModel
 import java.text.NumberFormat
-import java.time.Duration
 import java.time.ZoneId
+import java.time.YearMonth
 import java.time.format.DateTimeFormatter
+import java.util.Currency
 import java.util.Locale
+import kotlin.math.roundToInt
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun StudentDetailsScreen(
     onBack: () -> Unit,
-    onEdit: () -> Unit,
-    onCreateLesson: (Student) -> Unit = {},
+    onEdit: (Long) -> Unit,
+    onAddLesson: (Long) -> Unit,
+    onAddPrepayment: (Long) -> Unit = {},
     modifier: Modifier = Modifier,
     vm: StudentDetailsViewModel = hiltViewModel(),
 ) {
     val state by vm.uiState.collectAsState()
-    val scrollState = rememberScrollState()
     val lessonCardViewModel: LessonCardViewModel = hiltViewModel()
     val lessonCardState by lessonCardViewModel.uiState.collectAsState()
     LessonCardSheet(
@@ -85,18 +98,35 @@ fun StudentDetailsScreen(
         onSnackbarConsumed = lessonCardViewModel::consumeSnackbar
     )
 
+    val title = when (state) {
+        is StudentProfileUiState.Content -> (state as StudentProfileUiState.Content).profile.student.name
+        else -> stringResource(id = R.string.student_details_title_placeholder)
+    }
+
     Scaffold(
         topBar = {
-            StudentDetailsTopBar(
-                title = state.student?.name ?: stringResource(id = R.string.student_details_title_placeholder),
-                onBack = onBack,
-                onEdit = if (state.student != null) onEdit else null
+            StudentProfileTopBar(
+                title = title,
+                onBack = onBack
             )
+        },
+        floatingActionButton = {
+            if (state is StudentProfileUiState.Content) {
+                val profile = (state as StudentProfileUiState.Content).profile
+                FloatingActionButton(
+                    onClick = { onAddLesson(profile.student.id) },
+                    modifier = Modifier.navigationBarsPadding(),
+                    containerColor = MaterialTheme.colorScheme.primary,
+                    contentColor = MaterialTheme.colorScheme.onPrimary
+                ) {
+                    Icon(imageVector = Icons.Filled.Add, contentDescription = null)
+                }
+            }
         },
         containerColor = MaterialTheme.colorScheme.surface
     ) { innerPadding ->
-        when {
-            state.isLoading -> {
+        when (state) {
+            StudentProfileUiState.Hidden, StudentProfileUiState.Loading -> {
                 Box(
                     modifier = modifier
                         .fillMaxSize()
@@ -106,7 +136,8 @@ fun StudentDetailsScreen(
                     CircularProgressIndicator()
                 }
             }
-            state.student == null -> {
+
+            StudentProfileUiState.Error -> {
                 Box(
                     modifier = modifier
                         .fillMaxSize()
@@ -114,65 +145,24 @@ fun StudentDetailsScreen(
                     contentAlignment = Alignment.Center
                 ) {
                     Text(
-                        text = stringResource(id = R.string.student_details_missing),
+                        text = stringResource(id = R.string.student_profile_error),
                         style = MaterialTheme.typography.bodyMedium,
                         color = MaterialTheme.colorScheme.onSurfaceVariant
                     )
                 }
             }
-            else -> {
-                val student = requireNotNull(state.student)
-                val lessons = remember(state.lessons) {
-                    state.lessons.sortedByDescending { it.startAt }
-                }
-                val locale = remember { Locale("ru", "RU") }
-                val currencyFormatter = remember(locale) { NumberFormat.getCurrencyInstance(locale) }
-                val totalEarnedCents = remember(lessons) { lessons.sumOf { it.paidCents.toLong() } }
-                val formattedTotalEarned = remember(totalEarnedCents) {
-                    currencyFormatter.format(totalEarnedCents / 100.0)
-                }
-                val formattedDebt = remember(state.totalDebtCents) {
-                    currencyFormatter.format(state.totalDebtCents / 100.0)
-                }
-                Column(
+
+            is StudentProfileUiState.Content -> {
+                StudentProfileContent(
+                    profile = state.profile,
+                    onEdit = onEdit,
+                    onAddLesson = onAddLesson,
+                    onAddPrepayment = onAddPrepayment,
+                    onLessonClick = lessonCardViewModel::open,
                     modifier = modifier
                         .fillMaxSize()
                         .padding(innerPadding)
-                        .verticalScroll(scrollState)
-                        .padding(horizontal = 16.dp, vertical = 20.dp),
-                    verticalArrangement = Arrangement.spacedBy(20.dp)
-                ) {
-                    StudentSummaryCard(
-                        student = student,
-                        hasDebt = state.hasDebt,
-                        totalDebt = formattedDebt,
-                        subject = state.subject,
-                        grade = state.grade
-                    )
-                    Button(
-                        onClick = { onCreateLesson(student) },
-                        modifier = Modifier.fillMaxWidth()
-                    ) {
-                        Text(text = stringResource(id = R.string.student_details_create_lesson))
-                    }
-                    StudentContactCard(student = student)
-                    StudentStatsRow(
-                        totalLessons = lessons.size,
-                        formattedTotalEarned = formattedTotalEarned,
-                        paidLessons = lessons.count { it.paymentStatus == PaymentStatus.PAID },
-                        hasDebt = state.hasDebt,
-                        formattedDebt = formattedDebt
-                    )
-                    if (!student.note.isNullOrBlank()) {
-                        StudentNotesCard(note = student.note!!)
-                    }
-                    LessonsHistoryCard(
-                        lessons = lessons,
-                        currencyFormatter = currencyFormatter,
-                        locale = locale,
-                        onLessonClick = { lesson -> lessonCardViewModel.open(lesson.id) }
-                    )
-                }
+                )
             }
         }
     }
@@ -180,10 +170,9 @@ fun StudentDetailsScreen(
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-private fun StudentDetailsTopBar(
+private fun StudentProfileTopBar(
     title: String,
     onBack: () -> Unit,
-    onEdit: (() -> Unit)?
 ) {
     TopAppBar(
         title = {
@@ -201,16 +190,6 @@ private fun StudentDetailsTopBar(
                 )
             }
         },
-        actions = {
-            onEdit?.let {
-                IconButton(onClick = it) {
-                    Icon(
-                        imageVector = Icons.Filled.Edit,
-                        contentDescription = stringResource(id = R.string.student_details_edit)
-                    )
-                }
-            }
-        },
         colors = TopAppBarDefaults.topAppBarColors(
             containerColor = MaterialTheme.colorScheme.surface,
             titleContentColor = MaterialTheme.colorScheme.onSurface
@@ -219,286 +198,177 @@ private fun StudentDetailsTopBar(
 }
 
 @Composable
-private fun StudentSummaryCard(
-    student: Student,
-    hasDebt: Boolean,
-    totalDebt: String,
-    subject: String?,
-    grade: String?,
+private fun StudentProfileContent(
+    profile: StudentProfile,
+    onEdit: (Long) -> Unit,
+    onAddLesson: (Long) -> Unit,
+    onAddPrepayment: (Long) -> Unit,
+    onLessonClick: (Long) -> Unit,
     modifier: Modifier = Modifier
 ) {
-    val subjectText = subject?.takeIf { it.isNotBlank() }?.trim()
-        ?: stringResource(id = R.string.students_subject_placeholder)
-    val gradeText = grade?.takeIf { it.isNotBlank() }?.trim()
-        ?: stringResource(id = R.string.students_grade_placeholder)
-    Card(
-        modifier = modifier.fillMaxWidth(),
-        shape = MaterialTheme.shapes.extraLarge,
-        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.primaryContainer),
-        elevation = CardDefaults.cardElevation(defaultElevation = 4.dp)
-    ) {
-        Column(
-            modifier = Modifier.padding(20.dp),
-            verticalArrangement = Arrangement.spacedBy(12.dp)
-        ) {
-            Text(
-                text = student.name,
-                style = MaterialTheme.typography.headlineSmall,
-                color = MaterialTheme.colorScheme.onPrimaryContainer
-            )
-            Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
-                Text(
-                    text = stringResource(id = R.string.students_subject_label) + ": " + subjectText,
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.onPrimaryContainer
-                )
-                Text(
-                    text = stringResource(id = R.string.students_grade_label) + ": " + gradeText,
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.onPrimaryContainer
-                )
-            }
-            Row(
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                PaymentBadge(paid = !hasDebt)
-                Spacer(modifier = Modifier.width(12.dp))
-                Text(
-                    text = if (hasDebt) {
-                        stringResource(id = R.string.student_details_debt_amount, totalDebt)
-                    } else {
-                        stringResource(id = R.string.student_details_no_debt)
-                    },
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.onPrimaryContainer
-                )
-            }
+    val locale = remember { Locale("ru", "RU") }
+    val numberFormatter = remember(locale) {
+        NumberFormat.getNumberInstance(locale).apply {
+            maximumFractionDigits = 2
+            minimumFractionDigits = 0
         }
     }
-}
-
-@Composable
-private fun StudentContactCard(
-    student: Student,
-    modifier: Modifier = Modifier
-) {
-    Card(
-        modifier = modifier.fillMaxWidth(),
-        shape = MaterialTheme.shapes.large,
-        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceContainerLow),
-        elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
-    ) {
-        Column(
-            modifier = Modifier.padding(20.dp),
-            verticalArrangement = Arrangement.spacedBy(16.dp)
-        ) {
-            Text(
-                text = stringResource(id = R.string.student_details_contact_title),
-                style = MaterialTheme.typography.titleMedium
-            )
-            ContactInfoRow(
-                icon = Icons.Outlined.Phone,
-                label = stringResource(id = R.string.student_details_phone_label),
-                value = student.phone,
-                placeholder = stringResource(id = R.string.student_details_phone_placeholder)
-            )
-            ContactInfoRow(
-                icon = Icons.Outlined.Message,
-                label = stringResource(id = R.string.student_details_messenger_label),
-                value = student.messenger,
-                placeholder = stringResource(id = R.string.student_details_messenger_placeholder)
-            )
+    val currencyFormatter = remember(locale) {
+        NumberFormat.getCurrencyInstance(locale).apply {
+            currency = Currency.getInstance("RUB")
         }
     }
-}
+    val zoneId = remember { ZoneId.systemDefault() }
+    val dateFormatter = remember(locale) { DateTimeFormatter.ofPattern("d MMMM yyyy", locale) }
+    val timeFormatter = remember(locale) { DateTimeFormatter.ofPattern("HH:mm", locale) }
+    val monthFormatter = remember(locale) { DateTimeFormatter.ofPattern("LLLL yyyy", locale) }
 
-@Composable
-private fun ContactInfoRow(
-    icon: androidx.compose.ui.graphics.vector.ImageVector,
-    label: String,
-    value: String?,
-    placeholder: String,
-    modifier: Modifier = Modifier
-) {
-    Row(
-        modifier = modifier.fillMaxWidth(),
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(16.dp)
-    ) {
-        Surface(
-            color = MaterialTheme.colorScheme.primaryContainer,
-            contentColor = MaterialTheme.colorScheme.onPrimaryContainer,
-            shape = CircleShape,
-            tonalElevation = 2.dp
-        ) {
-            Icon(
-                imageVector = icon,
-                contentDescription = null,
-                modifier = Modifier.padding(12.dp)
-            )
+    val groupedLessons = remember(profile.recentLessons, zoneId) {
+        val sorted = profile.recentLessons.sortedByDescending { it.startAt }
+        val groups = linkedMapOf<YearMonth, MutableList<StudentProfileLesson>>()
+        sorted.forEach { lesson ->
+            val key = YearMonth.from(lesson.startAt.atZone(zoneId))
+            groups.getOrPut(key) { mutableListOf() }.add(lesson)
         }
-        Column(modifier = Modifier.weight(1f)) {
-            Text(
-                text = label,
-                style = MaterialTheme.typography.labelMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant
-            )
-            Text(
-                text = value?.takeIf { it.isNotBlank() } ?: placeholder,
-                style = MaterialTheme.typography.bodyLarge,
-                color = if (value.isNullOrBlank()) {
-                    MaterialTheme.colorScheme.onSurfaceVariant
-                } else {
-                    MaterialTheme.colorScheme.onSurface
-                },
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis
-            )
-        }
+        groups.map { it.key to it.value.toList() }
     }
-}
 
-@Composable
-private fun StudentStatsRow(
-    totalLessons: Int,
-    formattedTotalEarned: String,
-    paidLessons: Int,
-    hasDebt: Boolean,
-    formattedDebt: String,
-    modifier: Modifier = Modifier
-) {
-    Row(
-        modifier = modifier.fillMaxWidth(),
-        horizontalArrangement = Arrangement.spacedBy(12.dp)
-    ) {
-        SummaryStatCard(
-            modifier = Modifier.weight(1f),
-            value = totalLessons.toString(),
-            label = stringResource(id = R.string.student_details_stats_lessons)
-        )
-        SummaryStatCard(
-            modifier = Modifier.weight(1f),
-            value = formattedTotalEarned,
-            label = stringResource(id = R.string.student_details_stats_earned)
-        )
-        val (thirdValue, thirdLabel) = if (hasDebt) {
-            formattedDebt to stringResource(id = R.string.student_details_stats_debt)
-        } else {
-            paidLessons.toString() to stringResource(id = R.string.student_details_stats_paid)
-        }
-        SummaryStatCard(
-            modifier = Modifier.weight(1f),
-            value = thirdValue,
-            label = thirdLabel
-        )
-    }
-}
+    val listState = rememberLazyListState()
 
-@Composable
-private fun SummaryStatCard(
-    value: String,
-    label: String,
-    modifier: Modifier = Modifier
-) {
-    Card(
+    LazyColumn(
+        state = listState,
         modifier = modifier,
-        shape = MaterialTheme.shapes.large,
-        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceContainer),
-        elevation = CardDefaults.cardElevation(defaultElevation = 1.dp)
+        contentPadding = PaddingValues(horizontal = 20.dp, vertical = 20.dp),
+        verticalArrangement = Arrangement.spacedBy(20.dp)
     ) {
-        Column(
-            modifier = Modifier.padding(16.dp),
-            verticalArrangement = Arrangement.spacedBy(8.dp)
-        ) {
-            Text(
-                text = value,
-                style = MaterialTheme.typography.titleLarge
-            )
-            Text(
-                text = label,
-                style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant
+        item {
+            StudentProfileHeader(
+                profile = profile,
+                onEdit = onEdit
             )
         }
-    }
-}
 
-@Composable
-private fun StudentNotesCard(
-    note: String,
-    modifier: Modifier = Modifier
-) {
-    Card(
-        modifier = modifier.fillMaxWidth(),
-        shape = MaterialTheme.shapes.large,
-        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceContainerLow),
-        elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
-    ) {
-        Column(
-            modifier = Modifier.padding(20.dp),
-            verticalArrangement = Arrangement.spacedBy(8.dp)
-        ) {
-            Text(
-                text = stringResource(id = R.string.student_details_notes_title),
-                style = MaterialTheme.typography.titleMedium
-            )
-            Text(
-                text = note,
-                style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant
+        item {
+            Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                ProfileInfoCard(
+                    icon = Icons.Outlined.Phone,
+                    label = stringResource(id = R.string.student_details_phone_label),
+                    value = profile.student.phone,
+                    onClick = { onEdit(profile.student.id) }
+                )
+                ProfileInfoCard(
+                    icon = Icons.Outlined.Email,
+                    label = stringResource(id = R.string.student_details_messenger_label),
+                    value = profile.student.messenger,
+                    onClick = { onEdit(profile.student.id) }
+                )
+                if (!profile.student.note.isNullOrBlank()) {
+                    ProfileInfoCard(
+                        icon = Icons.Outlined.StickyNote2,
+                        label = stringResource(id = R.string.student_details_notes_title),
+                        value = profile.student.note,
+                        onClick = { onEdit(profile.student.id) }
+                    )
+                }
+            }
+        }
+
+        item {
+            StudentProfileMetricsSection(
+                profile = profile,
+                numberFormatter = numberFormatter
             )
         }
-    }
-}
 
-@Composable
-private fun LessonsHistoryCard(
-    lessons: List<Lesson>,
-    currencyFormatter: NumberFormat,
-    locale: Locale,
-    onLessonClick: (Lesson) -> Unit,
-    modifier: Modifier = Modifier
-) {
-    val dateFormatter = remember(locale) {
-        DateTimeFormatter.ofPattern("d MMMM", locale)
-    }
-    val timeFormatter = remember(locale) {
-        DateTimeFormatter.ofPattern("HH:mm", locale)
-    }
-    Card(
-        modifier = modifier.fillMaxWidth(),
-        shape = MaterialTheme.shapes.large,
-        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceContainerLow),
-        elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
-    ) {
-        Column(
-            modifier = Modifier.padding(20.dp),
-            verticalArrangement = Arrangement.spacedBy(16.dp)
-        ) {
+        item {
+            Button(
+                onClick = { onAddPrepayment(profile.student.id) },
+                modifier = Modifier.fillMaxWidth(),
+                shape = RoundedCornerShape(16.dp)
+            ) {
+                Text(text = stringResource(id = R.string.student_profile_add_prepayment))
+            }
+        }
+
+        item {
             Text(
                 text = stringResource(id = R.string.student_details_history_title),
                 style = MaterialTheme.typography.titleMedium
             )
-            if (lessons.isEmpty()) {
-                Text(
-                    text = stringResource(id = R.string.student_details_history_empty),
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant
+        }
+
+        if (groupedLessons.isEmpty()) {
+            item {
+                StudentProfileEmptyHistory(
+                    onAddLesson = { onAddLesson(profile.student.id) }
                 )
-            } else {
-                Column(verticalArrangement = Arrangement.spacedBy(16.dp)) {
-                    lessons.forEachIndexed { index, lesson ->
-                        LessonHistoryRow(
-                            lesson = lesson,
-                            currencyFormatter = currencyFormatter,
-                            dateFormatter = dateFormatter,
-                            timeFormatter = timeFormatter,
-                            onClick = onLessonClick
-                        )
-                        if (index != lessons.lastIndex) {
-                            Divider(color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.6f))
-                        }
-                    }
+            }
+        } else {
+            groupedLessons.forEach { (month, lessons) ->
+                item(key = month) {
+                    Text(
+                        text = monthFormatter.format(month),
+                        style = MaterialTheme.typography.titleSmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+                items(
+                    items = lessons,
+                    key = { it.id }
+                ) { lesson ->
+                    StudentProfileLessonCard(
+                        lesson = lesson,
+                        fallbackSubject = profile.subject,
+                        currencyFormatter = currencyFormatter,
+                        zoneId = zoneId,
+                        dateFormatter = dateFormatter,
+                        timeFormatter = timeFormatter,
+                        onClick = { onLessonClick(lesson.id) }
+                    )
+                }
+            }
+        }
+        item { Spacer(modifier = Modifier.height(60.dp)) }
+    }
+}
+
+@Composable
+private fun StudentProfileHeader(
+    profile: StudentProfile,
+    onEdit: (Long) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Card(
+        modifier = modifier
+            .fillMaxWidth()
+            .clickable { onEdit(profile.student.id) },
+        shape = MaterialTheme.shapes.extraLarge,
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.primaryContainer),
+        elevation = CardDefaults.cardElevation(defaultElevation = 0.dp)
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 20.dp, vertical = 24.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
+            StudentAvatar(name = profile.student.name, size = 64.dp)
+            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                Text(
+                    text = profile.student.name,
+                    style = MaterialTheme.typography.headlineSmall,
+                    color = MaterialTheme.colorScheme.onPrimaryContainer
+                )
+                val subject = profile.subject?.takeIf { it.isNotBlank() }?.trim()
+                val grade = profile.grade?.takeIf { it.isNotBlank() }?.trim()
+                val details = listOfNotNull(subject, grade).joinToString(separator = " • ")
+                if (details.isNotEmpty()) {
+                    Text(
+                        text = details,
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onPrimaryContainer
+                    )
                 }
             }
         }
@@ -506,88 +376,273 @@ private fun LessonsHistoryCard(
 }
 
 @Composable
-private fun LessonHistoryRow(
-    lesson: Lesson,
-    currencyFormatter: NumberFormat,
-    dateFormatter: DateTimeFormatter,
-    timeFormatter: DateTimeFormatter,
-    onClick: (Lesson) -> Unit,
+private fun ProfileInfoCard(
+    icon: ImageVector,
+    label: String,
+    value: String?,
+    onClick: () -> Unit,
     modifier: Modifier = Modifier
 ) {
-    val zoneId = remember { ZoneId.systemDefault() }
-    val start = remember(lesson.startAt) { lesson.startAt.atZone(zoneId) }
-    val end = remember(lesson.endAt) { lesson.endAt.atZone(zoneId) }
-    val durationMinutes = remember(lesson.startAt, lesson.endAt) {
-        Duration.between(lesson.startAt, lesson.endAt).toMinutes().toInt().coerceAtLeast(0)
-    }
-    Row(
+    val hasValue = !value.isNullOrBlank()
+    val displayValue = value?.takeIf { it.isNotBlank() }
+        ?: stringResource(id = R.string.student_profile_contact_placeholder)
+
+    Surface(
         modifier = modifier
             .fillMaxWidth()
-            .clickable(onClick = { onClick(lesson) }),
-        verticalAlignment = Alignment.CenterVertically
+            .clip(MaterialTheme.shapes.large)
+            .clickable { onClick() },
+        color = if (hasValue) MaterialTheme.colorScheme.surfaceVariant else MaterialTheme.colorScheme.surfaceContainerHighest,
+        tonalElevation = 1.dp
     ) {
-        Column(modifier = Modifier.weight(1f)) {
-            Text(
-                text = dateFormatter.format(start),
-                style = MaterialTheme.typography.titleSmall
-            )
-            Spacer(modifier = Modifier.height(4.dp))
-            Text(
-                text = stringResource(
-                    id = R.string.student_details_history_time_range,
-                    timeFormatter.format(start),
-                    timeFormatter.format(end),
-                    durationMinutes
-                ),
-                style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant
-            )
-        }
-        Column(horizontalAlignment = Alignment.End) {
-            Text(
-                text = currencyFormatter.format(lesson.priceCents / 100.0),
-                style = MaterialTheme.typography.titleSmall
-            )
-            Spacer(modifier = Modifier.height(8.dp))
-            LessonPaymentStatusBadge(status = lesson.paymentStatus)
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp, vertical = 14.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
+            Surface(
+                modifier = Modifier.size(36.dp),
+                shape = CircleShape,
+                color = MaterialTheme.colorScheme.primary.copy(alpha = 0.1f)
+            ) {
+                Box(contentAlignment = Alignment.Center) {
+                    Icon(
+                        imageVector = icon,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.primary
+                    )
+                }
+            }
+            Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                Text(
+                    text = label,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+                Text(
+                    text = displayValue,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = if (hasValue) MaterialTheme.colorScheme.onSurface else MaterialTheme.colorScheme.onSurfaceVariant,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis
+                )
+            }
         }
     }
 }
 
 @Composable
-private fun LessonPaymentStatusBadge(
-    status: PaymentStatus,
+private fun StudentProfileMetricsSection(
+    profile: StudentProfile,
+    numberFormatter: NumberFormat,
     modifier: Modifier = Modifier
 ) {
-    val colorScheme = MaterialTheme.colorScheme
-    val (labelRes, container, content) = when (status) {
-        PaymentStatus.PAID -> Triple(
-            R.string.lesson_status_paid,
-            colorScheme.tertiaryContainer,
-            colorScheme.onTertiaryContainer
-        )
-        PaymentStatus.DUE, PaymentStatus.UNPAID -> Triple(
-            R.string.lesson_status_due,
-            colorScheme.errorContainer,
-            colorScheme.onErrorContainer
-        )
-        PaymentStatus.CANCELLED -> Triple(
-            R.string.lesson_status_cancelled,
-            colorScheme.surfaceVariant,
-            colorScheme.onSurfaceVariant
-        )
+    val lessonsCount = profile.metrics.totalLessons.toString()
+    val hourlyRateCents = profile.rate?.let { rate ->
+        if (rate.durationMinutes > 0) {
+            ((rate.priceCents.toDouble() * 60) / rate.durationMinutes).roundToInt()
+        } else {
+            null
+        }
     }
-    Surface(
-        modifier = modifier,
-        color = container,
-        contentColor = content,
-        shape = RoundedCornerShape(999.dp),
-        tonalElevation = 1.dp
+    val rateValue = hourlyRateCents?.let { cents ->
+        numberFormatter.format(cents / 100.0)
+    } ?: stringResource(id = R.string.students_rate_placeholder)
+    val earnedValue = numberFormatter.format(profile.metrics.totalPaidCents / 100.0)
+
+    Column(
+        modifier = modifier.fillMaxWidth(),
+        verticalArrangement = Arrangement.spacedBy(12.dp)
     ) {
         Text(
-            text = stringResource(id = labelRes),
-            style = MaterialTheme.typography.labelMedium,
-            modifier = Modifier.padding(horizontal = 12.dp, vertical = 6.dp)
+            text = stringResource(id = R.string.student_profile_metrics_title),
+            style = MaterialTheme.typography.titleMedium
+        )
+        Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+            ProfileMetricTile(
+                icon = Icons.Outlined.CalendarToday,
+                value = lessonsCount,
+                label = stringResource(id = R.string.student_profile_metrics_lessons_label)
+            )
+            ProfileMetricTile(
+                icon = Icons.Outlined.Schedule,
+                value = rateValue,
+                label = stringResource(id = R.string.student_profile_metrics_rate_label)
+            )
+            ProfileMetricTile(
+                icon = Icons.Outlined.CurrencyRuble,
+                value = earnedValue,
+                label = stringResource(id = R.string.student_profile_metrics_earned_label)
+            )
+        }
+    }
+}
+
+@Composable
+private fun ProfileMetricTile(
+    icon: ImageVector,
+    value: String,
+    label: String,
+    modifier: Modifier = Modifier
+) {
+    Surface(
+        modifier = modifier.fillMaxWidth(),
+        shape = MaterialTheme.shapes.large,
+        color = MaterialTheme.colorScheme.surfaceVariant,
+        tonalElevation = 1.dp
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(vertical = 16.dp, horizontal = 20.dp),
+            verticalArrangement = Arrangement.spacedBy(6.dp),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Icon(imageVector = icon, contentDescription = null)
+            Text(
+                text = value,
+                style = MaterialTheme.typography.headlineSmall,
+                fontWeight = FontWeight.SemiBold
+            )
+            Text(
+                text = label,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+    }
+}
+
+@Composable
+private fun StudentProfileEmptyHistory(
+    onAddLesson: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Surface(
+        modifier = modifier.fillMaxWidth(),
+        shape = MaterialTheme.shapes.large,
+        tonalElevation = 1.dp,
+        color = MaterialTheme.colorScheme.surfaceContainerHigh
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 24.dp, vertical = 28.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
+            Text(
+                text = stringResource(id = R.string.student_details_history_empty),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                textAlign = androidx.compose.ui.text.style.TextAlign.Center
+            )
+            Button(onClick = onAddLesson) {
+                Text(text = stringResource(id = R.string.student_details_create_lesson))
+            }
+        }
+    }
+}
+
+@Composable
+private fun StudentProfileLessonCard(
+    lesson: StudentProfileLesson,
+    fallbackSubject: String?,
+    currencyFormatter: NumberFormat,
+    zoneId: ZoneId,
+    dateFormatter: DateTimeFormatter,
+    timeFormatter: DateTimeFormatter,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val start = remember(lesson.startAt, zoneId) { lesson.startAt.atZone(zoneId) }
+    val end = remember(lesson.endAt, zoneId) { lesson.endAt.atZone(zoneId) }
+    val dateText = remember(start) { dateFormatter.format(start) }
+    val timeText = stringResource(
+        id = R.string.student_details_history_time_range,
+        timeFormatter.format(start),
+        timeFormatter.format(end),
+        lesson.durationMinutes
+    )
+    val fallbackSubjectText = fallbackSubject?.takeIf { it.isNotBlank() }?.trim()
+    val title = lesson.title?.takeIf { it.isNotBlank() }?.trim()
+        ?: lesson.subjectName?.takeIf { it.isNotBlank() }?.trim()
+        ?: fallbackSubjectText
+        ?: stringResource(id = R.string.lesson_card_subject_placeholder)
+    val amount = currencyFormatter.format(lesson.priceCents / 100.0)
+    val isPaid = lesson.paymentStatus == PaymentStatus.PAID
+
+    Surface(
+        modifier = modifier
+            .fillMaxWidth()
+            .clickable { onClick() },
+        shape = MaterialTheme.shapes.large,
+        tonalElevation = 1.dp,
+        color = MaterialTheme.colorScheme.surface,
+        border = BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant)
+    ) {
+        Column(
+            modifier = Modifier.padding(horizontal = 20.dp, vertical = 18.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            Text(
+                text = dateText,
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+            Text(
+                text = title,
+                style = MaterialTheme.typography.titleMedium,
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis
+            )
+            Text(
+                text = timeText,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(
+                    text = amount,
+                    style = MaterialTheme.typography.titleMedium
+                )
+                PaymentBadge(paid = isPaid)
+            }
+        }
+    }
+}
+
+@Composable
+private fun StudentAvatar(
+    name: String,
+    size: androidx.compose.ui.unit.Dp = 48.dp,
+) {
+    val initials = remember(name) {
+        name
+            .split(" ")
+            .filter { it.isNotBlank() }
+            .take(2)
+            .joinToString(separator = "") { it.first().uppercaseChar().toString() }
+            .ifEmpty { "?" }
+    }
+
+    Box(
+        modifier = Modifier
+            .size(size)
+            .clip(CircleShape)
+            .background(MaterialTheme.colorScheme.surfaceVariant),
+        contentAlignment = Alignment.Center
+    ) {
+        Text(
+            text = initials,
+            style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.Bold),
+            color = MaterialTheme.colorScheme.onSurfaceVariant
         )
     }
 }

--- a/app/src/main/java/com/tutorly/ui/screens/StudentDetailsScreen.kt
+++ b/app/src/main/java/com/tutorly/ui/screens/StudentDetailsScreen.kt
@@ -75,7 +75,7 @@ import kotlin.math.roundToInt
 @Composable
 fun StudentDetailsScreen(
     onBack: () -> Unit,
-    onEdit: (Long) -> Unit,
+    onEdit: (Long, StudentEditTarget) -> Unit,
     onAddLesson: (Long) -> Unit,
     onAddPrepayment: (Long) -> Unit = {},
     modifier: Modifier = Modifier,
@@ -200,7 +200,7 @@ private fun StudentProfileTopBar(
 @Composable
 private fun StudentProfileContent(
     profile: StudentProfile,
-    onEdit: (Long) -> Unit,
+    onEdit: (Long, StudentEditTarget) -> Unit,
     onAddLesson: (Long) -> Unit,
     onAddPrepayment: (Long) -> Unit,
     onLessonClick: (Long) -> Unit,
@@ -244,7 +244,7 @@ private fun StudentProfileContent(
         item {
             StudentProfileHeader(
                 profile = profile,
-                onEdit = onEdit
+                onEdit = { target -> onEdit(profile.student.id, target) }
             )
         }
 
@@ -254,22 +254,21 @@ private fun StudentProfileContent(
                     icon = Icons.Outlined.Phone,
                     label = stringResource(id = R.string.student_details_phone_label),
                     value = profile.student.phone,
-                    onClick = { onEdit(profile.student.id) }
+                    onClick = { onEdit(profile.student.id, StudentEditTarget.PHONE) }
                 )
                 ProfileInfoCard(
                     icon = Icons.Outlined.Email,
                     label = stringResource(id = R.string.student_details_messenger_label),
                     value = profile.student.messenger,
-                    onClick = { onEdit(profile.student.id) }
+                    onClick = { onEdit(profile.student.id, StudentEditTarget.MESSENGER) }
                 )
-                if (!profile.student.note.isNullOrBlank()) {
-                    ProfileInfoCard(
-                        icon = Icons.Outlined.StickyNote2,
-                        label = stringResource(id = R.string.student_details_notes_title),
-                        value = profile.student.note,
-                        onClick = { onEdit(profile.student.id) }
-                    )
-                }
+                ProfileInfoCard(
+                    icon = Icons.Outlined.StickyNote2,
+                    label = stringResource(id = R.string.student_details_notes_title),
+                    value = profile.student.note,
+                    onClick = { onEdit(profile.student.id, StudentEditTarget.NOTES) },
+                    valueMaxLines = 4
+                )
             }
         }
 
@@ -335,13 +334,13 @@ private fun StudentProfileContent(
 @Composable
 private fun StudentProfileHeader(
     profile: StudentProfile,
-    onEdit: (Long) -> Unit,
+    onEdit: (StudentEditTarget) -> Unit,
     modifier: Modifier = Modifier
 ) {
     Card(
         modifier = modifier
             .fillMaxWidth()
-            .clickable { onEdit(profile.student.id) },
+            .clickable { onEdit(StudentEditTarget.PROFILE) },
         shape = MaterialTheme.shapes.extraLarge,
         colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.primaryContainer),
         elevation = CardDefaults.cardElevation(defaultElevation = 0.dp)
@@ -381,7 +380,8 @@ private fun ProfileInfoCard(
     label: String,
     value: String?,
     onClick: () -> Unit,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    valueMaxLines: Int = 2,
 ) {
     val hasValue = !value.isNullOrBlank()
     val displayValue = value?.takeIf { it.isNotBlank() }
@@ -425,7 +425,7 @@ private fun ProfileInfoCard(
                     text = displayValue,
                     style = MaterialTheme.typography.bodyMedium,
                     color = if (hasValue) MaterialTheme.colorScheme.onSurface else MaterialTheme.colorScheme.onSurfaceVariant,
-                    maxLines = 2,
+                    maxLines = valueMaxLines,
                     overflow = TextOverflow.Ellipsis
                 )
             }
@@ -460,21 +460,27 @@ private fun StudentProfileMetricsSection(
             text = stringResource(id = R.string.student_profile_metrics_title),
             style = MaterialTheme.typography.titleMedium
         )
-        Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
             ProfileMetricTile(
                 icon = Icons.Outlined.CalendarToday,
                 value = lessonsCount,
-                label = stringResource(id = R.string.student_profile_metrics_lessons_label)
+                label = stringResource(id = R.string.student_profile_metrics_lessons_label),
+                modifier = Modifier.weight(1f)
             )
             ProfileMetricTile(
                 icon = Icons.Outlined.Schedule,
                 value = rateValue,
-                label = stringResource(id = R.string.student_profile_metrics_rate_label)
+                label = stringResource(id = R.string.student_profile_metrics_rate_label),
+                modifier = Modifier.weight(1f)
             )
             ProfileMetricTile(
                 icon = Icons.Outlined.CurrencyRuble,
                 value = earnedValue,
-                label = stringResource(id = R.string.student_profile_metrics_earned_label)
+                label = stringResource(id = R.string.student_profile_metrics_earned_label),
+                modifier = Modifier.weight(1f)
             )
         }
     }

--- a/app/src/main/java/com/tutorly/ui/screens/StudentDetailsScreen.kt
+++ b/app/src/main/java/com/tutorly/ui/screens/StudentDetailsScreen.kt
@@ -16,7 +16,6 @@ import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -238,8 +237,8 @@ private fun StudentProfileContent(
     LazyColumn(
         state = listState,
         modifier = modifier,
-        contentPadding = PaddingValues(horizontal = 20.dp, vertical = 20.dp),
-        verticalArrangement = Arrangement.spacedBy(20.dp)
+        contentPadding = PaddingValues(horizontal = 16.dp, vertical = 24.dp),
+        verticalArrangement = Arrangement.spacedBy(24.dp)
     ) {
         item {
             StudentProfileHeader(
@@ -249,7 +248,7 @@ private fun StudentProfileContent(
         }
 
         item {
-            Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+            Column(verticalArrangement = Arrangement.spacedBy(16.dp)) {
                 ProfileInfoCard(
                     icon = Icons.Outlined.Phone,
                     label = stringResource(id = R.string.student_details_phone_label),
@@ -290,40 +289,39 @@ private fun StudentProfileContent(
         }
 
         item {
-            Text(
-                text = stringResource(id = R.string.student_details_history_title),
-                style = MaterialTheme.typography.titleMedium
-            )
-        }
-
-        if (groupedLessons.isEmpty()) {
-            item {
-                StudentProfileEmptyHistory(
-                    onAddLesson = { onAddLesson(profile.student.id) }
+            Column(verticalArrangement = Arrangement.spacedBy(16.dp)) {
+                Text(
+                    text = stringResource(id = R.string.student_details_history_title),
+                    style = MaterialTheme.typography.titleMedium
                 )
-            }
-        } else {
-            groupedLessons.forEach { (month, lessons) ->
-                item(key = month) {
-                    Text(
-                        text = monthFormatter.format(month),
-                        style = MaterialTheme.typography.titleSmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant
+
+                if (groupedLessons.isEmpty()) {
+                    StudentProfileEmptyHistory(
+                        onAddLesson = { onAddLesson(profile.student.id) }
                     )
-                }
-                items(
-                    items = lessons,
-                    key = { it.id }
-                ) { lesson ->
-                    StudentProfileLessonCard(
-                        lesson = lesson,
-                        fallbackSubject = profile.subject,
-                        currencyFormatter = currencyFormatter,
-                        zoneId = zoneId,
-                        dateFormatter = dateFormatter,
-                        timeFormatter = timeFormatter,
-                        onClick = { onLessonClick(lesson.id) }
-                    )
+                } else {
+                    Column(verticalArrangement = Arrangement.spacedBy(16.dp)) {
+                        groupedLessons.forEach { (month, lessons) ->
+                            Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                                Text(
+                                    text = monthFormatter.format(month),
+                                    style = MaterialTheme.typography.titleSmall,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                                )
+                                lessons.forEach { lesson ->
+                                    StudentProfileLessonCard(
+                                        lesson = lesson,
+                                        fallbackSubject = profile.subject,
+                                        currencyFormatter = currencyFormatter,
+                                        zoneId = zoneId,
+                                        dateFormatter = dateFormatter,
+                                        timeFormatter = timeFormatter,
+                                        onClick = { onLessonClick(lesson.id) }
+                                    )
+                                }
+                            }
+                        }
+                    }
                 }
             }
         }
@@ -348,7 +346,7 @@ private fun StudentProfileHeader(
         Row(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(horizontal = 20.dp, vertical = 24.dp),
+                .padding(horizontal = 16.dp, vertical = 20.dp),
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.spacedBy(16.dp)
         ) {
@@ -398,7 +396,7 @@ private fun ProfileInfoCard(
         Row(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(horizontal = 16.dp, vertical = 14.dp),
+                .padding(horizontal = 16.dp, vertical = 12.dp),
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.spacedBy(16.dp)
         ) {
@@ -454,7 +452,7 @@ private fun StudentProfileMetricsSection(
 
     Column(
         modifier = modifier.fillMaxWidth(),
-        verticalArrangement = Arrangement.spacedBy(12.dp)
+        verticalArrangement = Arrangement.spacedBy(16.dp)
     ) {
         Text(
             text = stringResource(id = R.string.student_profile_metrics_title),
@@ -502,20 +500,28 @@ private fun ProfileMetricTile(
         Column(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(vertical = 16.dp, horizontal = 20.dp),
+                .padding(vertical = 16.dp, horizontal = 16.dp),
             verticalArrangement = Arrangement.spacedBy(6.dp),
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
-            Icon(imageVector = icon, contentDescription = null)
+            Icon(
+                imageVector = icon,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.primary
+            )
             Text(
                 text = value,
-                style = MaterialTheme.typography.headlineSmall,
-                fontWeight = FontWeight.SemiBold
+                style = MaterialTheme.typography.titleLarge,
+                fontWeight = FontWeight.SemiBold,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
             )
             Text(
                 text = label,
                 style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis
             )
         }
     }
@@ -535,7 +541,7 @@ private fun StudentProfileEmptyHistory(
         Column(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(horizontal = 24.dp, vertical = 28.dp),
+                .padding(horizontal = 16.dp, vertical = 24.dp),
             horizontalAlignment = Alignment.CenterHorizontally,
             verticalArrangement = Arrangement.spacedBy(16.dp)
         ) {
@@ -590,7 +596,7 @@ private fun StudentProfileLessonCard(
         border = BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant)
     ) {
         Column(
-            modifier = Modifier.padding(horizontal = 20.dp, vertical = 18.dp),
+            modifier = Modifier.padding(horizontal = 16.dp, vertical = 16.dp),
             verticalArrangement = Arrangement.spacedBy(8.dp)
         ) {
             Text(

--- a/app/src/main/java/com/tutorly/ui/screens/StudentEditTarget.kt
+++ b/app/src/main/java/com/tutorly/ui/screens/StudentEditTarget.kt
@@ -1,0 +1,8 @@
+package com.tutorly.ui.screens
+
+enum class StudentEditTarget {
+    PROFILE,
+    PHONE,
+    MESSENGER,
+    NOTES,
+}

--- a/app/src/main/java/com/tutorly/ui/screens/StudentEditorForm.kt
+++ b/app/src/main/java/com/tutorly/ui/screens/StudentEditorForm.kt
@@ -57,12 +57,15 @@ fun StudentEditorForm(
     onArchivedChange: (Boolean) -> Unit,
     onActiveChange: (Boolean) -> Unit,
     modifier: Modifier = Modifier,
-    focusOnStart: Boolean = false,
+    initialFocus: StudentEditTarget? = null,
     enabled: Boolean = true,
     onSubmit: (() -> Unit)? = null,
 ) {
-    val focusRequester = remember { FocusRequester() }
+    val nameFocusRequester = remember { FocusRequester() }
     val gradeFocusRequester = remember { FocusRequester() }
+    val phoneFocusRequester = remember { FocusRequester() }
+    val messengerFocusRequester = remember { FocusRequester() }
+    val noteFocusRequester = remember { FocusRequester() }
     val scrollState = rememberScrollState()
     var isGradeDropdownExpanded by remember { mutableStateOf(false) }
     val gradeOtherOption = stringResource(id = R.string.student_editor_grade_other)
@@ -71,9 +74,15 @@ fun StudentEditorForm(
         stringResource(id = R.string.student_editor_grade_option, number)
     } + gradeOtherOption
 
-    LaunchedEffect(focusOnStart) {
-        if (focusOnStart) {
-            focusRequester.requestFocus()
+    LaunchedEffect(initialFocus, enabled) {
+        if (enabled) {
+            when (initialFocus) {
+                StudentEditTarget.PROFILE -> nameFocusRequester.requestFocus()
+                StudentEditTarget.PHONE -> phoneFocusRequester.requestFocus()
+                StudentEditTarget.MESSENGER -> messengerFocusRequester.requestFocus()
+                StudentEditTarget.NOTES -> noteFocusRequester.requestFocus()
+                null -> Unit
+            }
         }
     }
 
@@ -87,7 +96,7 @@ fun StudentEditorForm(
             label = { Text(text = stringResource(id = R.string.student_editor_name)) },
             modifier = Modifier
                 .fillMaxWidth()
-                .focusRequester(focusRequester),
+                .focusRequester(nameFocusRequester),
             singleLine = true,
             enabled = enabled,
             isError = state.nameError,
@@ -188,7 +197,9 @@ fun StudentEditorForm(
             value = state.phone,
             onValueChange = onPhoneChange,
             label = { Text(text = stringResource(id = R.string.student_editor_phone)) },
-            modifier = Modifier.fillMaxWidth(),
+            modifier = Modifier
+                .fillMaxWidth()
+                .focusRequester(phoneFocusRequester),
             singleLine = true,
             enabled = enabled,
             keyboardOptions = KeyboardOptions.Default.copy(imeAction = ImeAction.Next)
@@ -198,7 +209,9 @@ fun StudentEditorForm(
             value = state.messenger,
             onValueChange = onMessengerChange,
             label = { Text(text = stringResource(id = R.string.student_editor_messenger)) },
-            modifier = Modifier.fillMaxWidth(),
+            modifier = Modifier
+                .fillMaxWidth()
+                .focusRequester(messengerFocusRequester),
             singleLine = true,
             enabled = enabled,
             keyboardOptions = KeyboardOptions.Default.copy(imeAction = ImeAction.Next)
@@ -208,7 +221,9 @@ fun StudentEditorForm(
             value = state.note,
             onValueChange = onNoteChange,
             label = { Text(text = stringResource(id = R.string.student_editor_notes)) },
-            modifier = Modifier.fillMaxWidth(),
+            modifier = Modifier
+                .fillMaxWidth()
+                .focusRequester(noteFocusRequester),
             minLines = 3,
             enabled = enabled,
             keyboardOptions = KeyboardOptions.Default.copy(imeAction = ImeAction.Done),

--- a/app/src/main/java/com/tutorly/ui/screens/StudentEditorForm.kt
+++ b/app/src/main/java/com/tutorly/ui/screens/StudentEditorForm.kt
@@ -25,9 +25,9 @@ import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.getValue
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -42,6 +42,7 @@ import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
 import com.tutorly.R
+import java.util.Locale
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -57,6 +58,7 @@ fun StudentEditorForm(
     onArchivedChange: (Boolean) -> Unit,
     onActiveChange: (Boolean) -> Unit,
     modifier: Modifier = Modifier,
+    editTarget: StudentEditTarget? = null,
     initialFocus: StudentEditTarget? = null,
     enabled: Boolean = true,
     onSubmit: (() -> Unit)? = null,
@@ -86,10 +88,102 @@ fun StudentEditorForm(
         }
     }
 
+    val showFullForm = editTarget == null
     Column(
         modifier = modifier.verticalScroll(scrollState),
-        verticalArrangement = Arrangement.spacedBy(12.dp)
+        verticalArrangement = Arrangement.spacedBy(16.dp)
     ) {
+        if (showFullForm || editTarget == StudentEditTarget.PROFILE) {
+            ProfileSection(
+                state = state,
+                onNameChange = onNameChange,
+                onSubjectChange = onSubjectChange,
+                onGradeChange = onGradeChange,
+                enabled = enabled,
+                nameFocusRequester = nameFocusRequester,
+                gradeFocusRequester = gradeFocusRequester,
+                isGradeDropdownExpanded = isGradeDropdownExpanded,
+                onGradeDropdownExpandedChange = { isGradeDropdownExpanded = it },
+                gradeOptions = gradeOptions,
+                gradeOtherOption = gradeOtherOption,
+                isStandalone = !showFullForm && editTarget == StudentEditTarget.PROFILE,
+                onSubmit = onSubmit
+            )
+        }
+
+        if (showFullForm) {
+            RateSection(
+                rate = state.rate,
+                onRateChange = onRateChange,
+                enabled = enabled
+            )
+        }
+
+        if (showFullForm || editTarget == StudentEditTarget.PHONE) {
+            PhoneSection(
+                phone = state.phone,
+                onPhoneChange = onPhoneChange,
+                enabled = enabled,
+                focusRequester = phoneFocusRequester,
+                isStandalone = !showFullForm && editTarget == StudentEditTarget.PHONE,
+                onSubmit = onSubmit
+            )
+        }
+
+        if (showFullForm || editTarget == StudentEditTarget.MESSENGER) {
+            MessengerSection(
+                messenger = state.messenger,
+                onMessengerChange = onMessengerChange,
+                enabled = enabled,
+                focusRequester = messengerFocusRequester,
+                isStandalone = !showFullForm && editTarget == StudentEditTarget.MESSENGER,
+                onSubmit = onSubmit
+            )
+        }
+
+        if (showFullForm || editTarget == StudentEditTarget.NOTES) {
+            NotesSection(
+                note = state.note,
+                onNoteChange = onNoteChange,
+                enabled = enabled,
+                focusRequester = noteFocusRequester,
+                onSubmit = onSubmit
+            )
+        }
+
+        if (showFullForm) {
+            StatusSection(
+                isArchived = state.isArchived,
+                onArchivedChange = onArchivedChange,
+                isActive = state.isActive,
+                onActiveChange = onActiveChange,
+                enabled = enabled
+            )
+        }
+
+        if (showFullForm) {
+            Spacer(Modifier.height(4.dp))
+        }
+    }
+}
+
+@Composable
+private fun ProfileSection(
+    state: StudentEditorFormState,
+    onNameChange: (String) -> Unit,
+    onSubjectChange: (String) -> Unit,
+    onGradeChange: (String) -> Unit,
+    enabled: Boolean,
+    nameFocusRequester: FocusRequester,
+    gradeFocusRequester: FocusRequester,
+    isGradeDropdownExpanded: Boolean,
+    onGradeDropdownExpandedChange: (Boolean) -> Unit,
+    gradeOptions: List<String>,
+    gradeOtherOption: String,
+    isStandalone: Boolean,
+    onSubmit: (() -> Unit)?,
+) {
+    Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
         OutlinedTextField(
             value = state.name,
             onValueChange = onNameChange,
@@ -126,9 +220,7 @@ fun StudentEditorForm(
         Box {
             OutlinedTextField(
                 value = state.grade,
-                onValueChange = {
-                    onGradeChange(it)
-                },
+                onValueChange = onGradeChange,
                 label = { Text(text = stringResource(id = R.string.student_editor_grade)) },
                 modifier = Modifier
                     .fillMaxWidth()
@@ -136,16 +228,16 @@ fun StudentEditorForm(
                     .focusRequester(gradeFocusRequester)
                     .onFocusChanged { focusState ->
                         if (!focusState.isFocused) {
-                            isGradeDropdownExpanded = false
+                            onGradeDropdownExpandedChange(false)
                         } else if (enabled) {
-                            isGradeDropdownExpanded = true
+                            onGradeDropdownExpandedChange(true)
                         }
                     },
                 singleLine = true,
                 enabled = enabled,
                 trailingIcon = {
                     IconButton(
-                        onClick = { isGradeDropdownExpanded = !isGradeDropdownExpanded },
+                        onClick = { onGradeDropdownExpandedChange(!isGradeDropdownExpanded) },
                         enabled = enabled
                     ) {
                         Icon(
@@ -154,19 +246,26 @@ fun StudentEditorForm(
                         )
                     }
                 },
-                keyboardOptions = KeyboardOptions.Default.copy(imeAction = ImeAction.Next)
+                keyboardOptions = KeyboardOptions.Default.copy(
+                    imeAction = if (isStandalone) ImeAction.Done else ImeAction.Next
+                ),
+                keyboardActions = if (isStandalone) {
+                    KeyboardActions(onDone = { onSubmit?.invoke() })
+                } else {
+                    KeyboardActions.Default
+                }
             )
 
             DropdownMenu(
                 expanded = isGradeDropdownExpanded,
-                onDismissRequest = { isGradeDropdownExpanded = false },
+                onDismissRequest = { onGradeDropdownExpandedChange(false) },
                 modifier = gradeDropdownModifier
             ) {
                 gradeOptions.forEach { option ->
                     DropdownMenuItem(
                         text = { Text(text = option) },
                         onClick = {
-                            isGradeDropdownExpanded = false
+                            onGradeDropdownExpandedChange(false)
                             if (option == gradeOtherOption) {
                                 onGradeChange("")
                                 gradeFocusRequester.requestFocus()
@@ -179,78 +278,203 @@ fun StudentEditorForm(
                 }
             }
         }
+    }
+}
+
+@Composable
+private fun RateSection(
+    rate: String,
+    onRateChange: (String) -> Unit,
+    enabled: Boolean,
+) {
+    OutlinedTextField(
+        value = rate,
+        onValueChange = onRateChange,
+        label = { Text(text = stringResource(id = R.string.student_editor_rate)) },
+        modifier = Modifier.fillMaxWidth(),
+        singleLine = true,
+        enabled = enabled,
+        keyboardOptions = KeyboardOptions.Default.copy(
+            keyboardType = KeyboardType.Decimal,
+            imeAction = ImeAction.Next
+        )
+    )
+}
+
+@Composable
+private fun PhoneSection(
+    phone: String,
+    onPhoneChange: (String) -> Unit,
+    enabled: Boolean,
+    focusRequester: FocusRequester,
+    isStandalone: Boolean,
+    onSubmit: (() -> Unit)?,
+) {
+    OutlinedTextField(
+        value = phone,
+        onValueChange = onPhoneChange,
+        label = { Text(text = stringResource(id = R.string.student_editor_phone)) },
+        modifier = Modifier
+            .fillMaxWidth()
+            .focusRequester(focusRequester),
+        singleLine = true,
+        enabled = enabled,
+        keyboardOptions = KeyboardOptions.Default.copy(
+            imeAction = if (isStandalone) ImeAction.Done else ImeAction.Next
+        ),
+        keyboardActions = if (isStandalone) {
+            KeyboardActions(onDone = { onSubmit?.invoke() })
+        } else {
+            KeyboardActions.Default
+        }
+    )
+}
+
+@Composable
+private fun MessengerSection(
+    messenger: String,
+    onMessengerChange: (String) -> Unit,
+    enabled: Boolean,
+    focusRequester: FocusRequester,
+    isStandalone: Boolean,
+    onSubmit: (() -> Unit)?,
+) {
+    val messengerOptions = remember { StudentMessengerType.values().toList() }
+    var selectedType by remember { mutableStateOf(StudentMessengerType.TELEGRAM) }
+    var customLabel by remember { mutableStateOf("") }
+    var identifier by remember { mutableStateOf("") }
+
+    LaunchedEffect(messenger) {
+        val parsed = messenger.parseMessengerValue()
+        selectedType = parsed.type
+        customLabel = parsed.customLabel
+        identifier = parsed.identifier
+    }
+
+    Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+        var isDropdownExpanded by remember { mutableStateOf(false) }
+        Box {
+            OutlinedTextField(
+                value = if (selectedType == StudentMessengerType.OTHER) customLabel else stringResource(id = selectedType.labelRes),
+                onValueChange = {
+                    if (selectedType == StudentMessengerType.OTHER) {
+                        customLabel = it
+                        onMessengerChange(buildMessengerValue(selectedType, customLabel, identifier))
+                    }
+                },
+                label = { Text(text = stringResource(id = R.string.student_editor_messenger_type)) },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .onFocusChanged { focusState ->
+                        if (enabled && focusState.isFocused) {
+                            isDropdownExpanded = true
+                        }
+                    },
+                enabled = enabled,
+                readOnly = selectedType != StudentMessengerType.OTHER,
+                trailingIcon = {
+                    IconButton(onClick = { isDropdownExpanded = !isDropdownExpanded }, enabled = enabled) {
+                        Icon(
+                            imageVector = if (isDropdownExpanded) Icons.Filled.ArrowDropUp else Icons.Filled.ArrowDropDown,
+                            contentDescription = null
+                        )
+                    }
+                }
+            )
+
+            DropdownMenu(
+                expanded = isDropdownExpanded,
+                onDismissRequest = { isDropdownExpanded = false }
+            ) {
+                messengerOptions.forEach { option ->
+                    DropdownMenuItem(
+                        text = { Text(text = stringResource(id = option.labelRes)) },
+                        onClick = {
+                            isDropdownExpanded = false
+                            selectedType = option
+                            if (option != StudentMessengerType.OTHER) {
+                                customLabel = ""
+                            }
+                            onMessengerChange(buildMessengerValue(selectedType, customLabel, identifier))
+                        },
+                        enabled = enabled
+                    )
+                }
+            }
+        }
 
         OutlinedTextField(
-            value = state.rate,
-            onValueChange = onRateChange,
-            label = { Text(text = stringResource(id = R.string.student_editor_rate)) },
-            modifier = Modifier.fillMaxWidth(),
+            value = identifier,
+            onValueChange = {
+                identifier = it
+                onMessengerChange(buildMessengerValue(selectedType, customLabel, identifier))
+            },
+            label = { Text(text = stringResource(id = R.string.student_editor_messenger_id)) },
+            modifier = Modifier
+                .fillMaxWidth()
+                .focusRequester(focusRequester),
             singleLine = true,
             enabled = enabled,
             keyboardOptions = KeyboardOptions.Default.copy(
-                keyboardType = KeyboardType.Decimal,
-                imeAction = ImeAction.Next
-            )
+                imeAction = if (isStandalone) ImeAction.Done else ImeAction.Next
+            ),
+            keyboardActions = if (isStandalone) {
+                KeyboardActions(onDone = { onSubmit?.invoke() })
+            } else {
+                KeyboardActions.Default
+            }
         )
+    }
+}
 
-        OutlinedTextField(
-            value = state.phone,
-            onValueChange = onPhoneChange,
-            label = { Text(text = stringResource(id = R.string.student_editor_phone)) },
-            modifier = Modifier
-                .fillMaxWidth()
-                .focusRequester(phoneFocusRequester),
-            singleLine = true,
+@Composable
+private fun NotesSection(
+    note: String,
+    onNoteChange: (String) -> Unit,
+    enabled: Boolean,
+    focusRequester: FocusRequester,
+    onSubmit: (() -> Unit)?
+) {
+    OutlinedTextField(
+        value = note,
+        onValueChange = onNoteChange,
+        label = { Text(text = stringResource(id = R.string.student_editor_notes)) },
+        modifier = Modifier
+            .fillMaxWidth()
+            .focusRequester(focusRequester),
+        minLines = 3,
+        enabled = enabled,
+        keyboardOptions = KeyboardOptions.Default.copy(imeAction = ImeAction.Done),
+        keyboardActions = KeyboardActions(onDone = {
+            onSubmit?.invoke()
+        })
+    )
+}
+
+@Composable
+private fun StatusSection(
+    isArchived: Boolean,
+    onArchivedChange: (Boolean) -> Unit,
+    isActive: Boolean,
+    onActiveChange: (Boolean) -> Unit,
+    enabled: Boolean,
+) {
+    Column(
+        modifier = Modifier.fillMaxWidth(),
+        verticalArrangement = Arrangement.spacedBy(12.dp)
+    ) {
+        RowSwitch(
+            label = stringResource(id = R.string.student_editor_is_archived),
+            checked = isArchived,
             enabled = enabled,
-            keyboardOptions = KeyboardOptions.Default.copy(imeAction = ImeAction.Next)
+            onCheckedChange = onArchivedChange
         )
-
-        OutlinedTextField(
-            value = state.messenger,
-            onValueChange = onMessengerChange,
-            label = { Text(text = stringResource(id = R.string.student_editor_messenger)) },
-            modifier = Modifier
-                .fillMaxWidth()
-                .focusRequester(messengerFocusRequester),
-            singleLine = true,
+        RowSwitch(
+            label = stringResource(id = R.string.student_editor_active),
+            checked = isActive,
             enabled = enabled,
-            keyboardOptions = KeyboardOptions.Default.copy(imeAction = ImeAction.Next)
+            onCheckedChange = onActiveChange
         )
-
-        OutlinedTextField(
-            value = state.note,
-            onValueChange = onNoteChange,
-            label = { Text(text = stringResource(id = R.string.student_editor_notes)) },
-            modifier = Modifier
-                .fillMaxWidth()
-                .focusRequester(noteFocusRequester),
-            minLines = 3,
-            enabled = enabled,
-            keyboardOptions = KeyboardOptions.Default.copy(imeAction = ImeAction.Done),
-            keyboardActions = KeyboardActions(onDone = {
-                onSubmit?.invoke()
-            })
-        )
-
-        Column(
-            modifier = Modifier.fillMaxWidth(),
-            verticalArrangement = Arrangement.spacedBy(12.dp)
-        ) {
-            RowSwitch(
-                label = stringResource(id = R.string.student_editor_is_archived),
-                checked = state.isArchived,
-                enabled = enabled,
-                onCheckedChange = onArchivedChange
-            )
-            RowSwitch(
-                label = stringResource(id = R.string.student_editor_active),
-                checked = state.isActive,
-                enabled = enabled,
-                onCheckedChange = onActiveChange
-            )
-        }
-
-        Spacer(Modifier.height(4.dp))
     }
 }
 
@@ -272,5 +496,74 @@ private fun RowSwitch(
             onCheckedChange = onCheckedChange,
             enabled = enabled
         )
+    }
+}
+
+private data class MessengerValue(
+    val type: StudentMessengerType,
+    val customLabel: String,
+    val identifier: String
+)
+
+private fun String.parseMessengerValue(): MessengerValue {
+    val raw = trim()
+    if (raw.isEmpty()) {
+        return MessengerValue(StudentMessengerType.TELEGRAM, "", "")
+    }
+
+    val delimiterIndex = raw.indexOf(':')
+    if (delimiterIndex == -1) {
+        return MessengerValue(StudentMessengerType.OTHER, "", raw)
+    }
+
+    val label = raw.substring(0, delimiterIndex).trim()
+    val value = raw.substring(delimiterIndex + 1).trim()
+    val type = StudentMessengerType.fromLabel(label)
+    return if (type == StudentMessengerType.OTHER) {
+        MessengerValue(type, label, value)
+    } else {
+        MessengerValue(type, "", value)
+    }
+}
+
+private fun buildMessengerValue(
+    type: StudentMessengerType,
+    customLabel: String,
+    identifier: String
+): String {
+    val trimmedIdentifier = identifier.trim()
+    if (trimmedIdentifier.isEmpty()) {
+        return ""
+    }
+
+    val label = when (type) {
+        StudentMessengerType.OTHER -> customLabel.trim()
+        else -> type.label
+    }
+
+    return if (label.isNotEmpty()) {
+        "$label: $trimmedIdentifier"
+    } else {
+        trimmedIdentifier
+    }
+}
+
+private enum class StudentMessengerType(
+    val label: String,
+    val labelRes: Int,
+) {
+    TELEGRAM(label = "Telegram", labelRes = R.string.student_editor_messenger_type_telegram),
+    WHATSAPP(label = "WhatsApp", labelRes = R.string.student_editor_messenger_type_whatsapp),
+    VIBER(label = "Viber", labelRes = R.string.student_editor_messenger_type_viber),
+    VK(label = "VK", labelRes = R.string.student_editor_messenger_type_vk),
+    OTHER(label = "", labelRes = R.string.student_editor_messenger_type_other);
+
+    companion object {
+        fun fromLabel(label: String): StudentMessengerType {
+            val normalized = label.lowercase(Locale.getDefault())
+            return values().firstOrNull { option ->
+                option.label.lowercase(Locale.getDefault()) == normalized && option != OTHER
+            } ?: OTHER
+        }
     }
 }

--- a/app/src/main/java/com/tutorly/ui/screens/StudentEditorScreen.kt
+++ b/app/src/main/java/com/tutorly/ui/screens/StudentEditorScreen.kt
@@ -265,6 +265,7 @@ fun StudentEditorScreen(
                 modifier = Modifier
                     .weight(1f, fill = false)
                     .fillMaxWidth(),
+                editTarget = vm.editTarget,
                 initialFocus = vm.editTarget,
                 enabled = !vm.formState.isSaving,
                 onSubmit = attemptSave

--- a/app/src/main/java/com/tutorly/ui/screens/StudentEditorScreen.kt
+++ b/app/src/main/java/com/tutorly/ui/screens/StudentEditorScreen.kt
@@ -48,6 +48,10 @@ class StudentEditorVM @Inject constructor(
     private val repo: StudentsRepository
 ) : ViewModel() {
     private val id: Long? = savedStateHandle.get<Long>("studentId")
+    private val editTargetName: String? = savedStateHandle.get<String>("editTarget")
+    val editTarget: StudentEditTarget? = editTargetName?.let { target ->
+        runCatching { StudentEditTarget.valueOf(target) }.getOrNull()
+    }
     var formState by mutableStateOf(StudentEditorFormState())
         private set
     private var loadedStudent: Student? = null
@@ -261,7 +265,7 @@ fun StudentEditorScreen(
                 modifier = Modifier
                     .weight(1f, fill = false)
                     .fillMaxWidth(),
-                focusOnStart = false,
+                initialFocus = vm.editTarget,
                 enabled = !vm.formState.isSaving,
                 onSubmit = attemptSave
             )

--- a/app/src/main/java/com/tutorly/ui/screens/StudentEditorScreen.kt
+++ b/app/src/main/java/com/tutorly/ui/screens/StudentEditorScreen.kt
@@ -1,13 +1,15 @@
 package com.tutorly.ui.screens
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.widthIn
-import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
@@ -29,13 +31,11 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.Modifier
 import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.window.Dialog
-import androidx.compose.ui.window.DialogProperties
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
@@ -224,27 +224,25 @@ fun StudentEditorScreen(
         }
     }
 
-    Dialog(
-        onDismissRequest = {
-            if (!vm.formState.isSaving) {
-                onClose()
-            }
-        },
-        properties = DialogProperties(
-            dismissOnBackPress = !vm.formState.isSaving,
-            dismissOnClickOutside = !vm.formState.isSaving,
-            usePlatformDefaultWidth = false
-        )
+    BackHandler {
+        if (!vm.formState.isSaving) {
+            onClose()
+        }
+    }
+
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(horizontal = 16.dp, vertical = 24.dp),
+        contentAlignment = Alignment.Center
     ) {
         Surface(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(horizontal = 16.dp)
                 .widthIn(max = 520.dp),
             shape = MaterialTheme.shapes.extraLarge
         ) {
             Scaffold(
-                modifier = Modifier.wrapContentHeight(),
                 containerColor = MaterialTheme.colorScheme.surface,
                 snackbarHost = {
                     SnackbarHost(

--- a/app/src/main/java/com/tutorly/ui/screens/StudentEditorScreen.kt
+++ b/app/src/main/java/com/tutorly/ui/screens/StudentEditorScreen.kt
@@ -40,6 +40,8 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
 import com.tutorly.R
 import com.tutorly.domain.repo.StudentsRepository
 import com.tutorly.models.Student
@@ -191,6 +193,34 @@ class StudentEditorVM @Inject constructor(
                     onError(throwable.message ?: "")
                 }
         }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun StudentEditorDialog(
+    onDismiss: () -> Unit,
+    onSaved: (Long) -> Unit,
+    vm: StudentEditorVM = hiltViewModel(),
+) {
+    val formState = vm.formState
+    Dialog(
+        onDismissRequest = {
+            if (!formState.isSaving) {
+                onDismiss()
+            }
+        },
+        properties = DialogProperties(
+            usePlatformDefaultWidth = false,
+            dismissOnBackPress = false,
+            dismissOnClickOutside = false
+        )
+    ) {
+        StudentEditorScreen(
+            onClose = onDismiss,
+            onSaved = onSaved,
+            vm = vm
+        )
     }
 }
 

--- a/app/src/main/java/com/tutorly/ui/screens/StudentEditorScreen.kt
+++ b/app/src/main/java/com/tutorly/ui/screens/StudentEditorScreen.kt
@@ -2,23 +2,27 @@ package com.tutorly.ui.screens
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.layout.wrapContentHeight
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
-import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -26,9 +30,12 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
@@ -217,76 +224,100 @@ fun StudentEditorScreen(
         }
     }
 
-    Scaffold(
-        topBar = {
-            TopAppBar(
-                title = { Text(text = stringResource(id = R.string.student_editor_title)) },
-                navigationIcon = {
-                    IconButton(onClick = onClose, enabled = !vm.formState.isSaving) {
-                        Icon(
-                            imageVector = Icons.Default.Close,
-                            contentDescription = stringResource(id = R.string.student_editor_close)
-                        )
-                    }
-                },
-                actions = {
-                    IconButton(
-                        onClick = attemptSave,
-                        enabled = !vm.formState.isSaving
-                    ) {
-                        Icon(
-                            imageVector = Icons.Default.Check,
-                            contentDescription = stringResource(id = R.string.student_editor_save)
-                        )
-                    }
-                }
-            )
+    Dialog(
+        onDismissRequest = {
+            if (!vm.formState.isSaving) {
+                onClose()
+            }
         },
-        snackbarHost = { SnackbarHost(hostState = snackbarHostState) }
-    ) { inner ->
-        Column(
+        properties = DialogProperties(
+            dismissOnBackPress = !vm.formState.isSaving,
+            dismissOnClickOutside = !vm.formState.isSaving,
+            usePlatformDefaultWidth = false
+        )
+    ) {
+        Surface(
             modifier = Modifier
-                .fillMaxSize()
-                .padding(inner)
-                .padding(horizontal = 16.dp, vertical = 12.dp),
-            verticalArrangement = Arrangement.spacedBy(16.dp)
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp)
+                .widthIn(max = 520.dp),
+            shape = MaterialTheme.shapes.extraLarge
         ) {
-            StudentEditorForm(
-                state = vm.formState,
-                onNameChange = vm::onNameChange,
-                onPhoneChange = vm::onPhoneChange,
-                onMessengerChange = vm::onMessengerChange,
-                onRateChange = vm::onRateChange,
-                onSubjectChange = vm::onSubjectChange,
-                onGradeChange = vm::onGradeChange,
-                onNoteChange = vm::onNoteChange,
-                onArchivedChange = vm::onArchivedChange,
-                onActiveChange = vm::onActiveChange,
-                modifier = Modifier
-                    .weight(1f, fill = false)
-                    .fillMaxWidth(),
-                editTarget = vm.editTarget,
-                initialFocus = vm.editTarget,
-                enabled = !vm.formState.isSaving,
-                onSubmit = attemptSave
-            )
-
-            Button(
-                onClick = attemptSave,
-                modifier = Modifier.fillMaxWidth(),
-                enabled = !vm.formState.isSaving && vm.formState.name.isNotBlank()
-            ) {
-                if (vm.formState.isSaving) {
-                    CircularProgressIndicator(
-                        modifier = Modifier.size(20.dp),
-                        strokeWidth = 2.dp
+            Scaffold(
+                modifier = Modifier.wrapContentHeight(),
+                containerColor = MaterialTheme.colorScheme.surface,
+                snackbarHost = {
+                    SnackbarHost(
+                        hostState = snackbarHostState,
+                        modifier = Modifier
+                            .padding(horizontal = 24.dp, vertical = 12.dp)
                     )
-                } else {
-                    Text(
-                        text = stringResource(
-                            id = if (isEditing) R.string.student_editor_save else R.string.add_student
+                }
+            ) { inner ->
+                val scrollState = rememberScrollState()
+                Column(
+                    modifier = Modifier
+                        .padding(inner)
+                        .padding(horizontal = 24.dp, vertical = 20.dp)
+                        .verticalScroll(scrollState),
+                    verticalArrangement = Arrangement.spacedBy(20.dp)
+                ) {
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Text(
+                            text = stringResource(id = R.string.student_editor_title),
+                            style = MaterialTheme.typography.titleLarge,
+                            modifier = Modifier.weight(1f, fill = true)
                         )
+                        IconButton(
+                            onClick = onClose,
+                            enabled = !vm.formState.isSaving
+                        ) {
+                            Icon(
+                                imageVector = Icons.Default.Close,
+                                contentDescription = stringResource(id = R.string.student_editor_close)
+                            )
+                        }
+                    }
+
+                    StudentEditorForm(
+                        state = vm.formState,
+                        onNameChange = vm::onNameChange,
+                        onPhoneChange = vm::onPhoneChange,
+                        onMessengerChange = vm::onMessengerChange,
+                        onRateChange = vm::onRateChange,
+                        onSubjectChange = vm::onSubjectChange,
+                        onGradeChange = vm::onGradeChange,
+                        onNoteChange = vm::onNoteChange,
+                        onArchivedChange = vm::onArchivedChange,
+                        onActiveChange = vm::onActiveChange,
+                        modifier = Modifier.fillMaxWidth(),
+                        editTarget = vm.editTarget,
+                        initialFocus = vm.editTarget,
+                        enabled = !vm.formState.isSaving,
+                        onSubmit = attemptSave
                     )
+
+                    Button(
+                        onClick = attemptSave,
+                        modifier = Modifier.fillMaxWidth(),
+                        enabled = !vm.formState.isSaving && vm.formState.name.isNotBlank()
+                    ) {
+                        if (vm.formState.isSaving) {
+                            CircularProgressIndicator(
+                                modifier = Modifier.size(20.dp),
+                                strokeWidth = 2.dp
+                            )
+                        } else {
+                            Text(
+                                text = stringResource(
+                                    id = if (isEditing) R.string.student_editor_save else R.string.add_student
+                                )
+                            )
+                        }
+                    }
                 }
             }
         }

--- a/app/src/main/java/com/tutorly/ui/screens/StudentProfileUiState.kt
+++ b/app/src/main/java/com/tutorly/ui/screens/StudentProfileUiState.kt
@@ -1,0 +1,10 @@
+package com.tutorly.ui.screens
+
+import com.tutorly.domain.model.StudentProfile
+
+sealed interface StudentProfileUiState {
+    data object Hidden : StudentProfileUiState
+    data object Loading : StudentProfileUiState
+    data object Error : StudentProfileUiState
+    data class Content(val profile: StudentProfile) : StudentProfileUiState
+}

--- a/app/src/main/java/com/tutorly/ui/screens/StudentsScreen.kt
+++ b/app/src/main/java/com/tutorly/ui/screens/StudentsScreen.kt
@@ -3,7 +3,6 @@ package com.tutorly.ui.screens
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -20,11 +19,9 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
-import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
-import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.icons.outlined.CurrencyRuble
 import androidx.compose.material.icons.outlined.Email
@@ -34,7 +31,6 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
-import androidx.compose.material3.ExtendedFloatingActionButton
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
@@ -52,7 +48,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.foundation.rememberScrollState
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
@@ -73,25 +68,15 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import com.tutorly.R
-import com.tutorly.domain.model.StudentProfile
-import com.tutorly.domain.model.StudentProfileLesson
-import com.tutorly.models.PaymentStatus
-import com.tutorly.ui.lessoncard.LessonCardSheet
-import com.tutorly.ui.lessoncard.LessonCardViewModel
 import com.tutorly.ui.components.PaymentBadge
 import kotlinx.coroutines.launch
-import java.text.NumberFormat
-import java.time.ZoneId
-import java.time.YearMonth
-import java.time.format.DateTimeFormatter
-import java.util.Currency
-import java.util.Locale
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun StudentsScreen(
     onStudentEdit: (Long) -> Unit,
     onAddLesson: (Long) -> Unit,
+    onStudentOpen: (Long) -> Unit,
     onStudentCreatedFromLesson: (Long) -> Unit = {},
     initialEditorOrigin: StudentEditorOrigin = StudentEditorOrigin.NONE,
     modifier: Modifier = Modifier,
@@ -100,35 +85,15 @@ fun StudentsScreen(
     val query by vm.query.collectAsState()
     val students by vm.students.collectAsState()
     val formState by vm.editorFormState.collectAsState()
-    val profileUiState by vm.profileUiState.collectAsState()
-    val lessonCardViewModel: LessonCardViewModel = hiltViewModel()
-    val lessonCardState by lessonCardViewModel.uiState.collectAsState()
-    LessonCardSheet(
-        state = lessonCardState,
-        onDismissRequest = lessonCardViewModel::dismiss,
-        onStudentSelect = lessonCardViewModel::onStudentSelected,
-        onDateSelect = lessonCardViewModel::onDateSelected,
-        onTimeSelect = lessonCardViewModel::onTimeSelected,
-        onDurationSelect = lessonCardViewModel::onDurationSelected,
-        onPriceChange = lessonCardViewModel::onPriceChanged,
-        onStatusSelect = lessonCardViewModel::onPaymentStatusSelected,
-        onNoteChange = lessonCardViewModel::onNoteChanged,
-        onDeleteLesson = lessonCardViewModel::deleteLesson,
-        onSnackbarConsumed = lessonCardViewModel::consumeSnackbar
-    )
-
     val snackbarHostState = remember { SnackbarHostState() }
     val coroutineScope = rememberCoroutineScope()
     val context = LocalContext.current
     val editorSheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
-    val profileSheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
     var showEditor by rememberSaveable { mutableStateOf(false) }
     var editorOrigin by rememberSaveable { mutableStateOf(StudentEditorOrigin.NONE) }
-    var pendingProfileId by remember { mutableStateOf<Long?>(null) }
 
     val openCreationEditor: (StudentEditorOrigin) -> Unit = { origin ->
         editorOrigin = origin
-        pendingProfileId = null
         vm.startStudentCreation()
         showEditor = true
     }
@@ -136,7 +101,6 @@ fun StudentsScreen(
     LaunchedEffect(initialEditorOrigin) {
         if (initialEditorOrigin != StudentEditorOrigin.NONE) {
             editorOrigin = initialEditorOrigin
-            pendingProfileId = null
             vm.startStudentCreation()
             showEditor = true
         }
@@ -163,10 +127,7 @@ fun StudentsScreen(
                         if (editorOrigin == StudentEditorOrigin.LESSON_CREATION) {
                             onStudentCreatedFromLesson(id)
                         }
-                    } else {
-                        pendingProfileId?.let { vm.openStudentProfile(it) }
                     }
-                    pendingProfileId = null
                 },
                 onError = { error ->
                     val message = if (error.isNotBlank()) {
@@ -229,7 +190,7 @@ fun StudentsScreen(
                     ) { item ->
                         StudentCard(
                             item = item,
-                            onClick = { vm.openStudentProfile(item.student.id) }
+                            onClick = { onStudentOpen(item.student.id) }
                         )
                     }
                 }
@@ -241,7 +202,6 @@ fun StudentsScreen(
         ModalBottomSheet(
             onDismissRequest = {
                 if (!formState.isSaving) {
-                    pendingProfileId = null
                     closeEditor()
                 }
             },
@@ -261,45 +221,10 @@ fun StudentsScreen(
                 onActiveChange = vm::onEditorActiveChange,
                 onCancel = {
                     if (!formState.isSaving) {
-                        pendingProfileId = null
                         closeEditor()
                     }
                 },
                 onSave = handleSave
-            )
-        }
-    }
-
-    if (profileUiState !is StudentProfileUiState.Hidden) {
-        ModalBottomSheet(
-            onDismissRequest = vm::clearSelectedStudent,
-            sheetState = profileSheetState,
-            dragHandle = { BottomSheetDefaults.DragHandle() }
-        ) {
-            StudentProfileSheet(
-                state = profileUiState,
-                onClose = vm::clearSelectedStudent,
-                onEdit = { studentId ->
-                    val profileStudent = (profileUiState as? StudentProfileUiState.Content)?.profile?.student
-                    if (profileStudent != null && profileStudent.id == studentId) {
-                        vm.clearSelectedStudent()
-                        editorOrigin = StudentEditorOrigin.STUDENTS
-                        pendingProfileId = studentId
-                        vm.startStudentEdit(profileStudent)
-                        showEditor = true
-                    } else {
-                        vm.clearSelectedStudent()
-                        onStudentEdit(studentId)
-                    }
-                },
-                onAddLesson = { studentId ->
-                    vm.clearSelectedStudent()
-                    onAddLesson(studentId)
-                },
-                onLessonClick = { lessonId ->
-                    vm.clearSelectedStudent()
-                    lessonCardViewModel.open(lessonId)
-                }
             )
         }
     }
@@ -559,519 +484,6 @@ private fun StudentCard(
     }
 }
 
-
-@Composable
-fun StudentProfileSheet(
-    state: StudentProfileUiState,
-    onClose: () -> Unit,
-    onEdit: (Long) -> Unit,
-    onAddLesson: (Long) -> Unit,
-    onLessonClick: (Long) -> Unit,
-    onCall: ((String) -> Unit)? = null,
-    onMessage: ((String) -> Unit)? = null,
-    modifier: Modifier = Modifier
-) {
-    when (state) {
-        StudentProfileUiState.Hidden -> Unit
-        StudentProfileUiState.Loading -> {
-            Box(
-                modifier = modifier
-                    .fillMaxWidth()
-                    .padding(vertical = 48.dp),
-                contentAlignment = Alignment.Center
-            ) {
-                CircularProgressIndicator()
-            }
-        }
-
-        StudentProfileUiState.Error -> {
-            Column(
-                modifier = modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = 24.dp, vertical = 32.dp),
-                verticalArrangement = Arrangement.spacedBy(16.dp),
-                horizontalAlignment = Alignment.CenterHorizontally
-            ) {
-                Text(
-                    text = stringResource(id = R.string.student_profile_error),
-                    style = MaterialTheme.typography.bodyLarge,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    textAlign = TextAlign.Center
-                )
-                Button(onClick = onClose) {
-                    Text(text = stringResource(id = R.string.student_editor_close))
-                }
-            }
-        }
-
-        is StudentProfileUiState.Content -> {
-            StudentProfileContent(
-                profile = state.profile,
-                onEdit = onEdit,
-                onAddLesson = onAddLesson,
-                onLessonClick = onLessonClick,
-                onCall = onCall,
-                onMessage = onMessage,
-                modifier = modifier
-            )
-        }
-    }
-}
-
-
-@Composable
-private fun StudentProfileContent(
-    profile: StudentProfile,
-    onEdit: (Long) -> Unit,
-    onAddLesson: (Long) -> Unit,
-    onLessonClick: (Long) -> Unit,
-    onCall: ((String) -> Unit)?,
-    onMessage: ((String) -> Unit)?,
-    modifier: Modifier = Modifier
-) {
-    val listState = rememberLazyListState()
-    val locale = remember { Locale("ru", "RU") }
-    val currencyFormatter = remember(locale) {
-        NumberFormat.getCurrencyInstance(locale).apply {
-            currency = Currency.getInstance("RUB")
-        }
-    }
-    val zoneId = remember { ZoneId.systemDefault() }
-    val dateFormatter = remember(locale) { DateTimeFormatter.ofPattern("d MMMM yyyy", locale) }
-    val timeFormatter = remember(locale) { DateTimeFormatter.ofPattern("HH:mm", locale) }
-    val monthFormatter = remember(locale) { DateTimeFormatter.ofPattern("LLLL yyyy", locale) }
-
-    val groupedLessons = remember(profile.recentLessons, zoneId) {
-        val sorted = profile.recentLessons.sortedByDescending { it.startAt }
-        val groups = linkedMapOf<YearMonth, MutableList<StudentProfileLesson>>()
-        sorted.forEach { lesson ->
-            val key = YearMonth.from(lesson.startAt.atZone(zoneId))
-            groups.getOrPut(key) { mutableListOf() }.add(lesson)
-        }
-        groups.map { it.key to it.value.toList() }
-    }
-
-    Box(modifier = modifier.fillMaxWidth()) {
-        LazyColumn(
-            state = listState,
-            modifier = Modifier.fillMaxWidth(),
-            contentPadding = PaddingValues(start = 20.dp, end = 20.dp, top = 16.dp, bottom = 140.dp),
-            verticalArrangement = Arrangement.spacedBy(20.dp)
-        ) {
-            item {
-                StudentProfileHeader(
-                    profile = profile,
-                    onEdit = onEdit
-                )
-            }
-            item {
-                StudentProfileContacts(
-                    profile = profile,
-                    onCall = onCall,
-                    onMessage = onMessage
-                )
-            }
-            item {
-                StudentProfileMetricsSection(
-                    profile = profile,
-                    currencyFormatter = currencyFormatter
-                )
-            }
-            item {
-                Text(
-                    text = stringResource(id = R.string.student_details_history_title),
-                    style = MaterialTheme.typography.titleMedium
-                )
-            }
-            if (profile.recentLessons.isEmpty()) {
-                item {
-                    StudentProfileEmptyHistory(
-                        onAddLesson = { onAddLesson(profile.student.id) }
-                    )
-                }
-            } else {
-                groupedLessons.forEach { (month, lessons) ->
-                    item(key = "month-$month") {
-                        val monthTitle = remember(month) {
-                            month.format(monthFormatter).replaceFirstChar { char ->
-                                if (char.isLowerCase()) char.titlecase(locale) else char.toString()
-                            }
-                        }
-                        Text(
-                            text = monthTitle,
-                            style = MaterialTheme.typography.titleSmall,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant,
-                            modifier = Modifier.padding(top = 4.dp, bottom = 8.dp)
-                        )
-                    }
-                    items(lessons, key = { it.id }) { lesson ->
-                        StudentProfileLessonCard(
-                            lesson = lesson,
-                            fallbackSubject = profile.subject,
-                            currencyFormatter = currencyFormatter,
-                            zoneId = zoneId,
-                            dateFormatter = dateFormatter,
-                            timeFormatter = timeFormatter,
-                            onClick = { onLessonClick(lesson.id) }
-                        )
-                    }
-                }
-            }
-        }
-
-        ExtendedFloatingActionButton(
-            onClick = { onAddLesson(profile.student.id) },
-            icon = { Icon(imageVector = Icons.Filled.Add, contentDescription = null) },
-            text = { Text(text = stringResource(id = R.string.student_details_create_lesson)) },
-            modifier = Modifier
-                .align(Alignment.BottomEnd)
-                .padding(horizontal = 20.dp, vertical = 16.dp)
-                .navigationBarsPadding()
-        )
-    }
-}
-
-
-
-@Composable
-private fun StudentProfileHeader(
-    profile: StudentProfile,
-    onEdit: (Long) -> Unit,
-    modifier: Modifier = Modifier
-) {
-    Row(
-        modifier = modifier.fillMaxWidth(),
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(16.dp)
-    ) {
-        StudentAvatar(name = profile.student.name, size = 64.dp)
-        Column(
-            modifier = Modifier.weight(1f),
-            verticalArrangement = Arrangement.spacedBy(6.dp)
-        ) {
-            Text(
-                text = profile.student.name,
-                style = MaterialTheme.typography.headlineSmall,
-                maxLines = 2,
-                overflow = TextOverflow.Ellipsis
-            )
-            val subject = profile.subject?.takeIf { it.isNotBlank() }?.trim()
-            val grade = profile.grade?.takeIf { it.isNotBlank() }?.trim()
-            val details = listOfNotNull(subject, grade).joinToString(separator = " ")
-            if (details.isNotEmpty()) {
-                Text(
-                    text = details,
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    maxLines = 2,
-                    overflow = TextOverflow.Ellipsis
-                )
-            }
-        }
-        IconButton(onClick = { onEdit(profile.student.id) }) {
-            Icon(
-                imageVector = Icons.Filled.Edit,
-                contentDescription = stringResource(id = R.string.student_details_edit)
-            )
-        }
-    }
-}
-
-
-@Composable
-private fun StudentProfileContacts(
-    profile: StudentProfile,
-    onCall: ((String) -> Unit)?,
-    onMessage: ((String) -> Unit)?,
-    modifier: Modifier = Modifier
-) {
-    Column(
-        modifier = modifier.fillMaxWidth(),
-        verticalArrangement = Arrangement.spacedBy(12.dp)
-    ) {
-        Text(
-            text = stringResource(id = R.string.student_details_contact_title),
-            style = MaterialTheme.typography.titleMedium
-        )
-        ProfileContactRow(
-            icon = Icons.Outlined.Phone,
-            label = stringResource(id = R.string.student_profile_contact_call),
-            value = profile.student.phone,
-            onClick = onCall
-        )
-        ProfileContactRow(
-            icon = Icons.Outlined.Email,
-            label = stringResource(id = R.string.student_profile_contact_message),
-            value = profile.student.messenger,
-            onClick = onMessage
-        )
-    }
-}
-
-@Composable
-private fun ProfileContactRow(
-    icon: androidx.compose.ui.graphics.vector.ImageVector,
-    label: String,
-    value: String?,
-    onClick: ((String) -> Unit)?,
-    modifier: Modifier = Modifier
-) {
-    val hasValue = !value.isNullOrBlank()
-    val displayValue = value?.takeIf { it.isNotBlank() }
-        ?: stringResource(id = R.string.student_profile_contact_placeholder)
-    val background = if (hasValue) {
-        MaterialTheme.colorScheme.surfaceVariant
-    } else {
-        MaterialTheme.colorScheme.surfaceContainerHighest
-    }
-    val contentColor = if (hasValue) {
-        MaterialTheme.colorScheme.onSurface
-    } else {
-        MaterialTheme.colorScheme.onSurfaceVariant
-    }
-
-    Row(
-        modifier = modifier
-            .fillMaxWidth()
-            .clip(MaterialTheme.shapes.large)
-            .background(background)
-            .clickable(enabled = hasValue && onClick != null) {
-                value?.let { onClick?.invoke(it) }
-            }
-            .padding(horizontal = 16.dp, vertical = 14.dp),
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(16.dp)
-    ) {
-        Icon(
-            imageVector = icon,
-            contentDescription = null,
-            tint = if (hasValue) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurfaceVariant
-        )
-        Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
-            Text(
-                text = label,
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant
-            )
-            Text(
-                text = displayValue,
-                style = MaterialTheme.typography.bodyMedium,
-                color = contentColor,
-                maxLines = 2,
-                overflow = TextOverflow.Ellipsis
-            )
-        }
-    }
-}
-
-
-@Composable
-private fun StudentProfileMetricsSection(
-    profile: StudentProfile,
-    currencyFormatter: NumberFormat,
-    modifier: Modifier = Modifier
-) {
-    val scrollState = rememberScrollState()
-    val metrics = profile.metrics
-    val totalLessons = metrics.totalLessons.toString()
-    val totalPaid = formatCurrency(metrics.totalPaidCents, currencyFormatter)
-    val paidLessons = metrics.paidLessons.toString()
-    val debtText = if (metrics.outstandingCents > 0) {
-        formatCurrency(metrics.outstandingCents, currencyFormatter)
-    } else {
-        stringResource(id = R.string.student_details_no_debt)
-    }
-
-    Column(
-        modifier = modifier.fillMaxWidth(),
-        verticalArrangement = Arrangement.spacedBy(12.dp)
-    ) {
-        Text(
-            text = stringResource(id = R.string.student_profile_metrics_title),
-            style = MaterialTheme.typography.titleMedium
-        )
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .horizontalScroll(scrollState),
-            horizontalArrangement = Arrangement.spacedBy(12.dp)
-        ) {
-            ProfileMetricCard(
-                label = stringResource(id = R.string.student_details_stats_lessons),
-                value = totalLessons
-            )
-            ProfileMetricCard(
-                label = stringResource(id = R.string.student_details_stats_paid),
-                value = totalPaid
-            )
-            ProfileMetricCard(
-                label = stringResource(id = R.string.student_details_stats_paid_lessons),
-                value = paidLessons
-            )
-            ProfileMetricCard(
-                label = stringResource(id = R.string.student_details_stats_debt),
-                value = debtText,
-                badge = if (profile.hasDebt) {
-                    {
-                        PaymentBadge(paid = false)
-                    }
-                } else {
-                    null
-                }
-            )
-        }
-    }
-}
-
-
-@Composable
-private fun ProfileMetricCard(
-    label: String,
-    value: String,
-    modifier: Modifier = Modifier,
-    badge: (@Composable () -> Unit)? = null
-) {
-    Surface(
-        modifier = modifier,
-        shape = MaterialTheme.shapes.large,
-        tonalElevation = 2.dp,
-        color = MaterialTheme.colorScheme.surfaceVariant
-    ) {
-        Column(
-            modifier = Modifier.padding(horizontal = 16.dp, vertical = 12.dp),
-            verticalArrangement = Arrangement.spacedBy(6.dp)
-        ) {
-            Text(
-                text = label,
-                style = MaterialTheme.typography.labelMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant
-            )
-            if (badge != null) {
-                Row(
-                    verticalAlignment = Alignment.CenterVertically,
-                    horizontalArrangement = Arrangement.spacedBy(8.dp)
-                ) {
-                    badge()
-                    Text(
-                        text = value,
-                        style = MaterialTheme.typography.bodyMedium
-                    )
-                }
-            } else {
-                Text(
-                    text = value,
-                    style = MaterialTheme.typography.titleMedium
-                )
-            }
-        }
-    }
-}
-
-@Composable
-private fun StudentProfileEmptyHistory(
-    onAddLesson: () -> Unit,
-    modifier: Modifier = Modifier
-) {
-    Surface(
-        modifier = modifier.fillMaxWidth(),
-        shape = MaterialTheme.shapes.large,
-        tonalElevation = 1.dp,
-        color = MaterialTheme.colorScheme.surfaceContainerHigh
-    ) {
-        Column(
-            modifier = Modifier.padding(horizontal = 20.dp, vertical = 24.dp),
-            horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = Arrangement.spacedBy(16.dp)
-        ) {
-            Text(
-                text = stringResource(id = R.string.student_details_history_empty),
-                style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                textAlign = TextAlign.Center
-            )
-            Button(onClick = onAddLesson) {
-                Text(text = stringResource(id = R.string.student_details_create_lesson))
-            }
-        }
-    }
-}
-
-
-@Composable
-private fun StudentProfileLessonCard(
-    lesson: StudentProfileLesson,
-    fallbackSubject: String?,
-    currencyFormatter: NumberFormat,
-    zoneId: ZoneId,
-    dateFormatter: DateTimeFormatter,
-    timeFormatter: DateTimeFormatter,
-    onClick: () -> Unit,
-    modifier: Modifier = Modifier
-) {
-    val start = remember(lesson.startAt, zoneId) { lesson.startAt.atZone(zoneId) }
-    val end = remember(lesson.endAt, zoneId) { lesson.endAt.atZone(zoneId) }
-    val dateText = remember(start) { dateFormatter.format(start) }
-    val timeText = stringResource(
-        id = R.string.student_details_history_time_range,
-        timeFormatter.format(start),
-        timeFormatter.format(end),
-        lesson.durationMinutes
-    )
-    val fallbackSubjectText = fallbackSubject?.takeIf { it.isNotBlank() }?.trim()
-    val title = lesson.title?.takeIf { it.isNotBlank() }?.trim()
-        ?: lesson.subjectName?.takeIf { it.isNotBlank() }?.trim()
-        ?: fallbackSubjectText
-        ?: stringResource(id = R.string.lesson_card_subject_placeholder)
-    val amount = formatCurrency(lesson.priceCents.toLong(), currencyFormatter)
-    val isPaid = lesson.paymentStatus == PaymentStatus.PAID
-
-    Surface(
-        modifier = modifier
-            .fillMaxWidth()
-            .clickable { onClick() },
-        shape = MaterialTheme.shapes.large,
-        tonalElevation = 1.dp,
-        color = MaterialTheme.colorScheme.surfaceContainerLow
-    ) {
-        Column(
-            modifier = Modifier.padding(horizontal = 20.dp, vertical = 18.dp),
-            verticalArrangement = Arrangement.spacedBy(8.dp)
-        ) {
-            Text(
-                text = dateText,
-                style = MaterialTheme.typography.labelSmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant
-            )
-            Text(
-                text = title,
-                style = MaterialTheme.typography.titleMedium,
-                maxLines = 2,
-                overflow = TextOverflow.Ellipsis
-            )
-            Text(
-                text = timeText,
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant
-            )
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.SpaceBetween,
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                Text(
-                    text = amount,
-                    style = MaterialTheme.typography.titleMedium
-                )
-                PaymentBadge(paid = isPaid)
-            }
-        }
-    }
-}
-
-
-private fun formatCurrency(amountCents: Long, formatter: NumberFormat): String {
-    return formatter.format(amountCents / 100.0)
-}
 
 @Composable
 private fun StudentAvatar(

--- a/app/src/main/java/com/tutorly/ui/screens/StudentsScreen.kt
+++ b/app/src/main/java/com/tutorly/ui/screens/StudentsScreen.kt
@@ -287,7 +287,7 @@ private fun StudentEditorSheet(
             modifier = Modifier
                 .weight(1f, fill = false)
                 .fillMaxWidth(),
-            focusOnStart = true,
+            initialFocus = StudentEditTarget.PROFILE,
             enabled = !state.isSaving,
             onSubmit = onSave
         )

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -22,6 +22,13 @@
     <string name="student_editor_name_required">Имя обязательно</string>
     <string name="student_editor_phone">Телефон</string>
     <string name="student_editor_messenger">Мессенджер</string>
+    <string name="student_editor_messenger_type">Мессенджер</string>
+    <string name="student_editor_messenger_id">Идентификатор</string>
+    <string name="student_editor_messenger_type_telegram">Telegram</string>
+    <string name="student_editor_messenger_type_whatsapp">WhatsApp</string>
+    <string name="student_editor_messenger_type_viber">Viber</string>
+    <string name="student_editor_messenger_type_vk">VK</string>
+    <string name="student_editor_messenger_type_other">Другое</string>
     <string name="student_editor_rate">Ставка</string>
     <string name="student_editor_subject">Предмет</string>
     <string name="student_editor_grade">Класс</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -39,6 +39,10 @@
     <string name="student_profile_metrics_title">Показатели</string>
     <string name="student_profile_metrics_average">Средняя ставка</string>
     <string name="student_profile_close">Закрыть профиль ученика</string>
+    <string name="student_profile_metrics_lessons_label">занятий</string>
+    <string name="student_profile_metrics_rate_label">₽/час</string>
+    <string name="student_profile_metrics_earned_label">₽ заработано</string>
+    <string name="student_profile_add_prepayment">Добавить предоплату</string>
     <string name="student_details_title_placeholder">Ученик</string>
     <string name="student_details_back">Назад</string>
     <string name="student_details_edit">Редактировать ученика</string>


### PR DESCRIPTION
## Summary
- replace the student profile modal with a dedicated details screen that renders the editable profile and lesson history
- update the students list to navigate to the new screen and streamline the view model state
- add supporting UI state class and strings for the refreshed metrics and prepayment action

## Testing
- ./gradlew :app:compileDebugKotlin *(fails: Android SDK not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68eba4f3aae48320a4bdcfa6511d31c2