### PR TITLE
Fix bottom sheet background flash when editing student profile

### DIFF
--- a/app/src/main/java/com/tutorly/data/db/dao/LessonDao.kt
+++ b/app/src/main/java/com/tutorly/data/db/dao/LessonDao.kt
@@ -69,6 +69,9 @@ interface LessonDao {
     @Query("SELECT * FROM lessons WHERE id = :id LIMIT 1")
     fun observeById(id: Long): Flow<LessonWithStudent?>
 
+    @Query("SELECT * FROM lessons WHERE studentId = :studentId ORDER BY startAt")
+    suspend fun listByStudentAscending(studentId: Long): List<Lesson>
+
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun upsert(lesson: Lesson): Long
 

--- a/app/src/main/java/com/tutorly/data/db/dao/PaymentDao.kt
+++ b/app/src/main/java/com/tutorly/data/db/dao/PaymentDao.kt
@@ -45,6 +45,18 @@ interface PaymentDao {
         """
         SELECT COALESCE(SUM(amountCents), 0)
         FROM payments
+        WHERE studentId = :studentId AND lessonId IS NULL AND status = :status
+        """
+    )
+    fun observePrepaymentTotal(
+        studentId: Long,
+        status: PaymentStatus
+    ): Flow<Long>
+
+    @Query(
+        """
+        SELECT COALESCE(SUM(amountCents), 0)
+        FROM payments
         WHERE at >= :from AND at < :to AND status = :status
         """
     )

--- a/app/src/main/java/com/tutorly/data/db/dao/PaymentDao.kt
+++ b/app/src/main/java/com/tutorly/data/db/dao/PaymentDao.kt
@@ -48,10 +48,38 @@ interface PaymentDao {
         WHERE studentId = :studentId AND lessonId IS NULL AND status = :status
         """
     )
-    fun observePrepaymentTotal(
+    suspend fun totalPrepayment(
+        studentId: Long,
+        status: PaymentStatus
+    ): Long
+
+    @Query(
+        """
+        SELECT COALESCE(SUM(amountCents), 0)
+        FROM payments
+        WHERE studentId = :studentId AND lessonId IS NULL AND status = :status
+        """
+    )
+    fun observePrepaymentDeposits(
         studentId: Long,
         status: PaymentStatus
     ): Flow<Long>
+
+    @Query(
+        """
+        SELECT COALESCE(SUM(amountCents), 0)
+        FROM payments
+        WHERE studentId = :studentId AND lessonId IS NOT NULL AND status = :status AND method = :method
+        """
+    )
+    fun observePrepaymentAllocations(
+        studentId: Long,
+        status: PaymentStatus,
+        method: String
+    ): Flow<Long>
+
+    @Query("SELECT * FROM payments WHERE studentId = :studentId")
+    suspend fun getByStudent(studentId: Long): List<Payment>
 
     @Query(
         """

--- a/app/src/main/java/com/tutorly/data/repo/room/RoomPaymentsRepository.kt
+++ b/app/src/main/java/com/tutorly/data/repo/room/RoomPaymentsRepository.kt
@@ -10,7 +10,8 @@ import kotlinx.coroutines.flow.Flow
 
 @Singleton
 class RoomPaymentsRepository @Inject constructor(
-    private val paymentDao: PaymentDao
+    private val paymentDao: PaymentDao,
+    private val prepaymentAllocator: StudentPrepaymentAllocator
 ) : PaymentsRepository {
 
     override fun observePaymentsByStudent(studentId: Long): Flow<List<Payment>> =
@@ -36,4 +37,8 @@ class RoomPaymentsRepository @Inject constructor(
 
     override suspend fun delete(payment: Payment) =
         paymentDao.delete(payment)
+
+    override suspend fun applyPrepayment(studentId: Long) {
+        prepaymentAllocator.sync(studentId)
+    }
 }

--- a/app/src/main/java/com/tutorly/data/repo/room/RoomStudentsRepository.kt
+++ b/app/src/main/java/com/tutorly/data/repo/room/RoomStudentsRepository.kt
@@ -48,16 +48,18 @@ class RoomStudentsRepository @Inject constructor(
         val hasDebtFlow = paymentDao.observeHasDebt(studentId, PaymentStatus.outstandingStatuses)
         val lessonsFlow = lessonDao.observeByStudent(studentId)
         val recentLessonsFlow = lessonDao.observeRecentWithSubject(studentId, recentLessonsLimit)
+        val prepaymentFlow = paymentDao.observePrepaymentTotal(studentId, PaymentStatus.PAID)
 
         return combine(
             studentFlow,
             hasDebtFlow,
             lessonsFlow,
-            recentLessonsFlow
-        ) { student, hasDebt, lessons, recentLessons ->
+            recentLessonsFlow,
+            prepaymentFlow
+        ) { student, hasDebt, lessons, recentLessons, prepaymentCents ->
             student ?: return@combine null
 
-            val metrics = buildMetrics(lessons)
+            val metrics = buildMetrics(lessons, prepaymentCents)
             val rate = recentLessons.firstOrNull()?.lesson?.let(::buildRate)
             val recentSubject = recentLessons.firstOrNull()?.subject?.name?.takeIf { it.isNotBlank() }?.trim()
             val primarySubject = student.subject?.takeIf { it.isNotBlank() }?.trim()
@@ -97,7 +99,10 @@ class RoomStudentsRepository @Inject constructor(
         paymentDao.observeHasDebt(studentId, PaymentStatus.outstandingStatuses)
 }
 
-private fun buildMetrics(lessons: List<com.tutorly.models.Lesson>): StudentProfileMetrics {
+private fun buildMetrics(
+    lessons: List<com.tutorly.models.Lesson>,
+    prepaymentCents: Long
+): StudentProfileMetrics {
     if (lessons.isEmpty()) {
         return StudentProfileMetrics(
             totalLessons = 0,
@@ -105,7 +110,8 @@ private fun buildMetrics(lessons: List<com.tutorly.models.Lesson>): StudentProfi
             debtLessons = 0,
             totalPaidCents = 0,
             averagePriceCents = null,
-            outstandingCents = 0
+            outstandingCents = 0,
+            prepaymentCents = prepaymentCents
         )
     }
 
@@ -132,7 +138,8 @@ private fun buildMetrics(lessons: List<com.tutorly.models.Lesson>): StudentProfi
         debtLessons = debt,
         totalPaidCents = totalPaid,
         averagePriceCents = averagePrice?.toInt(),
-        outstandingCents = outstandingCents
+        outstandingCents = outstandingCents,
+        prepaymentCents = prepaymentCents
     )
 }
 

--- a/app/src/main/java/com/tutorly/data/repo/room/RoomStudentsRepository.kt
+++ b/app/src/main/java/com/tutorly/data/repo/room/RoomStudentsRepository.kt
@@ -48,7 +48,10 @@ class RoomStudentsRepository @Inject constructor(
         val hasDebtFlow = paymentDao.observeHasDebt(studentId, PaymentStatus.outstandingStatuses)
         val lessonsFlow = lessonDao.observeByStudent(studentId)
         val recentLessonsFlow = lessonDao.observeRecentWithSubject(studentId, recentLessonsLimit)
-        val prepaymentFlow = paymentDao.observePrepaymentTotal(studentId, PaymentStatus.PAID)
+        val prepaymentFlow = combine(
+            paymentDao.observePrepaymentDeposits(studentId, PaymentStatus.PAID),
+            paymentDao.observePrepaymentAllocations(studentId, PaymentStatus.PAID, PREPAYMENT_METHOD)
+        ) { deposits, allocations -> deposits - allocations }
 
         return combine(
             studentFlow,

--- a/app/src/main/java/com/tutorly/data/repo/room/StudentPrepaymentAllocator.kt
+++ b/app/src/main/java/com/tutorly/data/repo/room/StudentPrepaymentAllocator.kt
@@ -1,0 +1,133 @@
+package com.tutorly.data.repo.room
+
+import com.tutorly.data.db.dao.LessonDao
+import com.tutorly.data.db.dao.PaymentDao
+import com.tutorly.models.Lesson
+import com.tutorly.models.LessonStatus
+import com.tutorly.models.Payment
+import com.tutorly.models.PaymentStatus
+import java.time.Instant
+import javax.inject.Inject
+import javax.inject.Singleton
+
+internal const val PREPAYMENT_METHOD = "prepayment"
+
+@Singleton
+internal class StudentPrepaymentAllocator @Inject constructor(
+    private val lessonDao: LessonDao,
+    private val paymentDao: PaymentDao
+) {
+    suspend fun sync(studentId: Long) {
+        val lessons = lessonDao.listByStudentAscending(studentId)
+        if (lessons.isEmpty()) return
+
+        val payments = paymentDao.getByStudent(studentId)
+        if (payments.isEmpty()) {
+            allocateFromDeposits(studentId, lessons, emptyMap())
+        } else {
+            val paymentsByLesson = payments
+                .filter { it.lessonId != null }
+                .associateBy { it.lessonId!! }
+            allocateFromDeposits(studentId, lessons, paymentsByLesson)
+        }
+    }
+
+    private suspend fun allocateFromDeposits(
+        studentId: Long,
+        lessons: List<Lesson>,
+        paymentsByLesson: Map<Long, Payment>
+    ) {
+        val depositTotal = paymentDao.totalPrepayment(studentId, PaymentStatus.PAID)
+        var remaining = depositTotal
+        val referenceTime = Instant.now()
+
+        lessons.forEach { lesson ->
+            val payment = paymentsByLesson[lesson.id]
+
+            if (lesson.status == LessonStatus.CANCELED) {
+                if (payment?.method == PREPAYMENT_METHOD && payment.status == PaymentStatus.PAID) {
+                    revertPrepayment(lesson, payment, referenceTime)
+                }
+                return@forEach
+            }
+
+            if (payment != null && payment.status == PaymentStatus.PAID && payment.method != PREPAYMENT_METHOD) {
+                return@forEach
+            }
+
+            val price = lesson.priceCents
+            if (price <= 0) {
+                if (payment?.method == PREPAYMENT_METHOD && payment.status == PaymentStatus.PAID) {
+                    revertPrepayment(lesson, payment, referenceTime)
+                }
+                return@forEach
+            }
+
+            val priceLong = price.toLong()
+            if (remaining >= priceLong) {
+                remaining -= priceLong
+                ensurePrepaid(lesson, payment, referenceTime)
+            } else {
+                if (payment?.method == PREPAYMENT_METHOD && payment.status == PaymentStatus.PAID) {
+                    revertPrepayment(lesson, payment, referenceTime)
+                }
+            }
+        }
+    }
+
+    private suspend fun ensurePrepaid(
+        lesson: Lesson,
+        payment: Payment?,
+        referenceTime: Instant
+    ) {
+        if (lesson.paymentStatus != PaymentStatus.PAID || lesson.paidCents != lesson.priceCents) {
+            lessonDao.updatePayment(
+                id = lesson.id,
+                status = PaymentStatus.PAID,
+                paid = lesson.priceCents,
+                now = referenceTime,
+                markedAt = referenceTime
+            )
+        }
+
+        val updated = (payment ?: Payment(
+            lessonId = lesson.id,
+            studentId = lesson.studentId,
+            amountCents = lesson.priceCents,
+            status = PaymentStatus.PAID
+        )).copy(
+            amountCents = lesson.priceCents,
+            status = PaymentStatus.PAID,
+            method = PREPAYMENT_METHOD,
+            at = referenceTime
+        )
+
+        if (payment == null) {
+            paymentDao.insert(updated)
+        } else {
+            paymentDao.update(updated)
+        }
+    }
+
+    private suspend fun revertPrepayment(
+        lesson: Lesson,
+        payment: Payment,
+        referenceTime: Instant
+    ) {
+        val isPastLesson = lesson.startAt.isBefore(referenceTime)
+        val status = if (isPastLesson) PaymentStatus.DUE else PaymentStatus.UNPAID
+        val markedAt = if (status == PaymentStatus.UNPAID) null else referenceTime
+
+        if (lesson.paymentStatus != status || lesson.paidCents != 0) {
+            lessonDao.updatePayment(
+                id = lesson.id,
+                status = status,
+                paid = 0,
+                now = referenceTime,
+                markedAt = markedAt
+            )
+        }
+
+        paymentDao.delete(payment)
+    }
+}

--- a/app/src/main/java/com/tutorly/di/DatabaseModule.kt
+++ b/app/src/main/java/com/tutorly/di/DatabaseModule.kt
@@ -11,6 +11,7 @@ import com.tutorly.data.repo.room.RoomLessonsRepository
 import com.tutorly.data.repo.room.RoomPaymentsRepository
 import com.tutorly.data.repo.room.RoomStudentsRepository
 import com.tutorly.data.repo.room.RoomSubjectPresetsRepository
+import com.tutorly.data.repo.room.StudentPrepaymentAllocator
 import com.tutorly.domain.repo.LessonsRepository
 import com.tutorly.domain.repo.PaymentsRepository
 import com.tutorly.domain.repo.StudentsRepository
@@ -47,9 +48,16 @@ object DatabaseModule {
     ): StudentsRepository = RoomStudentsRepository(studentDao, paymentDao, lessonDao)
 
     @Provides @Singleton
-    fun providePaymentsRepo(
+    fun providePrepaymentAllocator(
+        lessonDao: LessonDao,
         paymentDao: PaymentDao
-    ): PaymentsRepository = RoomPaymentsRepository(paymentDao)
+    ): StudentPrepaymentAllocator = StudentPrepaymentAllocator(lessonDao, paymentDao)
+
+    @Provides @Singleton
+    fun providePaymentsRepo(
+        paymentDao: PaymentDao,
+        prepaymentAllocator: StudentPrepaymentAllocator
+    ): PaymentsRepository = RoomPaymentsRepository(paymentDao, prepaymentAllocator)
 
     @Provides @Singleton
     fun provideSubjectsRepo(dao: SubjectPresetDao): SubjectPresetsRepository = RoomSubjectPresetsRepository(dao)
@@ -57,8 +65,9 @@ object DatabaseModule {
     @Provides @Singleton
     fun provideLessonsRepo(
         lessonDao: LessonDao,
-        paymentDao: PaymentDao
-    ): LessonsRepository = RoomLessonsRepository(lessonDao, paymentDao)
+        paymentDao: PaymentDao,
+        prepaymentAllocator: StudentPrepaymentAllocator
+    ): LessonsRepository = RoomLessonsRepository(lessonDao, paymentDao, prepaymentAllocator)
 
     @Provides @Singleton
     fun provideUserSettingsRepo(): UserSettingsRepository = StaticUserSettingsRepository()

--- a/app/src/main/java/com/tutorly/domain/model/StudentProfile.kt
+++ b/app/src/main/java/com/tutorly/domain/model/StudentProfile.kt
@@ -24,7 +24,8 @@ data class StudentProfileMetrics(
     val debtLessons: Int,
     val totalPaidCents: Long,
     val averagePriceCents: Int?,
-    val outstandingCents: Long
+    val outstandingCents: Long,
+    val prepaymentCents: Long
 )
 
 data class StudentProfileLesson(

--- a/app/src/main/java/com/tutorly/domain/repo/PaymentsRepository.kt
+++ b/app/src/main/java/com/tutorly/domain/repo/PaymentsRepository.kt
@@ -13,4 +13,6 @@ interface PaymentsRepository {
     suspend fun insert(payment: Payment): Long
     suspend fun update(payment: Payment)
     suspend fun delete(payment: Payment)
+
+    suspend fun applyPrepayment(studentId: Long)
 }

--- a/app/src/main/java/com/tutorly/navigation/AppNav.kt
+++ b/app/src/main/java/com/tutorly/navigation/AppNav.kt
@@ -9,10 +9,12 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.window.DialogProperties
 import androidx.navigation.NavHostController
 import androidx.navigation.NavType
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
+import androidx.navigation.compose.dialog
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navArgument
@@ -198,7 +200,7 @@ fun AppNavRoot() {
                     creationViewModel = creationViewModel
                 )
             }
-            composable(
+            dialog(
                 route = ROUTE_STUDENT_EDIT,
                 arguments = listOf(
                     navArgument("studentId") { type = NavType.LongType },
@@ -206,7 +208,8 @@ fun AppNavRoot() {
                         type = NavType.StringType
                         defaultValue = StudentEditTarget.PROFILE.name
                     }
-                )
+                ),
+                dialogProperties = DialogProperties(usePlatformDefaultWidth = false)
             ) {
                 StudentEditorDialog(
                     onDismiss = { nav.popBackStack() },

--- a/app/src/main/java/com/tutorly/ui/components/TutorlyBottomSheetContainer.kt
+++ b/app/src/main/java/com/tutorly/ui/components/TutorlyBottomSheetContainer.kt
@@ -1,0 +1,34 @@
+package com.tutorly.ui.components
+
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+
+/**
+ * Wraps bottom-sheet content into a surface with rounded top corners so we can keep
+ * the sheet background while allowing the modal container itself to stay transparent.
+ */
+@Composable
+fun TutorlyBottomSheetContainer(
+    modifier: Modifier = Modifier,
+    color: Color = MaterialTheme.colorScheme.surface,
+    tonalElevation: Dp = 0.dp,
+    shape: Shape = RoundedCornerShape(topStart = 28.dp, topEnd = 28.dp),
+    content: @Composable () -> Unit,
+) {
+    Surface(
+        modifier = modifier.fillMaxWidth(),
+        shape = shape,
+        color = color,
+        tonalElevation = tonalElevation,
+    ) {
+        content()
+    }
+}

--- a/app/src/main/java/com/tutorly/ui/components/TutorlyBottomSheetContainer.kt
+++ b/app/src/main/java/com/tutorly/ui/components/TutorlyBottomSheetContainer.kt
@@ -1,11 +1,16 @@
 package com.tutorly.ui.components
 
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.BottomSheetDefaults
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.unit.Dp
@@ -21,6 +26,7 @@ fun TutorlyBottomSheetContainer(
     color: Color = MaterialTheme.colorScheme.surface,
     tonalElevation: Dp = 0.dp,
     shape: Shape = RoundedCornerShape(topStart = 28.dp, topEnd = 28.dp),
+    dragHandle: @Composable (() -> Unit)? = { BottomSheetDefaults.DragHandle() },
     content: @Composable () -> Unit,
 ) {
     Surface(
@@ -29,6 +35,19 @@ fun TutorlyBottomSheetContainer(
         color = color,
         tonalElevation = tonalElevation,
     ) {
-        content()
+        Column(modifier = Modifier.fillMaxWidth()) {
+            if (dragHandle != null) {
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(top = 12.dp, bottom = 4.dp),
+                    contentAlignment = Alignment.Center
+                ) {
+                    dragHandle()
+                }
+            }
+
+            content()
+        }
     }
 }

--- a/app/src/main/java/com/tutorly/ui/lessoncard/LessonCardSheet.kt
+++ b/app/src/main/java/com/tutorly/ui/lessoncard/LessonCardSheet.kt
@@ -71,6 +71,7 @@ import java.time.ZonedDateTime
 import java.time.format.DateTimeFormatter
 import java.util.Locale
 import kotlinx.coroutines.launch
+import com.tutorly.ui.components.TutorlyBottomSheetContainer
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -175,104 +176,108 @@ internal fun LessonCardSheet(
             scope.launch { sheetState.hide() }.invokeOnCompletion { onDismissRequest() }
         },
         sheetState = sheetState,
-        containerColor = Color.White,
+        containerColor = Color.Transparent,
+        contentColor = Color.Unspecified,
+        scrimColor = Color.Black.copy(alpha = 0.32f),
     ) {
-        Box(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(horizontal = 20.dp, vertical = 16.dp)
-        ) {
-            if (state.isLoading) {
-                Box(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .height(200.dp),
-                    contentAlignment = Alignment.Center
-                ) {
-                    CircularProgressIndicator()
-                }
-            } else {
-                Column(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .verticalScroll(rememberScrollState()),
-                    verticalArrangement = Arrangement.spacedBy(20.dp)
-                ) {
-                    if (state.isSaving) {
-                        LinearProgressIndicator(modifier = Modifier.fillMaxWidth())
+        TutorlyBottomSheetContainer {
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 20.dp, vertical = 16.dp)
+            ) {
+                if (state.isLoading) {
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .height(200.dp),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        CircularProgressIndicator()
                     }
+                } else {
+                    Column(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .verticalScroll(rememberScrollState()),
+                        verticalArrangement = Arrangement.spacedBy(20.dp)
+                    ) {
+                        if (state.isSaving) {
+                            LinearProgressIndicator(modifier = Modifier.fillMaxWidth())
+                        }
 
-                    LessonHeader(
-                        name = state.studentName,
-                        grade = state.studentGrade,
-                        subject = state.subjectName,
-                        onClick = onStudentClick
-                    )
+                        LessonHeader(
+                            name = state.studentName,
+                            grade = state.studentGrade,
+                            subject = state.subjectName,
+                            onClick = onStudentClick
+                        )
 
-                    DateRow(
-                        dateText = formattedDate,
-                        onClick = onDateClick
-                    )
+                        DateRow(
+                            dateText = formattedDate,
+                            onClick = onDateClick
+                        )
 
-                    TimeDurationRow(
-                        timeLabel = stringResource(id = R.string.lesson_details_time_label),
-                        timeText = state.time.format(timeFormatter),
-                        durationLabel = stringResource(id = R.string.lesson_details_duration_label),
-                        durationText = stringResource(id = R.string.lesson_card_duration_value, state.durationMinutes),
-                        onTimeClick = onTimeClick,
-                        onDurationClick = onDurationClick
-                    )
+                        TimeDurationRow(
+                            timeLabel = stringResource(id = R.string.lesson_details_time_label),
+                            timeText = state.time.format(timeFormatter),
+                            durationLabel = stringResource(id = R.string.lesson_details_duration_label),
+                            durationText = stringResource(id = R.string.lesson_card_duration_value, state.durationMinutes),
+                            onTimeClick = onTimeClick,
+                            onDurationClick = onDurationClick
+                        )
 
-                    PriceRow(
-                        price = priceText,
-                        statusLabel = stringResource(id = statusDisplay.labelRes),
-                        statusSymbol = statusDisplay.symbol,
-                        startDateTime = startDateTime,
-                        statusMenuExpanded = statusMenuExpanded,
-                        onPriceClick = onPriceClick,
-                        onStatusClick = onStatusClick,
-                        onStatusDismiss = { statusMenuExpanded = false },
-                        onStatusSelect = onStatusSelect,
-                        isStatusBusy = state.isPaymentActionRunning
-                    )
+                        PriceRow(
+                            price = priceText,
+                            statusLabel = stringResource(id = statusDisplay.labelRes),
+                            statusSymbol = statusDisplay.symbol,
+                            startDateTime = startDateTime,
+                            statusMenuExpanded = statusMenuExpanded,
+                            onPriceClick = onPriceClick,
+                            onStatusClick = onStatusClick,
+                            onStatusDismiss = { statusMenuExpanded = false },
+                            onStatusSelect = onStatusSelect,
+                            isStatusBusy = state.isPaymentActionRunning
+                        )
 
-                    NoteRow(
-                        note = state.note,
-                        onClick = onNoteClick
-                    )
+                        NoteRow(
+                            note = state.note,
+                            onClick = onNoteClick
+                        )
 
-                    if (state.lessonId != null) {
-                        OutlinedButton(
-                            onClick = { showDeleteDialog = true },
-                            modifier = Modifier.fillMaxWidth(),
-                            enabled = !state.isSaving && !state.isDeleting && !state.isLoading,
-                            colors = ButtonDefaults.outlinedButtonColors(
-                                contentColor = MaterialTheme.colorScheme.error
-                            ),
-                            border = BorderStroke(1.dp, MaterialTheme.colorScheme.error)
-                        ) {
-                            if (state.isDeleting) {
-                                CircularProgressIndicator(
-                                    modifier = Modifier.size(18.dp),
-                                    strokeWidth = 2.dp,
-                                    color = MaterialTheme.colorScheme.error
-                                )
-                            } else {
-                                Text(text = stringResource(id = R.string.lesson_card_delete))
+                        if (state.lessonId != null) {
+                            OutlinedButton(
+                                onClick = { showDeleteDialog = true },
+                                modifier = Modifier.fillMaxWidth(),
+                                enabled = !state.isSaving && !state.isDeleting && !state.isLoading,
+                                colors = ButtonDefaults.outlinedButtonColors(
+                                    contentColor = MaterialTheme.colorScheme.error
+                                ),
+                                border = BorderStroke(1.dp, MaterialTheme.colorScheme.error)
+                            ) {
+                                if (state.isDeleting) {
+                                    CircularProgressIndicator(
+                                        modifier = Modifier.size(18.dp),
+                                        strokeWidth = 2.dp,
+                                        color = MaterialTheme.colorScheme.error
+                                    )
+                                } else {
+                                    Text(text = stringResource(id = R.string.lesson_card_delete))
+                                }
                             }
                         }
+
+                        Spacer(modifier = Modifier.height(8.dp))
                     }
-
-                    Spacer(modifier = Modifier.height(8.dp))
                 }
-            }
 
-            SnackbarHost(
-                hostState = snackbarHostState,
-                modifier = Modifier
-                    .align(Alignment.BottomCenter)
-                    .padding(bottom = 8.dp)
-            )
+                SnackbarHost(
+                    hostState = snackbarHostState,
+                    modifier = Modifier
+                        .align(Alignment.BottomCenter)
+                        .padding(bottom = 8.dp)
+                )
+            }
         }
     }
 

--- a/app/src/main/java/com/tutorly/ui/lessoncreation/LessonCreationSheet.kt
+++ b/app/src/main/java/com/tutorly/ui/lessoncreation/LessonCreationSheet.kt
@@ -100,10 +100,9 @@ fun LessonCreationSheet(
         sheetState = sheetState,
         containerColor = Color.Transparent,
         contentColor = Color.Unspecified,
-        scrimColor = Color.Black.copy(alpha = 0.32f),
-        dragHandle = null
+        scrimColor = Color.Black.copy(alpha = 0.32f)
     ) {
-        TutorlyBottomSheetContainer {
+        TutorlyBottomSheetContainer(dragHandle = null) {
             Column(
                 modifier = Modifier
                     .fillMaxWidth()

--- a/app/src/main/java/com/tutorly/ui/lessoncreation/LessonCreationSheet.kt
+++ b/app/src/main/java/com/tutorly/ui/lessoncreation/LessonCreationSheet.kt
@@ -69,6 +69,7 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.IntSize
 import java.text.NumberFormat
+import com.tutorly.ui.components.TutorlyBottomSheetContainer
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
 @Composable
@@ -97,29 +98,33 @@ fun LessonCreationSheet(
     ModalBottomSheet(
         onDismissRequest = onDismiss,
         sheetState = sheetState,
-        containerColor = MaterialTheme.colorScheme.surface,
+        containerColor = Color.Transparent,
+        contentColor = Color.Unspecified,
+        scrimColor = Color.Black.copy(alpha = 0.32f),
         dragHandle = null
     ) {
-        Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .heightIn(min = minHeight)
-                .verticalScroll(rememberScrollState())
-                .padding(horizontal = 20.dp, vertical = 16.dp),
-            verticalArrangement = Arrangement.spacedBy(16.dp)
-        ) {
-            SheetHeader(onDismiss)
-            StudentSection(
-                state = state,
-                onQueryChange = onStudentQueryChange,
-                onStudentSelect = onStudentSelect,
-                onAddStudent = onAddStudent
-            )
-            SubjectSection(state = state, onSubjectSelect = onSubjectSelect)
-            TimeSection(state = state, onDateSelect = onDateSelect, onTimeSelect = onTimeSelect)
-            DurationPriceSection(state = state, onDurationChange = onDurationChange, onPriceChange = onPriceChange)
-            NoteSection(state = state, onNoteChange = onNoteChange)
-            ActionButtons(state = state, onSubmit = onSubmit)
+        TutorlyBottomSheetContainer {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .heightIn(min = minHeight)
+                    .verticalScroll(rememberScrollState())
+                    .padding(horizontal = 20.dp, vertical = 16.dp),
+                verticalArrangement = Arrangement.spacedBy(16.dp)
+            ) {
+                SheetHeader(onDismiss)
+                StudentSection(
+                    state = state,
+                    onQueryChange = onStudentQueryChange,
+                    onStudentSelect = onStudentSelect,
+                    onAddStudent = onAddStudent
+                )
+                SubjectSection(state = state, onSubjectSelect = onSubjectSelect)
+                TimeSection(state = state, onDateSelect = onDateSelect, onTimeSelect = onTimeSelect)
+                DurationPriceSection(state = state, onDurationChange = onDurationChange, onPriceChange = onPriceChange)
+                NoteSection(state = state, onNoteChange = onNoteChange)
+                ActionButtons(state = state, onSubmit = onSubmit)
+            }
         }
     }
 

--- a/app/src/main/java/com/tutorly/ui/lessoncreation/LessonCreationSheet.kt
+++ b/app/src/main/java/com/tutorly/ui/lessoncreation/LessonCreationSheet.kt
@@ -50,7 +50,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowDropDown
 import androidx.compose.material.icons.filled.ArrowDropUp
-import androidx.compose.material.icons.filled.AttachMoney
+import androidx.compose.material.icons.outlined.CurrencyRuble
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Description
@@ -444,7 +444,7 @@ private fun DurationPriceSection(
                 },
                 label = { Text(text = stringResource(id = R.string.lesson_create_price_label, state.currencySymbol)) },
                 leadingIcon = {
-                    Icon(imageVector = Icons.Filled.AttachMoney, contentDescription = null)
+                    Icon(imageVector = Icons.Outlined.CurrencyRuble, contentDescription = null)
                 },
                 keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
                 modifier = Modifier.fillMaxWidth(),

--- a/app/src/main/java/com/tutorly/ui/lessoncreation/LessonCreationSheet.kt
+++ b/app/src/main/java/com/tutorly/ui/lessoncreation/LessonCreationSheet.kt
@@ -50,8 +50,12 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowDropDown
 import androidx.compose.material.icons.filled.ArrowDropUp
+import androidx.compose.material.icons.filled.AttachMoney
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.Description
+import androidx.compose.material.icons.filled.Person
+import androidx.compose.material.icons.filled.Schedule
 import androidx.compose.material.icons.outlined.CalendarMonth
 import androidx.compose.material.icons.outlined.Schedule
 import com.tutorly.R
@@ -179,6 +183,9 @@ private fun StudentSection(
                     .onGloballyPositioned { textFieldSize = it.size }
                     .onFocusChanged { focusState -> expanded = focusState.isFocused },
                 singleLine = true,
+                leadingIcon = {
+                    Icon(imageVector = Icons.Filled.Person, contentDescription = null)
+                },
                 trailingIcon = {
                     IconButton(onClick = { expanded = !expanded }) {
                         Icon(
@@ -388,6 +395,9 @@ private fun DurationPriceSection(
                 },
                 label = { Text(text = stringResource(id = R.string.lesson_create_duration_custom_label)) },
                 suffix = { Text(text = stringResource(id = R.string.lesson_create_minutes_suffix)) },
+                leadingIcon = {
+                    Icon(imageVector = Icons.Filled.Schedule, contentDescription = null)
+                },
                 keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
                 modifier = Modifier.fillMaxWidth(),
                 isError = state.errors.containsKey(LessonCreationField.DURATION)
@@ -433,6 +443,9 @@ private fun DurationPriceSection(
                     onPriceChange((digits.toIntOrNull() ?: 0) * 100)
                 },
                 label = { Text(text = stringResource(id = R.string.lesson_create_price_label, state.currencySymbol)) },
+                leadingIcon = {
+                    Icon(imageVector = Icons.Filled.AttachMoney, contentDescription = null)
+                },
                 keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
                 modifier = Modifier.fillMaxWidth(),
                 isError = state.errors.containsKey(LessonCreationField.PRICE)
@@ -481,7 +494,10 @@ private fun NoteSection(state: LessonCreationUiState, onNoteChange: (String) -> 
         label = { Text(text = stringResource(id = R.string.lesson_create_note_label)) },
         modifier = Modifier
             .fillMaxWidth()
-            .heightIn(min = 80.dp)
+            .heightIn(min = 80.dp),
+        leadingIcon = {
+            Icon(imageVector = Icons.Filled.Description, contentDescription = null)
+        }
     )
 }
 

--- a/app/src/main/java/com/tutorly/ui/screens/MoneyInputFormatter.kt
+++ b/app/src/main/java/com/tutorly/ui/screens/MoneyInputFormatter.kt
@@ -14,10 +14,10 @@ internal fun parseMoneyInput(input: String): Int? {
     if (raw.isEmpty()) return null
     val normalized = raw.replace(',', '.')
     val decimal = runCatching { java.math.BigDecimal(normalized) }.getOrNull() ?: return null
-    if (decimal < java.math.BigDecimal.ZERO) return null
     val cents = decimal.multiply(java.math.BigDecimal(100)).setScale(0, java.math.RoundingMode.HALF_UP)
     val bigInt = runCatching { cents.toBigIntegerExact() }.getOrNull() ?: return null
     val max = java.math.BigInteger.valueOf(Int.MAX_VALUE.toLong())
-    if (bigInt > max) return null
+    val min = java.math.BigInteger.valueOf(Int.MIN_VALUE.toLong())
+    if (bigInt > max || bigInt < min) return null
     return bigInt.toInt()
 }

--- a/app/src/main/java/com/tutorly/ui/screens/StudentDetailsScreen.kt
+++ b/app/src/main/java/com/tutorly/ui/screens/StudentDetailsScreen.kt
@@ -21,7 +21,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material.icons.outlined.CalendarToday
-import androidx.compose.material.icons.outlined.CurrencyRuble
+import androidx.compose.material.icons.outlined.CreditCard
 import androidx.compose.material.icons.outlined.Email
 import androidx.compose.material.icons.outlined.Phone
 import androidx.compose.material.icons.outlined.Savings
@@ -416,7 +416,7 @@ private fun StudentProfileHeader(
                 )
                 val subject = profile.subject?.takeIf { it.isNotBlank() }?.trim()
                 val grade = profile.grade?.takeIf { it.isNotBlank() }?.trim()
-                val details = listOfNotNull(subject, grade).joinToString(separator = " • ")
+                val details = listOfNotNull(grade, subject).joinToString(separator = " • ")
                 if (details.isNotEmpty()) {
                     Text(
                         text = details,
@@ -509,10 +509,6 @@ private fun StudentProfileMetricsSection(
         modifier = modifier.fillMaxWidth(),
         verticalArrangement = Arrangement.spacedBy(16.dp)
     ) {
-        Text(
-            text = stringResource(id = R.string.student_profile_metrics_title),
-            style = MaterialTheme.typography.titleMedium
-        )
         Row(
             modifier = Modifier.fillMaxWidth(),
             horizontalArrangement = Arrangement.spacedBy(12.dp)
@@ -538,7 +534,7 @@ private fun StudentProfileMetricsSection(
                 verticalArrangement = Arrangement.spacedBy(12.dp)
             ) {
                 ProfileMetricTile(
-                    icon = Icons.Outlined.CurrencyRuble,
+                    icon = Icons.Outlined.CreditCard,
                     value = earnedValue,
                     label = stringResource(id = R.string.student_profile_metrics_earned_label)
                 )
@@ -821,7 +817,7 @@ private fun StudentAvatar(
     ) {
         Text(
             text = initials,
-            style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.Bold),
+            style = MaterialTheme.typography.headlineSmall.copy(fontWeight = FontWeight.Bold),
             color = MaterialTheme.colorScheme.onSurfaceVariant
         )
     }

--- a/app/src/main/java/com/tutorly/ui/screens/StudentDetailsScreen.kt
+++ b/app/src/main/java/com/tutorly/ui/screens/StudentDetailsScreen.kt
@@ -319,6 +319,24 @@ private fun StudentProfileContent(
         }
 
         item {
+            StudentProfileMetricsSection(
+                profile = profile,
+                numberFormatter = numberFormatter,
+                onRateClick = { onEdit(profile.student.id, StudentEditTarget.RATE) }
+            )
+        }
+
+        item {
+            Button(
+                onClick = { onAddPrepayment(profile.student.id) },
+                modifier = Modifier.fillMaxWidth(),
+                shape = RoundedCornerShape(16.dp)
+            ) {
+                Text(text = stringResource(id = R.string.student_profile_add_prepayment))
+            }
+        }
+
+        item {
             Column(verticalArrangement = Arrangement.spacedBy(16.dp)) {
                 ProfileInfoCard(
                     icon = Icons.Outlined.Phone,
@@ -339,24 +357,6 @@ private fun StudentProfileContent(
                     onClick = { onEdit(profile.student.id, StudentEditTarget.NOTES) },
                     valueMaxLines = 4
                 )
-            }
-        }
-
-        item {
-            StudentProfileMetricsSection(
-                profile = profile,
-                numberFormatter = numberFormatter,
-                onRateClick = { onEdit(profile.student.id, StudentEditTarget.RATE) }
-            )
-        }
-
-        item {
-            Button(
-                onClick = { onAddPrepayment(profile.student.id) },
-                modifier = Modifier.fillMaxWidth(),
-                shape = RoundedCornerShape(16.dp)
-            ) {
-                Text(text = stringResource(id = R.string.student_profile_add_prepayment))
             }
         }
 

--- a/app/src/main/java/com/tutorly/ui/screens/StudentDetailsScreen.kt
+++ b/app/src/main/java/com/tutorly/ui/screens/StudentDetailsScreen.kt
@@ -1,6 +1,5 @@
 package com.tutorly.ui.screens
 
-import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -18,7 +17,6 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.ArrowBack
@@ -35,6 +33,7 @@ import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -194,7 +193,7 @@ fun StudentDetailsScreen(
                 }
             }
         },
-        containerColor = MaterialTheme.colorScheme.surface
+        containerColor = MaterialTheme.colorScheme.surfaceContainerHighest
     ) { innerPadding ->
         when (val currentState = state) {
             StudentProfileUiState.Hidden, StudentProfileUiState.Loading -> {
@@ -228,7 +227,7 @@ fun StudentDetailsScreen(
                     profile = currentState.profile,
                     onEdit = onEdit,
                     onAddLesson = openLessonCreation,
-                    onAddPrepayment = { showPrepaymentSheet = true },
+                    onPrepaymentClick = { showPrepaymentSheet = true },
                     onLessonClick = lessonCardViewModel::open,
                     modifier = modifier
                         .fillMaxSize()
@@ -273,7 +272,7 @@ private fun StudentProfileContent(
     profile: StudentProfile,
     onEdit: (Long, StudentEditTarget) -> Unit,
     onAddLesson: (Long) -> Unit,
-    onAddPrepayment: (Long) -> Unit,
+    onPrepaymentClick: (Long) -> Unit,
     onLessonClick: (Long) -> Unit,
     modifier: Modifier = Modifier
 ) {
@@ -323,33 +322,18 @@ private fun StudentProfileContent(
             StudentProfileMetricsSection(
                 profile = profile,
                 numberFormatter = numberFormatter,
-                onRateClick = { onEdit(profile.student.id, StudentEditTarget.RATE) }
+                onRateClick = { onEdit(profile.student.id, StudentEditTarget.RATE) },
+                onPrepaymentClick = { onPrepaymentClick(profile.student.id) }
             )
         }
 
         item {
-            Button(
-                onClick = { onAddPrepayment(profile.student.id) },
-                modifier = Modifier.fillMaxWidth(),
-                shape = RoundedCornerShape(16.dp)
-            ) {
-                Text(text = stringResource(id = R.string.student_profile_add_prepayment))
-            }
-        }
-
-        item {
             Column(verticalArrangement = Arrangement.spacedBy(16.dp)) {
-                ProfileInfoCard(
-                    icon = Icons.Outlined.Phone,
-                    label = stringResource(id = R.string.student_details_phone_label),
-                    value = profile.student.phone,
-                    onClick = { onEdit(profile.student.id, StudentEditTarget.PHONE) }
-                )
-                ProfileInfoCard(
-                    icon = Icons.Outlined.Email,
-                    label = stringResource(id = R.string.student_details_messenger_label),
-                    value = profile.student.messenger,
-                    onClick = { onEdit(profile.student.id, StudentEditTarget.MESSENGER) }
+                ProfileContactsCard(
+                    phone = profile.student.phone,
+                    messenger = profile.student.messenger,
+                    onPhoneClick = { onEdit(profile.student.id, StudentEditTarget.PHONE) },
+                    onMessengerClick = { onEdit(profile.student.id, StudentEditTarget.MESSENGER) }
                 )
                 ProfileInfoCard(
                     icon = Icons.Outlined.StickyNote2,
@@ -413,8 +397,8 @@ private fun StudentProfileHeader(
             .fillMaxWidth()
             .clickable { onEdit(StudentEditTarget.PROFILE) },
         shape = MaterialTheme.shapes.extraLarge,
-        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.primaryContainer),
-        elevation = CardDefaults.cardElevation(defaultElevation = 0.dp)
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
+        elevation = CardDefaults.cardElevation(defaultElevation = 6.dp)
     ) {
         Row(
             modifier = Modifier
@@ -428,7 +412,7 @@ private fun StudentProfileHeader(
                 Text(
                     text = profile.student.name,
                     style = MaterialTheme.typography.headlineSmall,
-                    color = MaterialTheme.colorScheme.onPrimaryContainer
+                    color = MaterialTheme.colorScheme.onSurface
                 )
                 val subject = profile.subject?.takeIf { it.isNotBlank() }?.trim()
                 val grade = profile.grade?.takeIf { it.isNotBlank() }?.trim()
@@ -437,7 +421,7 @@ private fun StudentProfileHeader(
                     Text(
                         text = details,
                         style = MaterialTheme.typography.bodyMedium,
-                        color = MaterialTheme.colorScheme.onPrimaryContainer
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
                     )
                 }
             }
@@ -463,29 +447,22 @@ private fun ProfileInfoCard(
             .fillMaxWidth()
             .clip(MaterialTheme.shapes.large)
             .clickable { onClick() },
-        color = if (hasValue) MaterialTheme.colorScheme.surfaceVariant else MaterialTheme.colorScheme.surfaceContainerHighest,
-        tonalElevation = 1.dp
+        color = MaterialTheme.colorScheme.surface,
+        tonalElevation = 0.dp,
+        shadowElevation = 4.dp
     ) {
         Row(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(horizontal = 16.dp, vertical = 12.dp),
+                .padding(horizontal = 16.dp, vertical = 14.dp),
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.spacedBy(16.dp)
         ) {
-            Surface(
-                modifier = Modifier.size(36.dp),
-                shape = CircleShape,
-                color = MaterialTheme.colorScheme.primary.copy(alpha = 0.1f)
-            ) {
-                Box(contentAlignment = Alignment.Center) {
-                    Icon(
-                        imageVector = icon,
-                        contentDescription = null,
-                        tint = MaterialTheme.colorScheme.primary
-                    )
-                }
-            }
+            Icon(
+                imageVector = icon,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onSurfaceVariant
+            )
             Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
                 Text(
                     text = label,
@@ -509,6 +486,7 @@ private fun StudentProfileMetricsSection(
     profile: StudentProfile,
     numberFormatter: NumberFormat,
     onRateClick: () -> Unit,
+    onPrepaymentClick: () -> Unit,
     modifier: Modifier = Modifier
 ) {
     val lessonsCount = profile.metrics.totalLessons.toString()
@@ -567,7 +545,8 @@ private fun StudentProfileMetricsSection(
                 ProfileMetricTile(
                     icon = Icons.Outlined.Savings,
                     value = prepaymentValue,
-                    label = stringResource(id = R.string.student_profile_metrics_prepayment_label)
+                    label = stringResource(id = R.string.student_profile_metrics_prepayment_label),
+                    onClick = onPrepaymentClick
                 )
             }
         }
@@ -594,8 +573,9 @@ private fun ProfileMetricTile(
     Surface(
         modifier = tileModifier,
         shape = MaterialTheme.shapes.large,
-        color = MaterialTheme.colorScheme.surfaceVariant,
-        tonalElevation = 1.dp
+        color = MaterialTheme.colorScheme.surface,
+        tonalElevation = 0.dp,
+        shadowElevation = 4.dp
     ) {
         Column(
             modifier = Modifier
@@ -628,6 +608,93 @@ private fun ProfileMetricTile(
 }
 
 @Composable
+private fun ProfileContactsCard(
+    phone: String?,
+    messenger: String?,
+    onPhoneClick: () -> Unit,
+    onMessengerClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Surface(
+        modifier = modifier
+            .fillMaxWidth()
+            .clip(MaterialTheme.shapes.large),
+        color = MaterialTheme.colorScheme.surface,
+        tonalElevation = 0.dp,
+        shadowElevation = 4.dp
+    ) {
+        Column(
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            Text(
+                text = stringResource(id = R.string.student_details_contact_title),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(start = 16.dp, end = 16.dp, top = 16.dp)
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+            ProfileContactRow(
+                icon = Icons.Outlined.Phone,
+                label = stringResource(id = R.string.student_details_phone_label),
+                value = phone,
+                placeholder = stringResource(id = R.string.student_profile_contact_placeholder),
+                onClick = onPhoneClick
+            )
+            HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.4f))
+            ProfileContactRow(
+                icon = Icons.Outlined.Email,
+                label = stringResource(id = R.string.student_details_messenger_label),
+                value = messenger,
+                placeholder = stringResource(id = R.string.student_profile_contact_placeholder),
+                onClick = onMessengerClick,
+                modifier = Modifier.padding(bottom = 16.dp)
+            )
+        }
+    }
+}
+
+@Composable
+private fun ProfileContactRow(
+    icon: ImageVector,
+    label: String,
+    value: String?,
+    placeholder: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val hasValue = !value.isNullOrBlank()
+    val displayValue = value?.takeIf { it.isNotBlank() } ?: placeholder
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick)
+            .padding(horizontal = 16.dp, vertical = 12.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(16.dp)
+    ) {
+        Icon(
+            imageVector = icon,
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+        Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+            Text(
+                text = label,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+            Text(
+                text = displayValue,
+                style = MaterialTheme.typography.bodyMedium,
+                color = if (hasValue) MaterialTheme.colorScheme.onSurface else MaterialTheme.colorScheme.onSurfaceVariant,
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis
+            )
+        }
+    }
+}
+
+@Composable
 private fun StudentProfileEmptyHistory(
     onAddLesson: () -> Unit,
     modifier: Modifier = Modifier
@@ -635,8 +702,9 @@ private fun StudentProfileEmptyHistory(
     Surface(
         modifier = modifier.fillMaxWidth(),
         shape = MaterialTheme.shapes.large,
-        tonalElevation = 1.dp,
-        color = MaterialTheme.colorScheme.surfaceContainerHigh
+        tonalElevation = 0.dp,
+        shadowElevation = 4.dp,
+        color = MaterialTheme.colorScheme.surface
     ) {
         Column(
             modifier = Modifier
@@ -691,9 +759,9 @@ private fun StudentProfileLessonCard(
             .fillMaxWidth()
             .clickable { onClick() },
         shape = MaterialTheme.shapes.large,
-        tonalElevation = 1.dp,
-        color = MaterialTheme.colorScheme.surface,
-        border = BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant)
+        tonalElevation = 0.dp,
+        shadowElevation = 4.dp,
+        color = MaterialTheme.colorScheme.surface
     ) {
         Column(
             modifier = Modifier.padding(horizontal = 16.dp, vertical = 16.dp),

--- a/app/src/main/java/com/tutorly/ui/screens/StudentDetailsScreen.kt
+++ b/app/src/main/java/com/tutorly/ui/screens/StudentDetailsScreen.kt
@@ -26,6 +26,7 @@ import androidx.compose.material.icons.outlined.CalendarToday
 import androidx.compose.material.icons.outlined.CurrencyRuble
 import androidx.compose.material.icons.outlined.Email
 import androidx.compose.material.icons.outlined.Phone
+import androidx.compose.material.icons.outlined.Savings
 import androidx.compose.material.icons.outlined.Schedule
 import androidx.compose.material.icons.outlined.StickyNote2
 import androidx.compose.material3.Button
@@ -524,6 +525,7 @@ private fun StudentProfileMetricsSection(
         numberFormatter.format(cents / 100.0)
     } ?: stringResource(id = R.string.students_rate_placeholder)
     val earnedValue = numberFormatter.format(profile.metrics.totalPaidCents / 100.0)
+    val prepaymentValue = numberFormatter.format(profile.metrics.prepaymentCents / 100.0)
 
     Column(
         modifier = modifier.fillMaxWidth(),
@@ -537,25 +539,37 @@ private fun StudentProfileMetricsSection(
             modifier = Modifier.fillMaxWidth(),
             horizontalArrangement = Arrangement.spacedBy(12.dp)
         ) {
-            ProfileMetricTile(
-                icon = Icons.Outlined.CalendarToday,
-                value = lessonsCount,
-                label = stringResource(id = R.string.student_profile_metrics_lessons_label),
-                modifier = Modifier.weight(1f)
-            )
-            ProfileMetricTile(
-                icon = Icons.Outlined.Schedule,
-                value = rateValue,
-                label = stringResource(id = R.string.student_profile_metrics_rate_label),
+            Column(
                 modifier = Modifier.weight(1f),
-                onClick = onRateClick
-            )
-            ProfileMetricTile(
-                icon = Icons.Outlined.CurrencyRuble,
-                value = earnedValue,
-                label = stringResource(id = R.string.student_profile_metrics_earned_label),
-                modifier = Modifier.weight(1f)
-            )
+                verticalArrangement = Arrangement.spacedBy(12.dp)
+            ) {
+                ProfileMetricTile(
+                    icon = Icons.Outlined.CalendarToday,
+                    value = lessonsCount,
+                    label = stringResource(id = R.string.student_profile_metrics_lessons_label)
+                )
+                ProfileMetricTile(
+                    icon = Icons.Outlined.Schedule,
+                    value = rateValue,
+                    label = stringResource(id = R.string.student_profile_metrics_rate_label),
+                    onClick = onRateClick
+                )
+            }
+            Column(
+                modifier = Modifier.weight(1f),
+                verticalArrangement = Arrangement.spacedBy(12.dp)
+            ) {
+                ProfileMetricTile(
+                    icon = Icons.Outlined.CurrencyRuble,
+                    value = earnedValue,
+                    label = stringResource(id = R.string.student_profile_metrics_earned_label)
+                )
+                ProfileMetricTile(
+                    icon = Icons.Outlined.Savings,
+                    value = prepaymentValue,
+                    label = stringResource(id = R.string.student_profile_metrics_prepayment_label)
+                )
+            }
         }
     }
 }

--- a/app/src/main/java/com/tutorly/ui/screens/StudentEditorForm.kt
+++ b/app/src/main/java/com/tutorly/ui/screens/StudentEditorForm.kt
@@ -15,7 +15,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.AlternateEmail
 import androidx.compose.material.icons.filled.ArrowDropDown
 import androidx.compose.material.icons.filled.ArrowDropUp
-import androidx.compose.material.icons.filled.AttachMoney
+import androidx.compose.material.icons.outlined.CurrencyRuble
 import androidx.compose.material.icons.filled.Book
 import androidx.compose.material.icons.filled.Description
 import androidx.compose.material.icons.filled.Message
@@ -330,7 +330,7 @@ private fun RateSection(
         singleLine = true,
         enabled = enabled,
         leadingIcon = {
-            Icon(imageVector = Icons.Filled.AttachMoney, contentDescription = null)
+            Icon(imageVector = Icons.Outlined.CurrencyRuble, contentDescription = null)
         },
         keyboardOptions = KeyboardOptions.Default.copy(
             keyboardType = KeyboardType.Decimal,

--- a/app/src/main/java/com/tutorly/ui/screens/StudentEditorForm.kt
+++ b/app/src/main/java/com/tutorly/ui/screens/StudentEditorForm.kt
@@ -12,8 +12,16 @@ import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.AlternateEmail
 import androidx.compose.material.icons.filled.ArrowDropDown
 import androidx.compose.material.icons.filled.ArrowDropUp
+import androidx.compose.material.icons.filled.AttachMoney
+import androidx.compose.material.icons.filled.Book
+import androidx.compose.material.icons.filled.Description
+import androidx.compose.material.icons.filled.Message
+import androidx.compose.material.icons.filled.Person
+import androidx.compose.material.icons.filled.Phone
+import androidx.compose.material.icons.filled.School
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -207,6 +215,9 @@ private fun ProfileSection(
             singleLine = true,
             enabled = enabled,
             isError = state.nameError,
+            leadingIcon = {
+                Icon(imageVector = Icons.Filled.Person, contentDescription = null)
+            },
             keyboardOptions = KeyboardOptions.Default.copy(imeAction = ImeAction.Next)
         )
         if (state.nameError) {
@@ -224,6 +235,9 @@ private fun ProfileSection(
             modifier = Modifier.fillMaxWidth(),
             singleLine = true,
             enabled = enabled,
+            leadingIcon = {
+                Icon(imageVector = Icons.Filled.Book, contentDescription = null)
+            },
             keyboardOptions = KeyboardOptions.Default.copy(imeAction = ImeAction.Next)
         )
 
@@ -248,6 +262,9 @@ private fun ProfileSection(
                     },
                 singleLine = true,
                 enabled = enabled,
+                leadingIcon = {
+                    Icon(imageVector = Icons.Filled.School, contentDescription = null)
+                },
                 trailingIcon = {
                     IconButton(
                         onClick = { onGradeDropdownExpandedChange(!isGradeDropdownExpanded) },
@@ -312,6 +329,9 @@ private fun RateSection(
             .focusRequester(focusRequester),
         singleLine = true,
         enabled = enabled,
+        leadingIcon = {
+            Icon(imageVector = Icons.Filled.AttachMoney, contentDescription = null)
+        },
         keyboardOptions = KeyboardOptions.Default.copy(
             keyboardType = KeyboardType.Decimal,
             imeAction = if (isStandalone) ImeAction.Done else ImeAction.Next
@@ -342,6 +362,9 @@ private fun PhoneSection(
             .focusRequester(focusRequester),
         singleLine = true,
         enabled = enabled,
+        leadingIcon = {
+            Icon(imageVector = Icons.Filled.Phone, contentDescription = null)
+        },
         keyboardOptions = KeyboardOptions.Default.copy(
             imeAction = if (isStandalone) ImeAction.Done else ImeAction.Next
         ),
@@ -395,6 +418,9 @@ private fun MessengerSection(
                     },
                 enabled = enabled,
                 readOnly = selectedType != StudentMessengerType.OTHER,
+                leadingIcon = {
+                    Icon(imageVector = Icons.Filled.Message, contentDescription = null)
+                },
                 trailingIcon = {
                     IconButton(onClick = { isDropdownExpanded = !isDropdownExpanded }, enabled = enabled) {
                         Icon(
@@ -438,6 +464,9 @@ private fun MessengerSection(
                 .focusRequester(focusRequester),
             singleLine = true,
             enabled = enabled,
+            leadingIcon = {
+                Icon(imageVector = Icons.Filled.AlternateEmail, contentDescription = null)
+            },
             keyboardOptions = KeyboardOptions.Default.copy(
                 imeAction = if (isStandalone) ImeAction.Done else ImeAction.Next
             ),
@@ -467,6 +496,9 @@ private fun NotesSection(
             .focusRequester(focusRequester),
         minLines = 3,
         enabled = enabled,
+        leadingIcon = {
+            Icon(imageVector = Icons.Filled.Description, contentDescription = null)
+        },
         keyboardOptions = KeyboardOptions.Default.copy(imeAction = ImeAction.Done),
         keyboardActions = KeyboardActions(onDone = {
             onSubmit?.invoke()

--- a/app/src/main/java/com/tutorly/ui/screens/StudentEditorScreen.kt
+++ b/app/src/main/java/com/tutorly/ui/screens/StudentEditorScreen.kt
@@ -6,7 +6,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.BottomSheetDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
@@ -28,6 +27,7 @@ import androidx.lifecycle.viewModelScope
 import com.tutorly.R
 import com.tutorly.domain.repo.StudentsRepository
 import com.tutorly.models.Student
+import com.tutorly.ui.components.TutorlyBottomSheetContainer
 import dagger.hilt.android.lifecycle.HiltViewModel
 import java.time.Instant
 import javax.inject.Inject
@@ -232,33 +232,36 @@ fun StudentEditorDialog(
         },
         sheetState = sheetState,
         dragHandle = { BottomSheetDefaults.DragHandle() },
-        containerColor = MaterialTheme.colorScheme.surface,
+        containerColor = Color.Transparent,
+        contentColor = Color.Unspecified,
         scrimColor = Color.Black.copy(alpha = 0.32f),
     ) {
-        Column(modifier = Modifier.fillMaxWidth()) {
-            StudentEditorSheet(
-                state = formState,
-                onNameChange = vm::onNameChange,
-                onPhoneChange = vm::onPhoneChange,
-                onMessengerChange = vm::onMessengerChange,
-                onRateChange = vm::onRateChange,
-                onSubjectChange = vm::onSubjectChange,
-                onGradeChange = vm::onGradeChange,
-                onNoteChange = vm::onNoteChange,
-                onArchivedChange = vm::onArchivedChange,
-                onActiveChange = vm::onActiveChange,
-                onSave = attemptSave,
-                modifier = Modifier.fillMaxWidth(),
-                editTarget = vm.editTarget,
-                initialFocus = vm.editTarget,
-            )
+        TutorlyBottomSheetContainer {
+            Column(modifier = Modifier.fillMaxWidth()) {
+                StudentEditorSheet(
+                    state = formState,
+                    onNameChange = vm::onNameChange,
+                    onPhoneChange = vm::onPhoneChange,
+                    onMessengerChange = vm::onMessengerChange,
+                    onRateChange = vm::onRateChange,
+                    onSubjectChange = vm::onSubjectChange,
+                    onGradeChange = vm::onGradeChange,
+                    onNoteChange = vm::onNoteChange,
+                    onArchivedChange = vm::onArchivedChange,
+                    onActiveChange = vm::onActiveChange,
+                    onSave = attemptSave,
+                    modifier = Modifier.fillMaxWidth(),
+                    editTarget = vm.editTarget,
+                    initialFocus = vm.editTarget,
+                )
 
-            SnackbarHost(
-                hostState = snackbarHostState,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = 24.dp, vertical = 12.dp)
-            )
+                SnackbarHost(
+                    hostState = snackbarHostState,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 24.dp, vertical = 12.dp)
+                )
+            }
         }
     }
 }

--- a/app/src/main/java/com/tutorly/ui/screens/StudentEditorScreen.kt
+++ b/app/src/main/java/com/tutorly/ui/screens/StudentEditorScreen.kt
@@ -4,7 +4,6 @@ import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.BottomSheetDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.SnackbarHost
@@ -231,7 +230,6 @@ fun StudentEditorDialog(
             }
         },
         sheetState = sheetState,
-        dragHandle = { BottomSheetDefaults.DragHandle() },
         containerColor = Color.Transparent,
         contentColor = Color.Unspecified,
         scrimColor = Color.Black.copy(alpha = 0.32f),

--- a/app/src/main/java/com/tutorly/ui/screens/StudentPrepaymentSheet.kt
+++ b/app/src/main/java/com/tutorly/ui/screens/StudentPrepaymentSheet.kt
@@ -38,6 +38,7 @@ import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.tutorly.R
+import com.tutorly.ui.components.TutorlyBottomSheetContainer
 import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -107,18 +108,20 @@ fun StudentPrepaymentSheet(
         },
         sheetState = sheetState,
         dragHandle = { BottomSheetDefaults.DragHandle() },
-        containerColor = MaterialTheme.colorScheme.surface,
+        containerColor = Color.Transparent,
+        contentColor = Color.Unspecified,
         scrimColor = Color.Black.copy(alpha = 0.32f),
     ) {
-        Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .navigationBarsPadding()
-                .imePadding()
-                .padding(horizontal = 24.dp, vertical = 16.dp)
-                .heightIn(max = 480.dp),
-            verticalArrangement = Arrangement.spacedBy(20.dp)
-        ) {
+        TutorlyBottomSheetContainer {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .navigationBarsPadding()
+                    .imePadding()
+                    .padding(horizontal = 24.dp, vertical = 16.dp)
+                    .heightIn(max = 480.dp),
+                verticalArrangement = Arrangement.spacedBy(20.dp)
+            ) {
             Text(
                 text = stringResource(id = R.string.student_prepayment_title),
                 style = MaterialTheme.typography.titleLarge
@@ -177,6 +180,7 @@ fun StudentPrepaymentSheet(
                     .fillMaxWidth()
                     .padding(vertical = 4.dp)
             )
+            }
         }
     }
 }

--- a/app/src/main/java/com/tutorly/ui/screens/StudentPrepaymentSheet.kt
+++ b/app/src/main/java/com/tutorly/ui/screens/StudentPrepaymentSheet.kt
@@ -10,9 +10,13 @@ import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.AttachMoney
+import androidx.compose.material.icons.filled.Description
 import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.SnackbarHost
@@ -132,6 +136,9 @@ fun StudentPrepaymentSheet(
                 modifier = Modifier
                     .fillMaxWidth()
                     .focusRequester(amountFocusRequester),
+                leadingIcon = {
+                    Icon(imageVector = Icons.Filled.AttachMoney, contentDescription = null)
+                },
                 keyboardOptions = KeyboardOptions(
                     keyboardType = KeyboardType.Decimal,
                     imeAction = ImeAction.Next
@@ -151,6 +158,9 @@ fun StudentPrepaymentSheet(
                 onValueChange = vm::onNoteChange,
                 label = { Text(text = stringResource(id = R.string.student_prepayment_note_label)) },
                 modifier = Modifier.fillMaxWidth(),
+                leadingIcon = {
+                    Icon(imageVector = Icons.Filled.Description, contentDescription = null)
+                },
                 keyboardOptions = KeyboardOptions.Default.copy(imeAction = ImeAction.Done),
                 keyboardActions = KeyboardActions(onDone = { attemptSave() }),
                 enabled = !state.isSaving,

--- a/app/src/main/java/com/tutorly/ui/screens/StudentPrepaymentSheet.kt
+++ b/app/src/main/java/com/tutorly/ui/screens/StudentPrepaymentSheet.kt
@@ -11,8 +11,8 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.AttachMoney
 import androidx.compose.material.icons.filled.Description
+import androidx.compose.material.icons.outlined.CurrencyRuble
 import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -137,7 +137,7 @@ fun StudentPrepaymentSheet(
                     .fillMaxWidth()
                     .focusRequester(amountFocusRequester),
                 leadingIcon = {
-                    Icon(imageVector = Icons.Filled.AttachMoney, contentDescription = null)
+                    Icon(imageVector = Icons.Outlined.CurrencyRuble, contentDescription = null)
                 },
                 keyboardOptions = KeyboardOptions(
                     keyboardType = KeyboardType.Decimal,

--- a/app/src/main/java/com/tutorly/ui/screens/StudentPrepaymentSheet.kt
+++ b/app/src/main/java/com/tutorly/ui/screens/StudentPrepaymentSheet.kt
@@ -10,7 +10,6 @@ import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.text.KeyboardActions
-import androidx.compose.material3.BottomSheetDefaults
 import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -107,7 +106,6 @@ fun StudentPrepaymentSheet(
             }
         },
         sheetState = sheetState,
-        dragHandle = { BottomSheetDefaults.DragHandle() },
         containerColor = Color.Transparent,
         contentColor = Color.Unspecified,
         scrimColor = Color.Black.copy(alpha = 0.32f),

--- a/app/src/main/java/com/tutorly/ui/screens/StudentPrepaymentViewModel.kt
+++ b/app/src/main/java/com/tutorly/ui/screens/StudentPrepaymentViewModel.kt
@@ -51,7 +51,7 @@ class StudentPrepaymentViewModel @Inject constructor(
         if (formState.isSaving) return
 
         val parsedAmount = parseMoneyInput(formState.amount)
-        if (parsedAmount == null || parsedAmount <= 0) {
+        if (parsedAmount == null || parsedAmount == 0) {
             formState = formState.copy(amountError = true)
             return
         }
@@ -74,7 +74,10 @@ class StudentPrepaymentViewModel @Inject constructor(
                 status = PaymentStatus.PAID,
             )
 
-            runCatching { paymentsRepository.insert(payment) }
+            runCatching {
+                paymentsRepository.insert(payment)
+                paymentsRepository.applyPrepayment(studentId)
+            }
                 .onSuccess {
                     formState = StudentPrepaymentFormState()
                     onSuccess(parsedAmount)

--- a/app/src/main/java/com/tutorly/ui/screens/StudentsScreen.kt
+++ b/app/src/main/java/com/tutorly/ui/screens/StudentsScreen.kt
@@ -61,7 +61,6 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.Dp
 import androidx.hilt.navigation.compose.hiltViewModel
-import androidx.compose.material3.BottomSheetDefaults
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
@@ -206,7 +205,6 @@ fun StudentsScreen(
                 }
             },
             sheetState = editorSheetState,
-            dragHandle = { BottomSheetDefaults.DragHandle() },
             containerColor = Color.Transparent,
             contentColor = Color.Unspecified,
             scrimColor = Color.Black.copy(alpha = 0.32f),

--- a/app/src/main/java/com/tutorly/ui/screens/StudentsScreen.kt
+++ b/app/src/main/java/com/tutorly/ui/screens/StudentsScreen.kt
@@ -52,6 +52,7 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
@@ -67,6 +68,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import com.tutorly.R
 import com.tutorly.ui.components.PaymentBadge
+import com.tutorly.ui.components.TutorlyBottomSheetContainer
 import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -204,21 +206,26 @@ fun StudentsScreen(
                 }
             },
             sheetState = editorSheetState,
-            dragHandle = { BottomSheetDefaults.DragHandle() }
+            dragHandle = { BottomSheetDefaults.DragHandle() },
+            containerColor = Color.Transparent,
+            contentColor = Color.Unspecified,
+            scrimColor = Color.Black.copy(alpha = 0.32f),
         ) {
-            StudentEditorSheet(
-                state = formState,
-                onNameChange = vm::onEditorNameChange,
-                onPhoneChange = vm::onEditorPhoneChange,
-                onMessengerChange = vm::onEditorMessengerChange,
-                onRateChange = vm::onEditorRateChange,
-                onSubjectChange = vm::onEditorSubjectChange,
-                onGradeChange = vm::onEditorGradeChange,
-                onNoteChange = vm::onEditorNoteChange,
-                onArchivedChange = vm::onEditorArchivedChange,
-                onActiveChange = vm::onEditorActiveChange,
-                onSave = handleSave
-            )
+            TutorlyBottomSheetContainer {
+                StudentEditorSheet(
+                    state = formState,
+                    onNameChange = vm::onEditorNameChange,
+                    onPhoneChange = vm::onEditorPhoneChange,
+                    onMessengerChange = vm::onEditorMessengerChange,
+                    onRateChange = vm::onEditorRateChange,
+                    onSubjectChange = vm::onEditorSubjectChange,
+                    onGradeChange = vm::onEditorGradeChange,
+                    onNoteChange = vm::onEditorNoteChange,
+                    onArchivedChange = vm::onEditorArchivedChange,
+                    onActiveChange = vm::onEditorActiveChange,
+                    onSave = handleSave
+                )
+            }
         }
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -43,7 +43,6 @@
     <string name="student_profile_contact_call">Позвонить</string>
     <string name="student_profile_contact_message">Написать</string>
     <string name="student_profile_contact_placeholder">Не указано</string>
-    <string name="student_profile_metrics_title">Показатели</string>
     <string name="student_profile_metrics_average">Средняя ставка</string>
     <string name="student_profile_close">Закрыть профиль ученика</string>
     <string name="student_profile_metrics_lessons_label">занятий</string>
@@ -51,13 +50,13 @@
     <string name="student_profile_metrics_earned_label">₽ дохода</string>
     <string name="student_profile_metrics_prepayment_label">₽ предоплата</string>
     <string name="student_profile_add_prepayment">Добавить предоплату</string>
-    <string name="student_prepayment_title">Добавить предоплату</string>
+    <string name="student_prepayment_title">Редактировать предоплату</string>
     <string name="student_prepayment_amount_label">Сумма</string>
-    <string name="student_prepayment_amount_error">Введите сумму больше нуля</string>
+    <string name="student_prepayment_amount_error">Введите ненулевую сумму</string>
     <string name="student_prepayment_note_label">Комментарий (необязательно)</string>
     <string name="student_prepayment_save">Сохранить</string>
     <string name="student_prepayment_error">Не удалось сохранить предоплату</string>
-    <string name="student_prepayment_success">Предоплата %1$s ₽ сохранена</string>
+    <string name="student_prepayment_success">Предоплата изменена на %1$s ₽</string>
     <string name="student_details_title_placeholder">Ученик</string>
     <string name="student_details_back">Назад</string>
     <string name="student_details_edit">Редактировать ученика</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -17,7 +17,7 @@
     <string name="student_editor_title">Ученик</string>
     <string name="student_editor_edit_title">Редактировать ученика</string>
     <string name="student_editor_close">Закрыть</string>
-    <string name="student_editor_save">Сохранить ученика</string>
+    <string name="student_editor_save">Сохранить</string>
     <string name="student_editor_name">Имя*</string>
     <string name="student_editor_name_required">Имя обязательно</string>
     <string name="student_editor_phone">Телефон</string>
@@ -54,7 +54,7 @@
     <string name="student_prepayment_amount_label">Сумма</string>
     <string name="student_prepayment_amount_error">Введите сумму больше нуля</string>
     <string name="student_prepayment_note_label">Комментарий (необязательно)</string>
-    <string name="student_prepayment_save">Сохранить предоплату</string>
+    <string name="student_prepayment_save">Сохранить</string>
     <string name="student_prepayment_error">Не удалось сохранить предоплату</string>
     <string name="student_prepayment_success">Предоплата %1$s ₽ сохранена</string>
     <string name="student_details_title_placeholder">Ученик</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -49,6 +49,7 @@
     <string name="student_profile_metrics_lessons_label">занятий</string>
     <string name="student_profile_metrics_rate_label">₽/час</string>
     <string name="student_profile_metrics_earned_label">₽ дохода</string>
+    <string name="student_profile_metrics_prepayment_label">₽ предоплата</string>
     <string name="student_profile_add_prepayment">Добавить предоплату</string>
     <string name="student_prepayment_title">Добавить предоплату</string>
     <string name="student_prepayment_amount_label">Сумма</string>


### PR DESCRIPTION
## Summary
- add a reusable TutorlyBottomSheetContainer surface wrapper to maintain sheet styling with a transparent modal background
- update student editor, prepayment, lesson creation, and lesson card sheets to use the new container and prevent the white flash when opening bottom sheets

## Testing
- ./gradlew :app:lint *(fails: Android SDK is not available in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ec0fb4aea8832099dd3d75fb3fa706