### PR TITLE
Fix crash when opening student editor from profile

### DIFF
--- a/app/src/main/java/com/tutorly/navigation/AppNav.kt
+++ b/app/src/main/java/com/tutorly/navigation/AppNav.kt
@@ -190,19 +190,12 @@ fun AppNavRoot() {
                             launchSingleTop = true
                         }
                     },
-                    onAddLesson = { id ->
-                        creationViewModel.start(
-                            LessonCreationConfig(
-                                studentId = id,
-                                zoneId = ZonedDateTime.now().zone,
-                                origin = LessonCreationOrigin.STUDENT
-                            )
-                        )
-                        nav.navigate(calendarRoute(nav)) {
+                    onAddStudentFromCreation = {
+                        nav.navigate("$ROUTE_STUDENTS?$ARG_STUDENT_EDITOR_ORIGIN=${StudentEditorOrigin.LESSON_CREATION.name}") {
                             launchSingleTop = true
-                            restoreState = true
                         }
-                    }
+                    },
+                    creationViewModel = creationViewModel
                 )
             }
             composable(

--- a/app/src/main/java/com/tutorly/ui/screens/MoneyInputFormatter.kt
+++ b/app/src/main/java/com/tutorly/ui/screens/MoneyInputFormatter.kt
@@ -1,0 +1,23 @@
+package com.tutorly.ui.screens
+
+internal fun formatMoneyInput(cents: Int?): String {
+    if (cents == null) return ""
+    val decimal = java.math.BigDecimal(cents)
+        .divide(java.math.BigDecimal(100))
+        .stripTrailingZeros()
+    val separator = java.text.DecimalFormatSymbols.getInstance().decimalSeparator
+    return decimal.toPlainString().replace('.', separator)
+}
+
+internal fun parseMoneyInput(input: String): Int? {
+    val raw = input.trim()
+    if (raw.isEmpty()) return null
+    val normalized = raw.replace(',', '.')
+    val decimal = runCatching { java.math.BigDecimal(normalized) }.getOrNull() ?: return null
+    if (decimal < java.math.BigDecimal.ZERO) return null
+    val cents = decimal.multiply(java.math.BigDecimal(100)).setScale(0, java.math.RoundingMode.HALF_UP)
+    val bigInt = runCatching { cents.toBigIntegerExact() }.getOrNull() ?: return null
+    val max = java.math.BigInteger.valueOf(Int.MAX_VALUE.toLong())
+    if (bigInt > max) return null
+    return bigInt.toInt()
+}

--- a/app/src/main/java/com/tutorly/ui/screens/StudentDetailsScreen.kt
+++ b/app/src/main/java/com/tutorly/ui/screens/StudentDetailsScreen.kt
@@ -38,18 +38,26 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
@@ -62,27 +70,38 @@ import com.tutorly.models.PaymentStatus
 import com.tutorly.ui.components.PaymentBadge
 import com.tutorly.ui.lessoncard.LessonCardSheet
 import com.tutorly.ui.lessoncard.LessonCardViewModel
+import com.tutorly.ui.lessoncreation.LessonCreationConfig
+import com.tutorly.ui.lessoncreation.LessonCreationOrigin
+import com.tutorly.ui.lessoncreation.LessonCreationSheet
+import com.tutorly.ui.lessoncreation.LessonCreationViewModel
 import java.text.NumberFormat
 import java.time.ZoneId
+import java.time.ZonedDateTime
 import java.time.YearMonth
 import java.time.format.DateTimeFormatter
 import java.util.Currency
 import java.util.Locale
 import kotlin.math.roundToInt
+import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun StudentDetailsScreen(
     onBack: () -> Unit,
     onEdit: (Long, StudentEditTarget) -> Unit,
-    onAddLesson: (Long) -> Unit,
-    onAddPrepayment: (Long) -> Unit = {},
+    onAddStudentFromCreation: () -> Unit = {},
     modifier: Modifier = Modifier,
     vm: StudentDetailsViewModel = hiltViewModel(),
+    creationViewModel: LessonCreationViewModel,
 ) {
     val state by vm.uiState.collectAsState()
     val lessonCardViewModel: LessonCardViewModel = hiltViewModel()
     val lessonCardState by lessonCardViewModel.uiState.collectAsState()
+    val creationState by creationViewModel.uiState.collectAsState()
+    val context = LocalContext.current
+    val snackbarHostState = remember { SnackbarHostState() }
+    val coroutineScope = rememberCoroutineScope()
+    var showPrepaymentSheet by rememberSaveable { mutableStateOf(false) }
     LessonCardSheet(
         state = lessonCardState,
         onDismissRequest = lessonCardViewModel::dismiss,
@@ -97,9 +116,60 @@ fun StudentDetailsScreen(
         onSnackbarConsumed = lessonCardViewModel::consumeSnackbar
     )
 
+    LessonCreationSheet(
+        state = creationState,
+        onDismiss = { creationViewModel.dismiss() },
+        onStudentQueryChange = creationViewModel::onStudentQueryChange,
+        onStudentSelect = creationViewModel::onStudentSelected,
+        onAddStudent = {
+            creationViewModel.prepareForStudentCreation()
+            creationViewModel.dismiss()
+            onAddStudentFromCreation()
+        },
+        onSubjectSelect = creationViewModel::onSubjectSelected,
+        onDateSelect = creationViewModel::onDateSelected,
+        onTimeSelect = creationViewModel::onTimeSelected,
+        onDurationChange = creationViewModel::onDurationChanged,
+        onPriceChange = creationViewModel::onPriceChanged,
+        onNoteChange = creationViewModel::onNoteChanged,
+        onSubmit = creationViewModel::submit,
+        onConfirmConflict = creationViewModel::confirmConflict,
+        onDismissConflict = creationViewModel::dismissConflict
+    )
+
+    LaunchedEffect(creationState.snackbarMessage) {
+        val message = creationState.snackbarMessage
+        if (message != null) {
+            snackbarHostState.showSnackbar(message)
+            creationViewModel.consumeSnackbar()
+        }
+    }
+
+    if (showPrepaymentSheet) {
+        StudentPrepaymentSheet(
+            onDismiss = { showPrepaymentSheet = false },
+            onSaved = { amount ->
+                showPrepaymentSheet = false
+                val amountText = formatMoneyInput(amount)
+                val successMessage = context.getString(R.string.student_prepayment_success, amountText)
+                coroutineScope.launch { snackbarHostState.showSnackbar(successMessage) }
+            }
+        )
+    }
+
     val title = when (state) {
         is StudentProfileUiState.Content -> (state as StudentProfileUiState.Content).profile.student.name
         else -> stringResource(id = R.string.student_details_title_placeholder)
+    }
+
+    val openLessonCreation: (Long) -> Unit = { id ->
+        creationViewModel.start(
+            LessonCreationConfig(
+                studentId = id,
+                zoneId = ZonedDateTime.now().zone,
+                origin = LessonCreationOrigin.STUDENT
+            )
+        )
     }
 
     Scaffold(
@@ -109,11 +179,12 @@ fun StudentDetailsScreen(
                 onBack = onBack
             )
         },
+        snackbarHost = { SnackbarHost(hostState = snackbarHostState) },
         floatingActionButton = {
             if (state is StudentProfileUiState.Content) {
                 val profile = (state as StudentProfileUiState.Content).profile
                 FloatingActionButton(
-                    onClick = { onAddLesson(profile.student.id) },
+                    onClick = { openLessonCreation(profile.student.id) },
                     modifier = Modifier.navigationBarsPadding(),
                     containerColor = MaterialTheme.colorScheme.primary,
                     contentColor = MaterialTheme.colorScheme.onPrimary
@@ -155,8 +226,8 @@ fun StudentDetailsScreen(
                 StudentProfileContent(
                     profile = currentState.profile,
                     onEdit = onEdit,
-                    onAddLesson = onAddLesson,
-                    onAddPrepayment = onAddPrepayment,
+                    onAddLesson = openLessonCreation,
+                    onAddPrepayment = { showPrepaymentSheet = true },
                     onLessonClick = lessonCardViewModel::open,
                     modifier = modifier
                         .fillMaxSize()
@@ -440,14 +511,16 @@ private fun StudentProfileMetricsSection(
     modifier: Modifier = Modifier
 ) {
     val lessonsCount = profile.metrics.totalLessons.toString()
-    val hourlyRateCents = profile.rate?.let { rate ->
+    val baseRateCents = profile.student.rateCents?.takeIf { it > 0 }
+    val recentRateCents = profile.rate?.let { rate ->
         if (rate.durationMinutes > 0) {
             ((rate.priceCents.toDouble() * 60) / rate.durationMinutes).roundToInt()
         } else {
             null
         }
     }
-    val rateValue = hourlyRateCents?.let { cents ->
+    val rateCents = baseRateCents ?: recentRateCents
+    val rateValue = rateCents?.let { cents ->
         numberFormatter.format(cents / 100.0)
     } ?: stringResource(id = R.string.students_rate_placeholder)
     val earnedValue = numberFormatter.format(profile.metrics.totalPaidCents / 100.0)

--- a/app/src/main/java/com/tutorly/ui/screens/StudentDetailsScreen.kt
+++ b/app/src/main/java/com/tutorly/ui/screens/StudentDetailsScreen.kt
@@ -124,7 +124,7 @@ fun StudentDetailsScreen(
         },
         containerColor = MaterialTheme.colorScheme.surface
     ) { innerPadding ->
-        when (state) {
+        when (val currentState = state) {
             StudentProfileUiState.Hidden, StudentProfileUiState.Loading -> {
                 Box(
                     modifier = modifier
@@ -153,7 +153,7 @@ fun StudentDetailsScreen(
 
             is StudentProfileUiState.Content -> {
                 StudentProfileContent(
-                    profile = state.profile,
+                    profile = currentState.profile,
                     onEdit = onEdit,
                     onAddLesson = onAddLesson,
                     onAddPrepayment = onAddPrepayment,

--- a/app/src/main/java/com/tutorly/ui/screens/StudentDetailsScreen.kt
+++ b/app/src/main/java/com/tutorly/ui/screens/StudentDetailsScreen.kt
@@ -274,7 +274,8 @@ private fun StudentProfileContent(
         item {
             StudentProfileMetricsSection(
                 profile = profile,
-                numberFormatter = numberFormatter
+                numberFormatter = numberFormatter,
+                onRateClick = { onEdit(profile.student.id, StudentEditTarget.RATE) }
             )
         }
 
@@ -435,6 +436,7 @@ private fun ProfileInfoCard(
 private fun StudentProfileMetricsSection(
     profile: StudentProfile,
     numberFormatter: NumberFormat,
+    onRateClick: () -> Unit,
     modifier: Modifier = Modifier
 ) {
     val lessonsCount = profile.metrics.totalLessons.toString()
@@ -472,7 +474,8 @@ private fun StudentProfileMetricsSection(
                 icon = Icons.Outlined.Schedule,
                 value = rateValue,
                 label = stringResource(id = R.string.student_profile_metrics_rate_label),
-                modifier = Modifier.weight(1f)
+                modifier = Modifier.weight(1f),
+                onClick = onRateClick
             )
             ProfileMetricTile(
                 icon = Icons.Outlined.CurrencyRuble,
@@ -489,10 +492,20 @@ private fun ProfileMetricTile(
     icon: ImageVector,
     value: String,
     label: String,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    onClick: (() -> Unit)? = null
 ) {
+    val tileModifier = if (onClick != null) {
+        modifier
+            .fillMaxWidth()
+            .clip(MaterialTheme.shapes.large)
+            .clickable(onClick = onClick)
+    } else {
+        modifier.fillMaxWidth()
+    }
+
     Surface(
-        modifier = modifier.fillMaxWidth(),
+        modifier = tileModifier,
         shape = MaterialTheme.shapes.large,
         color = MaterialTheme.colorScheme.surfaceVariant,
         tonalElevation = 1.dp

--- a/app/src/main/java/com/tutorly/ui/screens/StudentEditTarget.kt
+++ b/app/src/main/java/com/tutorly/ui/screens/StudentEditTarget.kt
@@ -2,6 +2,7 @@ package com.tutorly.ui.screens
 
 enum class StudentEditTarget {
     PROFILE,
+    RATE,
     PHONE,
     MESSENGER,
     NOTES,

--- a/app/src/main/java/com/tutorly/ui/screens/StudentEditorForm.kt
+++ b/app/src/main/java/com/tutorly/ui/screens/StudentEditorForm.kt
@@ -29,6 +29,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.withFrameNanos
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
@@ -43,7 +44,6 @@ import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
 import com.tutorly.R
 import java.util.Locale
-import kotlinx.coroutines.delay
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -453,12 +453,15 @@ private fun NotesSection(
 }
 
 private suspend fun FocusRequester.safeRequestFocus() {
-    if (!tryRequestFocus()) {
+    repeat(5) {
+        if (tryRequestFocus()) {
+            return
+        }
         // When the dialog is first shown the focus target might not yet be attached.
-        // Wait a frame and retry to avoid crashing with "FocusRequester not initialized".
-        delay(16L)
-        tryRequestFocus()
+        // Wait for the next frame so Compose has a chance to attach the node before retrying.
+        withFrameNanos { }
     }
+    tryRequestFocus()
 }
 
 private fun FocusRequester.tryRequestFocus(): Boolean =

--- a/app/src/main/java/com/tutorly/ui/screens/StudentEditorForm.kt
+++ b/app/src/main/java/com/tutorly/ui/screens/StudentEditorForm.kt
@@ -43,6 +43,7 @@ import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
 import com.tutorly.R
 import java.util.Locale
+import kotlinx.coroutines.delay
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -79,10 +80,10 @@ fun StudentEditorForm(
     LaunchedEffect(initialFocus, enabled) {
         if (enabled) {
             when (initialFocus) {
-                StudentEditTarget.PROFILE -> nameFocusRequester.requestFocus()
-                StudentEditTarget.PHONE -> phoneFocusRequester.requestFocus()
-                StudentEditTarget.MESSENGER -> messengerFocusRequester.requestFocus()
-                StudentEditTarget.NOTES -> noteFocusRequester.requestFocus()
+                StudentEditTarget.PROFILE -> nameFocusRequester.safeRequestFocus()
+                StudentEditTarget.PHONE -> phoneFocusRequester.safeRequestFocus()
+                StudentEditTarget.MESSENGER -> messengerFocusRequester.safeRequestFocus()
+                StudentEditTarget.NOTES -> noteFocusRequester.safeRequestFocus()
                 null -> Unit
             }
         }
@@ -450,6 +451,18 @@ private fun NotesSection(
         })
     )
 }
+
+private suspend fun FocusRequester.safeRequestFocus() {
+    if (!tryRequestFocus()) {
+        // When the dialog is first shown the focus target might not yet be attached.
+        // Wait a frame and retry to avoid crashing with "FocusRequester not initialized".
+        delay(16L)
+        tryRequestFocus()
+    }
+}
+
+private fun FocusRequester.tryRequestFocus(): Boolean =
+    runCatching { requestFocus() }.isSuccess
 
 @Composable
 private fun StatusSection(

--- a/app/src/main/java/com/tutorly/ui/screens/StudentEditorForm.kt
+++ b/app/src/main/java/com/tutorly/ui/screens/StudentEditorForm.kt
@@ -61,6 +61,7 @@ fun StudentEditorForm(
     modifier: Modifier = Modifier,
     editTarget: StudentEditTarget? = null,
     initialFocus: StudentEditTarget? = null,
+    enableScrolling: Boolean = true,
     enabled: Boolean = true,
     onSubmit: (() -> Unit)? = null,
 ) {
@@ -90,8 +91,14 @@ fun StudentEditorForm(
     }
 
     val showFullForm = editTarget == null
+    val columnModifier = if (enableScrolling) {
+        modifier.verticalScroll(scrollState)
+    } else {
+        modifier
+    }
+
     Column(
-        modifier = modifier.verticalScroll(scrollState),
+        modifier = columnModifier,
         verticalArrangement = Arrangement.spacedBy(16.dp)
     ) {
         if (showFullForm || editTarget == StudentEditTarget.PROFILE) {

--- a/app/src/main/java/com/tutorly/ui/screens/StudentEditorForm.kt
+++ b/app/src/main/java/com/tutorly/ui/screens/StudentEditorForm.kt
@@ -67,6 +67,7 @@ fun StudentEditorForm(
 ) {
     val nameFocusRequester = remember { FocusRequester() }
     val gradeFocusRequester = remember { FocusRequester() }
+    val rateFocusRequester = remember { FocusRequester() }
     val phoneFocusRequester = remember { FocusRequester() }
     val messengerFocusRequester = remember { FocusRequester() }
     val noteFocusRequester = remember { FocusRequester() }
@@ -82,6 +83,7 @@ fun StudentEditorForm(
         if (enabled) {
             when (initialFocus) {
                 StudentEditTarget.PROFILE -> nameFocusRequester.safeRequestFocus()
+                StudentEditTarget.RATE -> rateFocusRequester.safeRequestFocus()
                 StudentEditTarget.PHONE -> phoneFocusRequester.safeRequestFocus()
                 StudentEditTarget.MESSENGER -> messengerFocusRequester.safeRequestFocus()
                 StudentEditTarget.NOTES -> noteFocusRequester.safeRequestFocus()
@@ -119,11 +121,14 @@ fun StudentEditorForm(
             )
         }
 
-        if (showFullForm) {
+        if (showFullForm || editTarget == StudentEditTarget.RATE) {
             RateSection(
                 rate = state.rate,
                 onRateChange = onRateChange,
-                enabled = enabled
+                enabled = enabled,
+                focusRequester = rateFocusRequester,
+                isStandalone = !showFullForm && editTarget == StudentEditTarget.RATE,
+                onSubmit = onSubmit
             )
         }
 
@@ -294,18 +299,28 @@ private fun RateSection(
     rate: String,
     onRateChange: (String) -> Unit,
     enabled: Boolean,
+    focusRequester: FocusRequester,
+    isStandalone: Boolean,
+    onSubmit: (() -> Unit)?,
 ) {
     OutlinedTextField(
         value = rate,
         onValueChange = onRateChange,
         label = { Text(text = stringResource(id = R.string.student_editor_rate)) },
-        modifier = Modifier.fillMaxWidth(),
+        modifier = Modifier
+            .fillMaxWidth()
+            .focusRequester(focusRequester),
         singleLine = true,
         enabled = enabled,
         keyboardOptions = KeyboardOptions.Default.copy(
             keyboardType = KeyboardType.Decimal,
-            imeAction = ImeAction.Next
-        )
+            imeAction = if (isStandalone) ImeAction.Done else ImeAction.Next
+        ),
+        keyboardActions = if (isStandalone) {
+            KeyboardActions(onDone = { onSubmit?.invoke() })
+        } else {
+            KeyboardActions.Default
+        }
     )
 }
 

--- a/app/src/main/java/com/tutorly/ui/screens/StudentEditorScreen.kt
+++ b/app/src/main/java/com/tutorly/ui/screens/StudentEditorScreen.kt
@@ -1,13 +1,13 @@
 package com.tutorly.ui.screens
 
 import androidx.activity.compose.BackHandler
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.BottomSheetDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
-import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.rememberModalBottomSheetState
@@ -19,6 +19,7 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
@@ -57,7 +58,7 @@ class StudentEditorVM @Inject constructor(
                             name = s.name,
                             phone = s.phone.orEmpty(),
                             messenger = s.messenger.orEmpty(),
-                            rate = formatRateInput(s.rateCents),
+                            rate = formatMoneyInput(s.rateCents),
                             subject = s.subject.orEmpty(),
                             grade = s.grade.orEmpty(),
                             note = s.note.orEmpty(),
@@ -119,9 +120,9 @@ class StudentEditorVM @Inject constructor(
         val trimmedPhone = formState.phone.trim().ifBlank { null }
         val trimmedMessenger = formState.messenger.trim().ifBlank { null }
         val rateInput = formState.rate.trim()
-        val parsedRate = parseRateInput(rateInput)
+        val parsedRate = parseMoneyInput(rateInput)
         val normalizedRate = if (rateInput.isNotEmpty() && parsedRate != null) {
-            formatRateInput(parsedRate)
+            formatMoneyInput(parsedRate)
         } else {
             rateInput
         }
@@ -232,17 +233,7 @@ fun StudentEditorDialog(
         dragHandle = { BottomSheetDefaults.DragHandle() },
         containerColor = MaterialTheme.colorScheme.surface,
     ) {
-        Scaffold(
-            containerColor = MaterialTheme.colorScheme.surface,
-            snackbarHost = {
-                SnackbarHost(
-                    hostState = snackbarHostState,
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(horizontal = 24.dp, vertical = 12.dp)
-                )
-            }
-        ) { innerPadding ->
+        Column(modifier = Modifier.fillMaxWidth()) {
             StudentEditorSheet(
                 state = formState,
                 onNameChange = vm::onNameChange,
@@ -255,9 +246,16 @@ fun StudentEditorDialog(
                 onArchivedChange = vm::onArchivedChange,
                 onActiveChange = vm::onActiveChange,
                 onSave = attemptSave,
-                modifier = Modifier.padding(innerPadding),
+                modifier = Modifier.fillMaxWidth(),
                 editTarget = vm.editTarget,
                 initialFocus = vm.editTarget,
+            )
+
+            SnackbarHost(
+                hostState = snackbarHostState,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 24.dp, vertical = 12.dp)
             )
         }
     }

--- a/app/src/main/java/com/tutorly/ui/screens/StudentEditorScreen.kt
+++ b/app/src/main/java/com/tutorly/ui/screens/StudentEditorScreen.kt
@@ -18,6 +18,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -232,6 +233,7 @@ fun StudentEditorDialog(
         sheetState = sheetState,
         dragHandle = { BottomSheetDefaults.DragHandle() },
         containerColor = MaterialTheme.colorScheme.surface,
+        scrimColor = Color.Black.copy(alpha = 0.32f),
     ) {
         Column(modifier = Modifier.fillMaxWidth()) {
             StudentEditorSheet(

--- a/app/src/main/java/com/tutorly/ui/screens/StudentEditorScreen.kt
+++ b/app/src/main/java/com/tutorly/ui/screens/StudentEditorScreen.kt
@@ -254,11 +254,6 @@ fun StudentEditorDialog(
                 onNoteChange = vm::onNoteChange,
                 onArchivedChange = vm::onArchivedChange,
                 onActiveChange = vm::onActiveChange,
-                onCancel = {
-                    if (!formState.isSaving) {
-                        hideSheetAndThen(onDismiss)
-                    }
-                },
                 onSave = attemptSave,
                 modifier = Modifier.padding(innerPadding),
                 editTarget = vm.editTarget,

--- a/app/src/main/java/com/tutorly/ui/screens/StudentEditorScreen.kt
+++ b/app/src/main/java/com/tutorly/ui/screens/StudentEditorScreen.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -269,6 +270,7 @@ fun StudentEditorScreen(
         Surface(
             modifier = Modifier
                 .fillMaxWidth()
+                .fillMaxHeight(fraction = 0.9f)
                 .widthIn(max = 520.dp),
             shape = MaterialTheme.shapes.extraLarge
         ) {
@@ -324,6 +326,7 @@ fun StudentEditorScreen(
                         modifier = Modifier.fillMaxWidth(),
                         editTarget = vm.editTarget,
                         initialFocus = vm.editTarget,
+                        enableScrolling = false,
                         enabled = !vm.formState.isSaving,
                         onSubmit = attemptSave
                     )

--- a/app/src/main/java/com/tutorly/ui/screens/StudentEditorUiState.kt
+++ b/app/src/main/java/com/tutorly/ui/screens/StudentEditorUiState.kt
@@ -14,25 +14,3 @@ data class StudentEditorFormState(
     val nameError: Boolean = false,
     val isSaving: Boolean = false,
 )
-
-internal fun formatRateInput(cents: Int?): String {
-    if (cents == null) return ""
-    val decimal = java.math.BigDecimal(cents)
-        .divide(java.math.BigDecimal(100))
-        .stripTrailingZeros()
-    val separator = java.text.DecimalFormatSymbols.getInstance().decimalSeparator
-    return decimal.toPlainString().replace('.', separator)
-}
-
-internal fun parseRateInput(input: String): Int? {
-    val raw = input.trim()
-    if (raw.isEmpty()) return null
-    val normalized = raw.replace(',', '.')
-    val decimal = runCatching { java.math.BigDecimal(normalized) }.getOrNull() ?: return null
-    if (decimal < java.math.BigDecimal.ZERO) return null
-    val cents = decimal.multiply(java.math.BigDecimal(100)).setScale(0, java.math.RoundingMode.HALF_UP)
-    val bigInt = runCatching { cents.toBigIntegerExact() }.getOrNull() ?: return null
-    val max = java.math.BigInteger.valueOf(Int.MAX_VALUE.toLong())
-    if (bigInt > max) return null
-    return bigInt.toInt()
-}

--- a/app/src/main/java/com/tutorly/ui/screens/StudentPrepaymentSheet.kt
+++ b/app/src/main/java/com/tutorly/ui/screens/StudentPrepaymentSheet.kt
@@ -32,7 +32,7 @@ import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.ImeAction
-import androidx.compose.ui.text.input.KeyboardOptions
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel

--- a/app/src/main/java/com/tutorly/ui/screens/StudentPrepaymentSheet.kt
+++ b/app/src/main/java/com/tutorly/ui/screens/StudentPrepaymentSheet.kt
@@ -1,0 +1,180 @@
+package com.tutorly.ui.screens
+
+import androidx.activity.compose.BackHandler
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.imePadding
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.material3.BottomSheetDefaults
+import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardOptions
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.tutorly.R
+import kotlinx.coroutines.launch
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun StudentPrepaymentSheet(
+    onDismiss: () -> Unit,
+    onSaved: (Int) -> Unit,
+    vm: StudentPrepaymentViewModel = hiltViewModel(),
+) {
+    val state = vm.formState
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    val snackbarHostState = remember { SnackbarHostState() }
+    val coroutineScope = rememberCoroutineScope()
+    val context = LocalContext.current
+    val amountFocusRequester = remember { FocusRequester() }
+
+    fun hideSheetAndThen(action: () -> Unit) {
+        if (sheetState.isVisible) {
+            coroutineScope.launch { sheetState.hide() }.invokeOnCompletion { action() }
+        } else {
+            action()
+        }
+    }
+
+    BackHandler(enabled = !state.isSaving) {
+        hideSheetAndThen {
+            vm.reset()
+            onDismiss()
+        }
+    }
+
+    LaunchedEffect(state.isSaving) {
+        if (!state.isSaving) {
+            amountFocusRequester.requestFocus()
+        }
+    }
+
+    val attemptSave: () -> Unit = {
+        if (!state.isSaving) {
+            vm.submit(
+                onSuccess = { amount ->
+                    hideSheetAndThen {
+                        vm.reset()
+                        onSaved(amount)
+                    }
+                },
+                onError = { message ->
+                    val text = if (message.isNotBlank()) {
+                        message
+                    } else {
+                        context.getString(R.string.student_prepayment_error)
+                    }
+                    coroutineScope.launch { snackbarHostState.showSnackbar(text) }
+                }
+            )
+        }
+    }
+
+    ModalBottomSheet(
+        onDismissRequest = {
+            if (!state.isSaving) {
+                hideSheetAndThen {
+                    vm.reset()
+                    onDismiss()
+                }
+            }
+        },
+        sheetState = sheetState,
+        dragHandle = { BottomSheetDefaults.DragHandle() },
+        containerColor = MaterialTheme.colorScheme.surface,
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .navigationBarsPadding()
+                .imePadding()
+                .padding(horizontal = 24.dp, vertical = 16.dp)
+                .heightIn(max = 480.dp),
+            verticalArrangement = Arrangement.spacedBy(20.dp)
+        ) {
+            Text(
+                text = stringResource(id = R.string.student_prepayment_title),
+                style = MaterialTheme.typography.titleLarge
+            )
+
+            OutlinedTextField(
+                value = state.amount,
+                onValueChange = vm::onAmountChange,
+                label = { Text(text = stringResource(id = R.string.student_prepayment_amount_label)) },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .focusRequester(amountFocusRequester),
+                keyboardOptions = KeyboardOptions(
+                    keyboardType = KeyboardType.Decimal,
+                    imeAction = ImeAction.Next
+                ),
+                isError = state.amountError,
+                supportingText = {
+                    if (state.amountError) {
+                        Text(text = stringResource(id = R.string.student_prepayment_amount_error))
+                    }
+                },
+                singleLine = true,
+                enabled = !state.isSaving
+            )
+
+            OutlinedTextField(
+                value = state.note,
+                onValueChange = vm::onNoteChange,
+                label = { Text(text = stringResource(id = R.string.student_prepayment_note_label)) },
+                modifier = Modifier.fillMaxWidth(),
+                keyboardOptions = KeyboardOptions.Default.copy(imeAction = ImeAction.Done),
+                keyboardActions = KeyboardActions(onDone = { attemptSave() }),
+                enabled = !state.isSaving,
+                minLines = 3
+            )
+
+            Button(
+                onClick = attemptSave,
+                modifier = Modifier.fillMaxWidth(),
+                enabled = !state.isSaving
+            ) {
+                if (state.isSaving) {
+                    CircularProgressIndicator(
+                        modifier = Modifier.size(20.dp),
+                        strokeWidth = 2.dp
+                    )
+                } else {
+                    Text(text = stringResource(id = R.string.student_prepayment_save))
+                }
+            }
+
+            SnackbarHost(
+                hostState = snackbarHostState,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(vertical = 4.dp)
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/tutorly/ui/screens/StudentPrepaymentSheet.kt
+++ b/app/src/main/java/com/tutorly/ui/screens/StudentPrepaymentSheet.kt
@@ -29,6 +29,7 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.ImeAction
@@ -107,6 +108,7 @@ fun StudentPrepaymentSheet(
         sheetState = sheetState,
         dragHandle = { BottomSheetDefaults.DragHandle() },
         containerColor = MaterialTheme.colorScheme.surface,
+        scrimColor = Color.Black.copy(alpha = 0.32f),
     ) {
         Column(
             modifier = Modifier

--- a/app/src/main/java/com/tutorly/ui/screens/StudentPrepaymentViewModel.kt
+++ b/app/src/main/java/com/tutorly/ui/screens/StudentPrepaymentViewModel.kt
@@ -1,0 +1,88 @@
+package com.tutorly.ui.screens
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.tutorly.domain.repo.PaymentsRepository
+import com.tutorly.models.Payment
+import com.tutorly.models.PaymentStatus
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+import kotlinx.coroutines.launch
+
+data class StudentPrepaymentFormState(
+    val amount: String = "",
+    val note: String = "",
+    val isSaving: Boolean = false,
+    val amountError: Boolean = false,
+)
+
+@HiltViewModel
+class StudentPrepaymentViewModel @Inject constructor(
+    savedStateHandle: SavedStateHandle,
+    private val paymentsRepository: PaymentsRepository,
+) : ViewModel() {
+
+    private val studentId: Long = savedStateHandle.get<Long>("studentId")
+        ?: error("studentId is required")
+
+    var formState by mutableStateOf(StudentPrepaymentFormState())
+        private set
+
+    fun onAmountChange(value: String) {
+        formState = formState.copy(amount = value, amountError = false)
+    }
+
+    fun onNoteChange(value: String) {
+        formState = formState.copy(note = value)
+    }
+
+    fun reset() {
+        formState = StudentPrepaymentFormState()
+    }
+
+    fun submit(
+        onSuccess: (Int) -> Unit,
+        onError: (String) -> Unit,
+    ) {
+        if (formState.isSaving) return
+
+        val parsedAmount = parseMoneyInput(formState.amount)
+        if (parsedAmount == null || parsedAmount <= 0) {
+            formState = formState.copy(amountError = true)
+            return
+        }
+
+        val trimmedNote = formState.note.trim().ifBlank { null }
+
+        viewModelScope.launch {
+            formState = formState.copy(
+                amount = formatMoneyInput(parsedAmount),
+                note = trimmedNote.orEmpty(),
+                amountError = false,
+                isSaving = true,
+            )
+
+            val payment = Payment(
+                lessonId = null,
+                studentId = studentId,
+                amountCents = parsedAmount,
+                note = trimmedNote,
+                status = PaymentStatus.PAID,
+            )
+
+            runCatching { paymentsRepository.insert(payment) }
+                .onSuccess {
+                    formState = StudentPrepaymentFormState()
+                    onSuccess(parsedAmount)
+                }
+                .onFailure { throwable ->
+                    formState = formState.copy(isSaving = false)
+                    onError(throwable.message ?: "")
+                }
+        }
+    }
+}

--- a/app/src/main/java/com/tutorly/ui/screens/StudentsScreen.kt
+++ b/app/src/main/java/com/tutorly/ui/screens/StudentsScreen.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
@@ -245,7 +246,8 @@ fun StudentEditorSheet(
             .fillMaxWidth()
             .navigationBarsPadding()
             .imePadding()
-            .padding(horizontal = 24.dp, vertical = 16.dp),
+            .padding(horizontal = 24.dp, vertical = 16.dp)
+            .heightIn(max = 600.dp),
         verticalArrangement = Arrangement.spacedBy(20.dp)
     ) {
         Text(
@@ -267,10 +269,10 @@ fun StudentEditorSheet(
             onArchivedChange = onArchivedChange,
             onActiveChange = onActiveChange,
             modifier = Modifier
-                .weight(1f, fill = false)
                 .fillMaxWidth(),
             editTarget = editTarget,
             initialFocus = initialFocus,
+            enableScrolling = editTarget == null,
             enabled = !state.isSaving,
             onSubmit = onSave
         )

--- a/app/src/main/java/com/tutorly/ui/screens/StudentsScreen.kt
+++ b/app/src/main/java/com/tutorly/ui/screens/StudentsScreen.kt
@@ -231,7 +231,7 @@ fun StudentsScreen(
 }
 
 @Composable
-private fun StudentEditorSheet(
+fun StudentEditorSheet(
     state: StudentEditorFormState,
     onNameChange: (String) -> Unit,
     onPhoneChange: (String) -> Unit,
@@ -244,10 +244,13 @@ private fun StudentEditorSheet(
     onActiveChange: (Boolean) -> Unit,
     onCancel: () -> Unit,
     onSave: () -> Unit,
+    modifier: Modifier = Modifier,
+    editTarget: StudentEditTarget? = null,
+    initialFocus: StudentEditTarget? = StudentEditTarget.PROFILE,
 ) {
     val isEditing = state.studentId != null
     Column(
-        modifier = Modifier
+        modifier = modifier
             .fillMaxWidth()
             .navigationBarsPadding()
             .imePadding()
@@ -287,7 +290,8 @@ private fun StudentEditorSheet(
             modifier = Modifier
                 .weight(1f, fill = false)
                 .fillMaxWidth(),
-            initialFocus = StudentEditTarget.PROFILE,
+            editTarget = editTarget,
+            initialFocus = initialFocus,
             enabled = !state.isSaving,
             onSubmit = onSave
         )

--- a/app/src/main/java/com/tutorly/ui/screens/StudentsScreen.kt
+++ b/app/src/main/java/com/tutorly/ui/screens/StudentsScreen.kt
@@ -36,19 +36,16 @@ import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
-import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
-import androidx.compose.material3.IconButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.material.icons.filled.Close
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
@@ -219,11 +216,6 @@ fun StudentsScreen(
                 onNoteChange = vm::onEditorNoteChange,
                 onArchivedChange = vm::onEditorArchivedChange,
                 onActiveChange = vm::onEditorActiveChange,
-                onCancel = {
-                    if (!formState.isSaving) {
-                        closeEditor()
-                    }
-                },
                 onSave = handleSave
             )
         }
@@ -242,7 +234,6 @@ fun StudentEditorSheet(
     onNoteChange: (String) -> Unit,
     onArchivedChange: (Boolean) -> Unit,
     onActiveChange: (Boolean) -> Unit,
-    onCancel: () -> Unit,
     onSave: () -> Unit,
     modifier: Modifier = Modifier,
     editTarget: StudentEditTarget? = null,
@@ -257,24 +248,12 @@ fun StudentEditorSheet(
             .padding(horizontal = 24.dp, vertical = 16.dp),
         verticalArrangement = Arrangement.spacedBy(20.dp)
     ) {
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.SpaceBetween,
-            verticalAlignment = Alignment.CenterVertically
-        ) {
-            Text(
-                text = stringResource(
-                    id = if (isEditing) R.string.student_editor_edit_title else R.string.add_student
-                ),
-                style = MaterialTheme.typography.titleLarge
-            )
-            IconButton(onClick = onCancel, enabled = !state.isSaving) {
-                Icon(
-                    imageVector = Icons.Default.Close,
-                    contentDescription = stringResource(id = R.string.student_editor_close)
-                )
-            }
-        }
+        Text(
+            text = stringResource(
+                id = if (isEditing) R.string.student_editor_edit_title else R.string.add_student
+            ),
+            style = MaterialTheme.typography.titleLarge
+        )
 
         StudentEditorForm(
             state = state,
@@ -296,33 +275,20 @@ fun StudentEditorSheet(
             onSubmit = onSave
         )
 
-        Row(
+        Button(
+            onClick = onSave,
             modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.spacedBy(12.dp)
+            enabled = !state.isSaving && state.name.isNotBlank()
         ) {
-            OutlinedButton(
-                onClick = onCancel,
-                modifier = Modifier.weight(1f),
-                enabled = !state.isSaving
-            ) {
-                Text(text = stringResource(id = R.string.student_editor_cancel))
-            }
-
-            Button(
-                onClick = onSave,
-                modifier = Modifier.weight(1f),
-                enabled = !state.isSaving && state.name.isNotBlank()
-            ) {
-                if (state.isSaving) {
-                    CircularProgressIndicator(
-                        modifier = Modifier.size(20.dp),
-                        strokeWidth = 2.dp
-                    )
-                } else {
-                    Text(
-                        text = stringResource(id = R.string.student_editor_save)
-                    )
-                }
+            if (state.isSaving) {
+                CircularProgressIndicator(
+                    modifier = Modifier.size(20.dp),
+                    strokeWidth = 2.dp
+                )
+            } else {
+                Text(
+                    text = stringResource(id = R.string.student_editor_save)
+                )
             }
         }
     }

--- a/app/src/main/java/com/tutorly/ui/screens/StudentsViewModel.kt
+++ b/app/src/main/java/com/tutorly/ui/screens/StudentsViewModel.kt
@@ -111,7 +111,7 @@ class StudentsViewModel @Inject constructor(
             name = student.name,
             phone = student.phone.orEmpty(),
             messenger = student.messenger.orEmpty(),
-            rate = formatRateInput(student.rateCents),
+            rate = formatMoneyInput(student.rateCents),
             subject = student.subject.orEmpty(),
             grade = student.grade.orEmpty(),
             note = student.note.orEmpty(),
@@ -178,9 +178,9 @@ class StudentsViewModel @Inject constructor(
         val trimmedGrade = state.grade.trim().ifBlank { null }
         val trimmedNote = state.note.trim().ifBlank { null }
         val rateInput = state.rate.trim()
-        val parsedRate = parseRateInput(rateInput)
+        val parsedRate = parseMoneyInput(rateInput)
         val normalizedRate = if (rateInput.isNotEmpty() && parsedRate != null) {
-            formatRateInput(parsedRate)
+            formatMoneyInput(parsedRate)
         } else {
             rateInput
         }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -50,6 +50,13 @@
     <string name="student_profile_metrics_rate_label">₽/час</string>
     <string name="student_profile_metrics_earned_label">₽ дохода</string>
     <string name="student_profile_add_prepayment">Добавить предоплату</string>
+    <string name="student_prepayment_title">Добавить предоплату</string>
+    <string name="student_prepayment_amount_label">Сумма</string>
+    <string name="student_prepayment_amount_error">Введите сумму больше нуля</string>
+    <string name="student_prepayment_note_label">Комментарий (необязательно)</string>
+    <string name="student_prepayment_save">Сохранить предоплату</string>
+    <string name="student_prepayment_error">Не удалось сохранить предоплату</string>
+    <string name="student_prepayment_success">Предоплата %1$s ₽ сохранена</string>
     <string name="student_details_title_placeholder">Ученик</string>
     <string name="student_details_back">Назад</string>
     <string name="student_details_edit">Редактировать ученика</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -48,7 +48,7 @@
     <string name="student_profile_close">Закрыть профиль ученика</string>
     <string name="student_profile_metrics_lessons_label">занятий</string>
     <string name="student_profile_metrics_rate_label">₽/час</string>
-    <string name="student_profile_metrics_earned_label">₽ заработано</string>
+    <string name="student_profile_metrics_earned_label">₽ дохода</string>
     <string name="student_profile_add_prepayment">Добавить предоплату</string>
     <string name="student_details_title_placeholder">Ученик</string>
     <string name="student_details_back">Назад</string>


### PR DESCRIPTION
## Summary
- guard focus requests in the student editor so they retry once instead of crashing when the dialog opens
- add a short delay retry helper to avoid the FocusRequester initialization error

## Testing
- not run (Android SDK not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68ebb97ac3a88320bcf1e8a8e56bc8df