### PR TITLE
Refine student profile editors

### DIFF
--- a/app/src/main/java/com/tutorly/data/db/projections/LessonWithStudent.kt
+++ b/app/src/main/java/com/tutorly/data/db/projections/LessonWithStudent.kt
@@ -73,6 +73,7 @@ fun LessonWithStudent.toLessonForToday(): LessonForToday {
         id = lesson.id,
         studentId = lesson.studentId,
         studentName = student.name,
+        studentGrade = student.grade,
         subjectName = subjectName,
         lessonTitle = lesson.title,
         startAt = lesson.startAt,

--- a/app/src/main/java/com/tutorly/data/repo/memory/InMemoryLessonsRepository.kt
+++ b/app/src/main/java/com/tutorly/data/repo/memory/InMemoryLessonsRepository.kt
@@ -226,6 +226,7 @@ private fun Lesson.toTodayStub(): LessonForToday {
         id = id,
         studentId = studentId,
         studentName = "Student #$studentId",
+        studentGrade = null,
         subjectName = null,
         lessonTitle = title,
         startAt = startAt,

--- a/app/src/main/java/com/tutorly/domain/model/LessonForToday.kt
+++ b/app/src/main/java/com/tutorly/domain/model/LessonForToday.kt
@@ -12,6 +12,7 @@ data class LessonForToday(
     val id: Long,
     val studentId: Long,
     val studentName: String,
+    val studentGrade: String?,
     val subjectName: String?,
     val lessonTitle: String?,
     val startAt: Instant,

--- a/app/src/main/java/com/tutorly/navigation/AppNav.kt
+++ b/app/src/main/java/com/tutorly/navigation/AppNav.kt
@@ -95,7 +95,7 @@ fun AppNavRoot() {
                 }
             )
         },
-        containerColor = MaterialTheme.colorScheme.surface,
+        containerColor = MaterialTheme.colorScheme.surfaceContainerHighest,
         // чтобы контент корректно учитывал статус/навигационные панели
         contentWindowInsets = WindowInsets.systemBars
     ) { innerPadding ->

--- a/app/src/main/java/com/tutorly/ui/components/AppBottomBar.kt
+++ b/app/src/main/java/com/tutorly/ui/components/AppBottomBar.kt
@@ -14,6 +14,7 @@ import com.tutorly.navigation.ROUTE_CALENDAR
 import com.tutorly.navigation.ROUTE_FINANCE
 import com.tutorly.navigation.ROUTE_STUDENTS
 import com.tutorly.navigation.ROUTE_TODAY
+import androidx.compose.ui.graphics.Color
 
 enum class Tab(val route:String, val label:String, val icon: androidx.compose.ui.graphics.vector.ImageVector){
     Calendar(ROUTE_CALENDAR, "Календарь", Icons.Outlined.CalendarMonth),
@@ -25,7 +26,7 @@ enum class Tab(val route:String, val label:String, val icon: androidx.compose.ui
 @Composable
 fun AppBottomBar(currentRoute: String, onSelect:(String)->Unit) {
     NavigationBar(
-        containerColor = MaterialTheme.colorScheme.surface,
+        containerColor = Color.White,
         tonalElevation = NavigationBarDefaults.Elevation
     ) {
         Tab.entries.forEach { tab ->

--- a/app/src/main/java/com/tutorly/ui/components/TopBar.kt
+++ b/app/src/main/java/com/tutorly/ui/components/TopBar.kt
@@ -28,7 +28,7 @@ fun AppTopBar(title: String, onAddClick: (() -> Unit)? = null) {
             )
         },
         colors = TopAppBarDefaults.topAppBarColors(
-            containerColor = MaterialTheme.colorScheme.surface,
+            containerColor = MaterialTheme.colorScheme.surfaceContainerHighest,
             titleContentColor = MaterialTheme.colorScheme.onSurface
         ),
         actions = {

--- a/app/src/main/java/com/tutorly/ui/components/TutorlyBottomSheetContainer.kt
+++ b/app/src/main/java/com/tutorly/ui/components/TutorlyBottomSheetContainer.kt
@@ -6,7 +6,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.BottomSheetDefaults
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -23,7 +22,7 @@ import androidx.compose.ui.unit.dp
 @Composable
 fun TutorlyBottomSheetContainer(
     modifier: Modifier = Modifier,
-    color: Color = MaterialTheme.colorScheme.surface,
+    color: Color = Color.White,
     tonalElevation: Dp = 0.dp,
     shape: Shape = RoundedCornerShape(topStart = 28.dp, topEnd = 28.dp),
     dragHandle: @Composable (() -> Unit)? = { BottomSheetDefaults.DragHandle() },

--- a/app/src/main/java/com/tutorly/ui/lessoncard/LessonCardSheet.kt
+++ b/app/src/main/java/com/tutorly/ui/lessoncard/LessonCardSheet.kt
@@ -27,6 +27,7 @@ import androidx.compose.material.icons.outlined.Schedule
 import androidx.compose.material.icons.outlined.Timelapse
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Card
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
@@ -72,6 +73,7 @@ import java.time.format.DateTimeFormatter
 import java.util.Locale
 import kotlinx.coroutines.launch
 import com.tutorly.ui.components.TutorlyBottomSheetContainer
+import com.tutorly.ui.theme.TutorlyCardDefaults
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -399,13 +401,12 @@ private fun DateRow(
     dateText: String,
     onClick: () -> Unit,
 ) {
-    Surface(
-        modifier = Modifier
-            .fillMaxWidth()
-            .clickable(onClick = onClick),
+    Card(
+        onClick = onClick,
+        modifier = Modifier.fillMaxWidth(),
         shape = RoundedCornerShape(20.dp),
-        tonalElevation = 1.dp,
-        color = MaterialTheme.colorScheme.surfaceVariant
+        colors = TutorlyCardDefaults.colors(),
+        elevation = TutorlyCardDefaults.elevation()
     ) {
         Row(
             modifier = Modifier
@@ -472,11 +473,12 @@ private fun TimeCard(
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    Surface(
-        modifier = modifier.clickable(onClick = onClick),
+    Card(
+        onClick = onClick,
+        modifier = modifier,
         shape = RoundedCornerShape(20.dp),
-        tonalElevation = 1.dp,
-        color = MaterialTheme.colorScheme.surfaceVariant
+        colors = TutorlyCardDefaults.colors(),
+        elevation = TutorlyCardDefaults.elevation()
     ) {
         Column(
             modifier = Modifier
@@ -590,13 +592,12 @@ private fun NoteRow(
     note: String?,
     onClick: () -> Unit,
 ) {
-    Surface(
-        modifier = Modifier
-            .fillMaxWidth()
-            .clickable(onClick = onClick),
+    Card(
+        onClick = onClick,
+        modifier = Modifier.fillMaxWidth(),
         shape = RoundedCornerShape(20.dp),
-        tonalElevation = 1.dp,
-        color = MaterialTheme.colorScheme.surfaceVariant
+        colors = TutorlyCardDefaults.colors(),
+        elevation = TutorlyCardDefaults.elevation()
     ) {
         Column(
             modifier = Modifier

--- a/app/src/main/java/com/tutorly/ui/screens/CalendarScreen.kt
+++ b/app/src/main/java/com/tutorly/ui/screens/CalendarScreen.kt
@@ -50,6 +50,7 @@ import com.tutorly.ui.components.StatusChipData
 import com.tutorly.ui.components.WeekMosaic
 import com.tutorly.ui.components.statusChipData
 import com.tutorly.ui.theme.NowRed
+import com.tutorly.ui.theme.RailBlue
 import com.tutorly.ui.theme.TutorlyCardDefaults
 import com.tutorly.ui.lessoncreation.LessonCreationConfig
 import com.tutorly.ui.lessoncreation.LessonCreationOrigin
@@ -442,8 +443,7 @@ fun PlanScreenHeader(
 
 /* --------------------------- DAY TIMELINE -------------------------------- */
 
-private val GridColor = Color(0xFFE9F0FF)
-private val SpineColor = Color(0xFF2D7FF9).copy(alpha = 0.6f)
+private val SpineColor = RailBlue.copy(alpha = 0.6f)
 private val LabelWidth = 64.dp
 private val HourHeight = 64.dp
 private val DefaultSlotDuration: Duration = Duration.ofMinutes(60)
@@ -538,6 +538,7 @@ private fun DayTimeline(
                 }
         ) {
             // 1) Сетка фоном
+            val gridLineColor = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.08f)
             Canvas(Modifier.matchParentSize()) {
                 val rowH = HourHeight.toPx()
                 val leftPad = LabelWidth.toPx()
@@ -546,7 +547,7 @@ private fun DayTimeline(
                 repeat(hours.size + 1) { i ->
                     val y = i * rowH
                     drawLine(
-                        color = GridColor,
+                        color = gridLineColor,
                         start = androidx.compose.ui.geometry.Offset(0f, y),
                         end = androidx.compose.ui.geometry.Offset(size.width, y),
                         strokeWidth = 1.dp.toPx()
@@ -942,13 +943,22 @@ private fun DayTwoLineChip(
     onClick: () -> Unit,
     modifier: Modifier = Modifier
 ) {
-    val bg = if (selected) Color(0x1A2D7FF9) else Color(0xFFF2F3F7)
-    val fg = if (selected) Color(0xFF2D7FF9) else MaterialTheme.colorScheme.onSurface.copy(alpha = 0.8f)
+    val background = if (selected) {
+        MaterialTheme.colorScheme.surfaceContainerHighest
+    } else {
+        MaterialTheme.colorScheme.surfaceContainerLow
+    }
+    val foreground = if (selected) {
+        MaterialTheme.colorScheme.onSurface
+    } else {
+        MaterialTheme.colorScheme.onSurfaceVariant
+    }
     Surface(
-        color = bg,
+        color = background,
         shape = MaterialTheme.shapes.medium,
         onClick = onClick,
-        modifier = modifier
+        modifier = modifier,
+        shadowElevation = if (selected) 6.dp else 4.dp
     ) {
         Column(
             Modifier
@@ -961,12 +971,12 @@ private fun DayTwoLineChip(
                 date.dayOfWeek.getDisplayName(TextStyle.SHORT, Locale("ru"))
                     .replaceFirstChar { it.titlecase(Locale("ru")) },
                 style = MaterialTheme.typography.labelSmall,
-                color = fg
+                color = foreground
             )
             Text(
                 "${date.dayOfMonth}",
                 style = MaterialTheme.typography.labelLarge,
-                color = fg
+                color = foreground
             )
         }
     }

--- a/app/src/main/java/com/tutorly/ui/screens/CalendarScreen.kt
+++ b/app/src/main/java/com/tutorly/ui/screens/CalendarScreen.kt
@@ -215,7 +215,8 @@ fun CalendarScreen(
             }) {
                 Icon(Icons.Filled.Add, contentDescription = null)
             }
-        }
+        },
+        containerColor = MaterialTheme.colorScheme.surfaceContainerHighest
     ) { padding ->
         Column(
             Modifier

--- a/app/src/main/java/com/tutorly/ui/screens/CalendarScreen.kt
+++ b/app/src/main/java/com/tutorly/ui/screens/CalendarScreen.kt
@@ -50,6 +50,7 @@ import com.tutorly.ui.components.StatusChipData
 import com.tutorly.ui.components.WeekMosaic
 import com.tutorly.ui.components.statusChipData
 import com.tutorly.ui.theme.NowRed
+import com.tutorly.ui.theme.TutorlyCardDefaults
 import com.tutorly.ui.lessoncreation.LessonCreationConfig
 import com.tutorly.ui.lessoncreation.LessonCreationOrigin
 import com.tutorly.ui.lessoncreation.LessonCreationSheet
@@ -660,6 +661,7 @@ private fun LessonBlock(
             colors = CardDefaults.cardColors(
                 containerColor = containerColor
             ),
+            elevation = TutorlyCardDefaults.elevation(),
             modifier = Modifier.fillMaxSize()
         ) {
             Column(

--- a/app/src/main/java/com/tutorly/ui/screens/FinanceScreen.kt
+++ b/app/src/main/java/com/tutorly/ui/screens/FinanceScreen.kt
@@ -1,6 +1,22 @@
 package com.tutorly.ui.screens
 
-import androidx.compose.runtime.Composable
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
 
-@Composable fun FinanceScreen() { Text("Финансы: доход/долги") }
+@Composable
+fun FinanceScreen(modifier: Modifier = Modifier) {
+    Box(
+        modifier = modifier
+            .fillMaxSize()
+            .background(MaterialTheme.colorScheme.surfaceContainerHighest),
+        contentAlignment = Alignment.Center
+    ) {
+        Text("Финансы: доход/долги")
+    }
+}

--- a/app/src/main/java/com/tutorly/ui/screens/StudentDetailsScreen.kt
+++ b/app/src/main/java/com/tutorly/ui/screens/StudentDetailsScreen.kt
@@ -260,7 +260,7 @@ private fun StudentProfileTopBar(
             }
         },
         colors = TopAppBarDefaults.topAppBarColors(
-            containerColor = MaterialTheme.colorScheme.surface,
+            containerColor = MaterialTheme.colorScheme.surfaceContainerHighest,
             titleContentColor = MaterialTheme.colorScheme.onSurface
         )
     )

--- a/app/src/main/java/com/tutorly/ui/screens/StudentDetailsScreen.kt
+++ b/app/src/main/java/com/tutorly/ui/screens/StudentDetailsScreen.kt
@@ -29,7 +29,6 @@ import androidx.compose.material.icons.outlined.Schedule
 import androidx.compose.material.icons.outlined.StickyNote2
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
-import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FloatingActionButton
@@ -40,7 +39,6 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
-import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
@@ -74,6 +72,7 @@ import com.tutorly.ui.lessoncreation.LessonCreationConfig
 import com.tutorly.ui.lessoncreation.LessonCreationOrigin
 import com.tutorly.ui.lessoncreation.LessonCreationSheet
 import com.tutorly.ui.lessoncreation.LessonCreationViewModel
+import com.tutorly.ui.theme.TutorlyCardDefaults
 import java.text.NumberFormat
 import java.time.ZoneId
 import java.time.ZonedDateTime
@@ -397,8 +396,8 @@ private fun StudentProfileHeader(
             .fillMaxWidth()
             .clickable { onEdit(StudentEditTarget.PROFILE) },
         shape = MaterialTheme.shapes.extraLarge,
-        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
-        elevation = CardDefaults.cardElevation(defaultElevation = 6.dp)
+        colors = TutorlyCardDefaults.colors(),
+        elevation = TutorlyCardDefaults.elevation()
     ) {
         Row(
             modifier = Modifier
@@ -442,14 +441,12 @@ private fun ProfileInfoCard(
     val displayValue = value?.takeIf { it.isNotBlank() }
         ?: stringResource(id = R.string.student_profile_contact_placeholder)
 
-    Surface(
-        modifier = modifier
-            .fillMaxWidth()
-            .clip(MaterialTheme.shapes.large)
-            .clickable { onClick() },
-        color = MaterialTheme.colorScheme.surface,
-        tonalElevation = 0.dp,
-        shadowElevation = 4.dp
+    Card(
+        onClick = onClick,
+        modifier = modifier.fillMaxWidth(),
+        shape = MaterialTheme.shapes.large,
+        colors = TutorlyCardDefaults.colors(),
+        elevation = TutorlyCardDefaults.elevation()
     ) {
         Row(
             modifier = Modifier
@@ -557,22 +554,8 @@ private fun ProfileMetricTile(
     modifier: Modifier = Modifier,
     onClick: (() -> Unit)? = null
 ) {
-    val tileModifier = if (onClick != null) {
-        modifier
-            .fillMaxWidth()
-            .clip(MaterialTheme.shapes.large)
-            .clickable(onClick = onClick)
-    } else {
-        modifier.fillMaxWidth()
-    }
-
-    Surface(
-        modifier = tileModifier,
-        shape = MaterialTheme.shapes.large,
-        color = MaterialTheme.colorScheme.surface,
-        tonalElevation = 0.dp,
-        shadowElevation = 4.dp
-    ) {
+    val cardModifier = modifier.fillMaxWidth()
+    val content: @Composable () -> Unit = {
         Column(
             modifier = Modifier
                 .fillMaxWidth()
@@ -601,6 +584,22 @@ private fun ProfileMetricTile(
             )
         }
     }
+    if (onClick != null) {
+        Card(
+            onClick = onClick,
+            modifier = cardModifier,
+            shape = MaterialTheme.shapes.large,
+            colors = TutorlyCardDefaults.colors(),
+            elevation = TutorlyCardDefaults.elevation()
+        ) { content() }
+    } else {
+        Card(
+            modifier = cardModifier,
+            shape = MaterialTheme.shapes.large,
+            colors = TutorlyCardDefaults.colors(),
+            elevation = TutorlyCardDefaults.elevation()
+        ) { content() }
+    }
 }
 
 @Composable
@@ -611,13 +610,12 @@ private fun ProfileContactsCard(
     onMessengerClick: () -> Unit,
     modifier: Modifier = Modifier
 ) {
-    Surface(
+    Card(
         modifier = modifier
-            .fillMaxWidth()
-            .clip(MaterialTheme.shapes.large),
-        color = MaterialTheme.colorScheme.surface,
-        tonalElevation = 0.dp,
-        shadowElevation = 4.dp
+            .fillMaxWidth(),
+        shape = MaterialTheme.shapes.large,
+        colors = TutorlyCardDefaults.colors(),
+        elevation = TutorlyCardDefaults.elevation()
     ) {
         Column(
             modifier = Modifier.fillMaxWidth()
@@ -695,12 +693,11 @@ private fun StudentProfileEmptyHistory(
     onAddLesson: () -> Unit,
     modifier: Modifier = Modifier
 ) {
-    Surface(
+    Card(
         modifier = modifier.fillMaxWidth(),
         shape = MaterialTheme.shapes.large,
-        tonalElevation = 0.dp,
-        shadowElevation = 4.dp,
-        color = MaterialTheme.colorScheme.surface
+        colors = TutorlyCardDefaults.colors(),
+        elevation = TutorlyCardDefaults.elevation()
     ) {
         Column(
             modifier = Modifier
@@ -750,14 +747,12 @@ private fun StudentProfileLessonCard(
     val amount = currencyFormatter.format(lesson.priceCents / 100.0)
     val isPaid = lesson.paymentStatus == PaymentStatus.PAID
 
-    Surface(
-        modifier = modifier
-            .fillMaxWidth()
-            .clickable { onClick() },
+    Card(
+        onClick = onClick,
+        modifier = modifier.fillMaxWidth(),
         shape = MaterialTheme.shapes.large,
-        tonalElevation = 0.dp,
-        shadowElevation = 4.dp,
-        color = MaterialTheme.colorScheme.surface
+        colors = TutorlyCardDefaults.colors(),
+        elevation = TutorlyCardDefaults.elevation()
     ) {
         Column(
             modifier = Modifier.padding(horizontal = 16.dp, vertical = 16.dp),

--- a/app/src/main/java/com/tutorly/ui/screens/StudentEditorScreen.kt
+++ b/app/src/main/java/com/tutorly/ui/screens/StudentEditorScreen.kt
@@ -1,27 +1,14 @@
 package com.tutorly.ui.screens
 
 import androidx.activity.compose.BackHandler
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.layout.widthIn
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.rememberModalBottomSheetState
-import androidx.compose.material3.BasicAlertDialog
-import androidx.compose.material3.Button
-import androidx.compose.material3.CircularProgressIndicator
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Surface
-import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -29,10 +16,8 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.SavedStateHandle
@@ -207,19 +192,14 @@ fun StudentEditorDialog(
     val snackbarHostState = remember { SnackbarHostState() }
     val context = LocalContext.current
 
-    val currentEditTarget by androidx.compose.runtime.rememberUpdatedState(editTarget)
     val currentOnDismiss by androidx.compose.runtime.rememberUpdatedState(onDismiss)
     val currentOnSaved by androidx.compose.runtime.rememberUpdatedState(onSaved)
 
     fun closeEditor(action: () -> Unit) {
-        if (currentEditTarget == null) {
-            if (sheetState.isVisible) {
-                coroutineScope.launch {
-                    sheetState.hide()
-                }.invokeOnCompletion { action() }
-            } else {
-                action()
-            }
+        if (sheetState.isVisible) {
+            coroutineScope.launch {
+                sheetState.hide()
+            }.invokeOnCompletion { action() }
         } else {
             action()
         }
@@ -249,131 +229,42 @@ fun StudentEditorDialog(
         }
     }
 
-    if (editTarget == null) {
-        ModalBottomSheet(
-            onDismissRequest = {
-                if (!formState.isSaving) {
-                    closeEditor(currentOnDismiss)
-                }
-            },
-            sheetState = sheetState,
-            containerColor = Color.Transparent,
-            contentColor = Color.Unspecified,
-            scrimColor = Color.Black.copy(alpha = 0.32f),
-        ) {
-            TutorlyBottomSheetContainer {
-                Column(modifier = Modifier.fillMaxWidth()) {
-                    StudentEditorSheet(
-                        state = formState,
-                        onNameChange = vm::onNameChange,
-                        onPhoneChange = vm::onPhoneChange,
-                        onMessengerChange = vm::onMessengerChange,
-                        onRateChange = vm::onRateChange,
-                        onSubjectChange = vm::onSubjectChange,
-                        onGradeChange = vm::onGradeChange,
-                        onNoteChange = vm::onNoteChange,
-                        onArchivedChange = vm::onArchivedChange,
-                        onActiveChange = vm::onActiveChange,
-                        onSave = attemptSave,
-                        modifier = Modifier.fillMaxWidth(),
-                        editTarget = editTarget,
-                        initialFocus = editTarget,
-                    )
+    ModalBottomSheet(
+        onDismissRequest = {
+            if (!formState.isSaving) {
+                closeEditor(currentOnDismiss)
+            }
+        },
+        sheetState = sheetState,
+        containerColor = Color.Transparent,
+        contentColor = Color.Unspecified,
+        scrimColor = Color.Black.copy(alpha = 0.32f),
+    ) {
+        TutorlyBottomSheetContainer {
+            Column(modifier = Modifier.fillMaxWidth()) {
+                StudentEditorSheet(
+                    state = formState,
+                    onNameChange = vm::onNameChange,
+                    onPhoneChange = vm::onPhoneChange,
+                    onMessengerChange = vm::onMessengerChange,
+                    onRateChange = vm::onRateChange,
+                    onSubjectChange = vm::onSubjectChange,
+                    onGradeChange = vm::onGradeChange,
+                    onNoteChange = vm::onNoteChange,
+                    onArchivedChange = vm::onArchivedChange,
+                    onActiveChange = vm::onActiveChange,
+                    onSave = attemptSave,
+                    modifier = Modifier.fillMaxWidth(),
+                    editTarget = editTarget,
+                    initialFocus = editTarget,
+                )
 
-                    SnackbarHost(
-                        hostState = snackbarHostState,
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(horizontal = 24.dp, vertical = 12.dp)
-                    )
-                }
-            }
-        }
-    } else {
-        BasicAlertDialog(
-            onDismissRequest = {
-                if (!formState.isSaving) {
-                    closeEditor(currentOnDismiss)
-                }
-            }
-        ) {
-            Surface(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = 24.dp),
-                shape = MaterialTheme.shapes.extraLarge,
-                tonalElevation = 6.dp
-            ) {
-                Column(
+                SnackbarHost(
+                    hostState = snackbarHostState,
                     modifier = Modifier
-                        .widthIn(max = 360.dp)
-                        .padding(horizontal = 24.dp, vertical = 20.dp),
-                    verticalArrangement = Arrangement.spacedBy(16.dp)
-                ) {
-                    Text(
-                        text = when (editTarget) {
-                            StudentEditTarget.PROFILE -> stringResource(id = R.string.student_editor_profile_title)
-                            StudentEditTarget.RATE -> stringResource(id = R.string.student_editor_rate_title)
-                            StudentEditTarget.PHONE -> stringResource(id = R.string.student_editor_phone_title)
-                            StudentEditTarget.MESSENGER -> stringResource(id = R.string.student_editor_messenger_title)
-                            StudentEditTarget.NOTES -> stringResource(id = R.string.student_editor_notes_title)
-                        },
-                        style = MaterialTheme.typography.titleLarge
-                    )
-
-                    StudentEditorForm(
-                        state = formState,
-                        onNameChange = vm::onNameChange,
-                        onPhoneChange = vm::onPhoneChange,
-                        onMessengerChange = vm::onMessengerChange,
-                        onRateChange = vm::onRateChange,
-                        onSubjectChange = vm::onSubjectChange,
-                        onGradeChange = vm::onGradeChange,
-                        onNoteChange = vm::onNoteChange,
-                        onArchivedChange = vm::onArchivedChange,
-                        onActiveChange = vm::onActiveChange,
-                        modifier = Modifier.fillMaxWidth(),
-                        editTarget = editTarget,
-                        initialFocus = editTarget,
-                        enableScrolling = false,
-                        enabled = !formState.isSaving,
-                        onSubmit = attemptSave
-                    )
-
-                    if (snackbarHostState.currentSnackbarData != null) {
-                        SnackbarHost(
-                            hostState = snackbarHostState,
-                            modifier = Modifier.fillMaxWidth()
-                        )
-                    }
-
-                    Row(
-                        modifier = Modifier.fillMaxWidth(),
-                        horizontalArrangement = Arrangement.End,
-                        verticalAlignment = Alignment.CenterVertically
-                    ) {
-                        TextButton(
-                            onClick = { closeEditor(currentOnDismiss) },
-                            enabled = !formState.isSaving
-                        ) {
-                            Text(text = stringResource(id = R.string.student_editor_cancel))
-                        }
-                        Spacer(modifier = Modifier.width(12.dp))
-                        Button(
-                            onClick = attemptSave,
-                            enabled = !formState.isSaving && formState.name.isNotBlank()
-                        ) {
-                            if (formState.isSaving) {
-                                CircularProgressIndicator(
-                                    modifier = Modifier.size(20.dp),
-                                    strokeWidth = 2.dp
-                                )
-                            } else {
-                                Text(text = stringResource(id = R.string.student_editor_save))
-                            }
-                        }
-                    }
-                }
+                        .fillMaxWidth()
+                        .padding(horizontal = 24.dp, vertical = 12.dp)
+                )
             }
         }
     }

--- a/app/src/main/java/com/tutorly/ui/screens/StudentEditorScreen.kt
+++ b/app/src/main/java/com/tutorly/ui/screens/StudentEditorScreen.kt
@@ -1,12 +1,9 @@
 package com.tutorly.ui.screens
 
 import androidx.activity.compose.BackHandler
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ModalBottomSheet
-import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
@@ -241,31 +238,23 @@ fun StudentEditorDialog(
         scrimColor = Color.Black.copy(alpha = 0.32f),
     ) {
         TutorlyBottomSheetContainer {
-            Column(modifier = Modifier.fillMaxWidth()) {
-                StudentEditorSheet(
-                    state = formState,
-                    onNameChange = vm::onNameChange,
-                    onPhoneChange = vm::onPhoneChange,
-                    onMessengerChange = vm::onMessengerChange,
-                    onRateChange = vm::onRateChange,
-                    onSubjectChange = vm::onSubjectChange,
-                    onGradeChange = vm::onGradeChange,
-                    onNoteChange = vm::onNoteChange,
-                    onArchivedChange = vm::onArchivedChange,
-                    onActiveChange = vm::onActiveChange,
-                    onSave = attemptSave,
-                    modifier = Modifier.fillMaxWidth(),
-                    editTarget = editTarget,
-                    initialFocus = editTarget,
-                )
-
-                SnackbarHost(
-                    hostState = snackbarHostState,
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(horizontal = 24.dp, vertical = 12.dp)
-                )
-            }
+            StudentEditorSheet(
+                state = formState,
+                onNameChange = vm::onNameChange,
+                onPhoneChange = vm::onPhoneChange,
+                onMessengerChange = vm::onMessengerChange,
+                onRateChange = vm::onRateChange,
+                onSubjectChange = vm::onSubjectChange,
+                onGradeChange = vm::onGradeChange,
+                onNoteChange = vm::onNoteChange,
+                onArchivedChange = vm::onArchivedChange,
+                onActiveChange = vm::onActiveChange,
+                onSave = attemptSave,
+                modifier = Modifier.fillMaxWidth(),
+                editTarget = editTarget,
+                initialFocus = editTarget,
+                snackbarHostState = snackbarHostState
+            )
         }
     }
 }

--- a/app/src/main/java/com/tutorly/ui/screens/StudentEditorScreen.kt
+++ b/app/src/main/java/com/tutorly/ui/screens/StudentEditorScreen.kt
@@ -1,14 +1,27 @@
 package com.tutorly.ui.screens
 
 import androidx.activity.compose.BackHandler
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.material3.BasicAlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -16,8 +29,10 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.SavedStateHandle
@@ -186,30 +201,41 @@ fun StudentEditorDialog(
     vm: StudentEditorVM = hiltViewModel(),
 ) {
     val formState = vm.formState
+    val editTarget = vm.editTarget
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
     val coroutineScope = rememberCoroutineScope()
     val snackbarHostState = remember { SnackbarHostState() }
     val context = LocalContext.current
 
-    fun hideSheetAndThen(action: () -> Unit) {
-        if (sheetState.isVisible) {
-            coroutineScope.launch {
-                sheetState.hide()
-            }.invokeOnCompletion { action() }
+    val currentEditTarget by androidx.compose.runtime.rememberUpdatedState(editTarget)
+    val currentOnDismiss by androidx.compose.runtime.rememberUpdatedState(onDismiss)
+    val currentOnSaved by androidx.compose.runtime.rememberUpdatedState(onSaved)
+
+    fun closeEditor(action: () -> Unit) {
+        if (currentEditTarget == null) {
+            if (sheetState.isVisible) {
+                coroutineScope.launch {
+                    sheetState.hide()
+                }.invokeOnCompletion { action() }
+            } else {
+                action()
+            }
         } else {
             action()
         }
     }
 
     BackHandler(enabled = !formState.isSaving) {
-        hideSheetAndThen(onDismiss)
+        if (!formState.isSaving) {
+            closeEditor(currentOnDismiss)
+        }
     }
 
     val attemptSave: () -> Unit = {
         if (!formState.isSaving) {
             vm.save(
                 onSaved = { id ->
-                    hideSheetAndThen { onSaved(id) }
+                    closeEditor { currentOnSaved(id) }
                 },
                 onError = { message ->
                     val text = if (message.isNotBlank()) {
@@ -223,42 +249,131 @@ fun StudentEditorDialog(
         }
     }
 
-    ModalBottomSheet(
-        onDismissRequest = {
-            if (!formState.isSaving) {
-                hideSheetAndThen(onDismiss)
-            }
-        },
-        sheetState = sheetState,
-        containerColor = Color.Transparent,
-        contentColor = Color.Unspecified,
-        scrimColor = Color.Black.copy(alpha = 0.32f),
-    ) {
-        TutorlyBottomSheetContainer {
-            Column(modifier = Modifier.fillMaxWidth()) {
-                StudentEditorSheet(
-                    state = formState,
-                    onNameChange = vm::onNameChange,
-                    onPhoneChange = vm::onPhoneChange,
-                    onMessengerChange = vm::onMessengerChange,
-                    onRateChange = vm::onRateChange,
-                    onSubjectChange = vm::onSubjectChange,
-                    onGradeChange = vm::onGradeChange,
-                    onNoteChange = vm::onNoteChange,
-                    onArchivedChange = vm::onArchivedChange,
-                    onActiveChange = vm::onActiveChange,
-                    onSave = attemptSave,
-                    modifier = Modifier.fillMaxWidth(),
-                    editTarget = vm.editTarget,
-                    initialFocus = vm.editTarget,
-                )
+    if (editTarget == null) {
+        ModalBottomSheet(
+            onDismissRequest = {
+                if (!formState.isSaving) {
+                    closeEditor(currentOnDismiss)
+                }
+            },
+            sheetState = sheetState,
+            containerColor = Color.Transparent,
+            contentColor = Color.Unspecified,
+            scrimColor = Color.Black.copy(alpha = 0.32f),
+        ) {
+            TutorlyBottomSheetContainer {
+                Column(modifier = Modifier.fillMaxWidth()) {
+                    StudentEditorSheet(
+                        state = formState,
+                        onNameChange = vm::onNameChange,
+                        onPhoneChange = vm::onPhoneChange,
+                        onMessengerChange = vm::onMessengerChange,
+                        onRateChange = vm::onRateChange,
+                        onSubjectChange = vm::onSubjectChange,
+                        onGradeChange = vm::onGradeChange,
+                        onNoteChange = vm::onNoteChange,
+                        onArchivedChange = vm::onArchivedChange,
+                        onActiveChange = vm::onActiveChange,
+                        onSave = attemptSave,
+                        modifier = Modifier.fillMaxWidth(),
+                        editTarget = editTarget,
+                        initialFocus = editTarget,
+                    )
 
-                SnackbarHost(
-                    hostState = snackbarHostState,
+                    SnackbarHost(
+                        hostState = snackbarHostState,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 24.dp, vertical = 12.dp)
+                    )
+                }
+            }
+        }
+    } else {
+        BasicAlertDialog(
+            onDismissRequest = {
+                if (!formState.isSaving) {
+                    closeEditor(currentOnDismiss)
+                }
+            }
+        ) {
+            Surface(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 24.dp),
+                shape = MaterialTheme.shapes.extraLarge,
+                tonalElevation = 6.dp
+            ) {
+                Column(
                     modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(horizontal = 24.dp, vertical = 12.dp)
-                )
+                        .widthIn(max = 360.dp)
+                        .padding(horizontal = 24.dp, vertical = 20.dp),
+                    verticalArrangement = Arrangement.spacedBy(16.dp)
+                ) {
+                    Text(
+                        text = when (editTarget) {
+                            StudentEditTarget.PROFILE -> stringResource(id = R.string.student_editor_profile_title)
+                            StudentEditTarget.RATE -> stringResource(id = R.string.student_editor_rate_title)
+                            StudentEditTarget.PHONE -> stringResource(id = R.string.student_editor_phone_title)
+                            StudentEditTarget.MESSENGER -> stringResource(id = R.string.student_editor_messenger_title)
+                            StudentEditTarget.NOTES -> stringResource(id = R.string.student_editor_notes_title)
+                        },
+                        style = MaterialTheme.typography.titleLarge
+                    )
+
+                    StudentEditorForm(
+                        state = formState,
+                        onNameChange = vm::onNameChange,
+                        onPhoneChange = vm::onPhoneChange,
+                        onMessengerChange = vm::onMessengerChange,
+                        onRateChange = vm::onRateChange,
+                        onSubjectChange = vm::onSubjectChange,
+                        onGradeChange = vm::onGradeChange,
+                        onNoteChange = vm::onNoteChange,
+                        onArchivedChange = vm::onArchivedChange,
+                        onActiveChange = vm::onActiveChange,
+                        modifier = Modifier.fillMaxWidth(),
+                        editTarget = editTarget,
+                        initialFocus = editTarget,
+                        enableScrolling = false,
+                        enabled = !formState.isSaving,
+                        onSubmit = attemptSave
+                    )
+
+                    if (snackbarHostState.currentSnackbarData != null) {
+                        SnackbarHost(
+                            hostState = snackbarHostState,
+                            modifier = Modifier.fillMaxWidth()
+                        )
+                    }
+
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.End,
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        TextButton(
+                            onClick = { closeEditor(currentOnDismiss) },
+                            enabled = !formState.isSaving
+                        ) {
+                            Text(text = stringResource(id = R.string.student_editor_cancel))
+                        }
+                        Spacer(modifier = Modifier.width(12.dp))
+                        Button(
+                            onClick = attemptSave,
+                            enabled = !formState.isSaving && formState.name.isNotBlank()
+                        ) {
+                            if (formState.isSaving) {
+                                CircularProgressIndicator(
+                                    modifier = Modifier.size(20.dp),
+                                    strokeWidth = 2.dp
+                                )
+                            } else {
+                                Text(text = stringResource(id = R.string.student_editor_save))
+                            }
+                        }
+                    }
+                }
             }
         }
     }

--- a/app/src/main/java/com/tutorly/ui/screens/StudentsScreen.kt
+++ b/app/src/main/java/com/tutorly/ui/screens/StudentsScreen.kt
@@ -30,6 +30,7 @@ import androidx.compose.material.icons.outlined.StickyNote2
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
@@ -243,59 +244,78 @@ fun StudentEditorSheet(
     modifier: Modifier = Modifier,
     editTarget: StudentEditTarget? = null,
     initialFocus: StudentEditTarget? = StudentEditTarget.PROFILE,
+    snackbarHostState: SnackbarHostState? = null,
 ) {
     val isEditing = state.studentId != null
-    Column(
+    Box(
         modifier = modifier
             .fillMaxWidth()
             .navigationBarsPadding()
             .imePadding()
-            .padding(horizontal = 24.dp, vertical = 16.dp)
-            .heightIn(max = 600.dp),
-        verticalArrangement = Arrangement.spacedBy(20.dp)
+            .padding(horizontal = 20.dp, vertical = 16.dp)
+            .heightIn(max = 600.dp)
     ) {
-        Text(
-            text = stringResource(
-                id = if (isEditing) R.string.student_editor_edit_title else R.string.add_student
-            ),
-            style = MaterialTheme.typography.titleLarge
-        )
-
-        StudentEditorForm(
-            state = state,
-            onNameChange = onNameChange,
-            onPhoneChange = onPhoneChange,
-            onMessengerChange = onMessengerChange,
-            onRateChange = onRateChange,
-            onSubjectChange = onSubjectChange,
-            onGradeChange = onGradeChange,
-            onNoteChange = onNoteChange,
-            onArchivedChange = onArchivedChange,
-            onActiveChange = onActiveChange,
-            modifier = Modifier
-                .fillMaxWidth(),
-            editTarget = editTarget,
-            initialFocus = initialFocus,
-            enableScrolling = editTarget == null,
-            enabled = !state.isSaving,
-            onSubmit = onSave
-        )
-
-        Button(
-            onClick = onSave,
+        Column(
             modifier = Modifier.fillMaxWidth(),
-            enabled = !state.isSaving && state.name.isNotBlank()
+            verticalArrangement = Arrangement.spacedBy(20.dp)
         ) {
             if (state.isSaving) {
-                CircularProgressIndicator(
-                    modifier = Modifier.size(20.dp),
-                    strokeWidth = 2.dp
-                )
-            } else {
-                Text(
-                    text = stringResource(id = R.string.student_editor_save)
-                )
+                LinearProgressIndicator(modifier = Modifier.fillMaxWidth())
             }
+
+            Text(
+                text = stringResource(
+                    id = if (isEditing) R.string.student_editor_edit_title else R.string.add_student
+                ),
+                style = MaterialTheme.typography.titleLarge
+            )
+
+            StudentEditorForm(
+                state = state,
+                onNameChange = onNameChange,
+                onPhoneChange = onPhoneChange,
+                onMessengerChange = onMessengerChange,
+                onRateChange = onRateChange,
+                onSubjectChange = onSubjectChange,
+                onGradeChange = onGradeChange,
+                onNoteChange = onNoteChange,
+                onArchivedChange = onArchivedChange,
+                onActiveChange = onActiveChange,
+                modifier = Modifier.fillMaxWidth(),
+                editTarget = editTarget,
+                initialFocus = initialFocus,
+                enableScrolling = editTarget == null,
+                enabled = !state.isSaving,
+                onSubmit = onSave
+            )
+
+            Button(
+                onClick = onSave,
+                modifier = Modifier.fillMaxWidth(),
+                enabled = !state.isSaving && state.name.isNotBlank()
+            ) {
+                if (state.isSaving) {
+                    CircularProgressIndicator(
+                        modifier = Modifier.size(20.dp),
+                        strokeWidth = 2.dp
+                    )
+                } else {
+                    Text(
+                        text = stringResource(id = R.string.student_editor_save)
+                    )
+                }
+            }
+
+            Spacer(modifier = Modifier.height(8.dp))
+        }
+
+        if (snackbarHostState != null) {
+            SnackbarHost(
+                hostState = snackbarHostState,
+                modifier = Modifier
+                    .align(Alignment.BottomCenter)
+                    .padding(bottom = 8.dp)
+            )
         }
     }
 }

--- a/app/src/main/java/com/tutorly/ui/screens/StudentsScreen.kt
+++ b/app/src/main/java/com/tutorly/ui/screens/StudentsScreen.kt
@@ -1,6 +1,5 @@
 package com.tutorly.ui.screens
 
-import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -30,7 +29,6 @@ import androidx.compose.material.icons.outlined.Phone
 import androidx.compose.material.icons.outlined.StickyNote2
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
-import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FloatingActionButton
@@ -68,6 +66,7 @@ import androidx.compose.runtime.setValue
 import com.tutorly.R
 import com.tutorly.ui.components.PaymentBadge
 import com.tutorly.ui.components.TutorlyBottomSheetContainer
+import com.tutorly.ui.theme.TutorlyCardDefaults
 import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -332,9 +331,8 @@ private fun StudentCard(
         onClick = onClick,
         modifier = modifier.fillMaxWidth(),
         shape = MaterialTheme.shapes.large,
-        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
-        border = BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant),
-        elevation = CardDefaults.cardElevation(defaultElevation = 0.dp)
+        colors = TutorlyCardDefaults.colors(),
+        elevation = TutorlyCardDefaults.elevation()
     ) {
         Row(
             modifier = Modifier

--- a/app/src/main/java/com/tutorly/ui/screens/StudentsScreen.kt
+++ b/app/src/main/java/com/tutorly/ui/screens/StudentsScreen.kt
@@ -142,7 +142,7 @@ fun StudentsScreen(
     Scaffold(
         modifier = modifier,
         snackbarHost = { SnackbarHost(hostState = snackbarHostState) },
-        containerColor = MaterialTheme.colorScheme.surface,
+        containerColor = MaterialTheme.colorScheme.surfaceContainerHighest,
         floatingActionButton = {
             FloatingActionButton(
                 onClick = { openCreationEditor(StudentEditorOrigin.STUDENTS) },

--- a/app/src/main/java/com/tutorly/ui/screens/TodayScreen.kt
+++ b/app/src/main/java/com/tutorly/ui/screens/TodayScreen.kt
@@ -26,7 +26,6 @@ import androidx.compose.material.icons.outlined.WarningAmber
 import androidx.compose.material3.AssistChip
 import androidx.compose.material3.AssistChipDefaults
 import androidx.compose.material3.Card
-import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
@@ -58,6 +57,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import com.tutorly.ui.theme.TutorlyCardDefaults
 import com.tutorly.R
 import com.tutorly.domain.model.LessonForToday
 import com.tutorly.models.PaymentStatus
@@ -321,7 +321,8 @@ private fun TodayStatsCard(
     Card(
         modifier = modifier,
         shape = MaterialTheme.shapes.large,
-        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceContainerLow)
+        colors = TutorlyCardDefaults.colors(),
+        elevation = TutorlyCardDefaults.elevation()
     ) {
         Column(
             modifier = Modifier
@@ -584,8 +585,8 @@ private fun LessonCard(
     Card(
         modifier = modifier,
         shape = MaterialTheme.shapes.large,
-        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceContainerLow),
-        elevation = CardDefaults.cardElevation(defaultElevation = 1.dp)
+        colors = TutorlyCardDefaults.colors(),
+        elevation = TutorlyCardDefaults.elevation()
     ) {
         Column(
             modifier = Modifier.padding(horizontal = 20.dp, vertical = 18.dp),

--- a/app/src/main/java/com/tutorly/ui/screens/TodayScreen.kt
+++ b/app/src/main/java/com/tutorly/ui/screens/TodayScreen.kt
@@ -119,7 +119,8 @@ fun TodayScreen(
     Scaffold(
         modifier = modifier,
         topBar = { TodayTopBar(state = uiState) },
-        snackbarHost = { SnackbarHost(hostState = snackbarHostState) }
+        snackbarHost = { SnackbarHost(hostState = snackbarHostState) },
+        containerColor = MaterialTheme.colorScheme.surfaceContainerHighest
     ) { innerPadding ->
         Box(
             modifier = Modifier

--- a/app/src/main/java/com/tutorly/ui/theme/CardDefaults.kt
+++ b/app/src/main/java/com/tutorly/ui/theme/CardDefaults.kt
@@ -1,0 +1,30 @@
+package com.tutorly.ui.theme
+
+import androidx.compose.material3.CardColors
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CardElevation
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.luminance
+import androidx.compose.ui.unit.dp
+
+object TutorlyCardDefaults {
+    @Composable
+    fun containerColor(): Color {
+        val colorScheme = MaterialTheme.colorScheme
+        val base = colorScheme.surfaceContainerLowest
+        val surface = colorScheme.surface
+        return if (base.luminance() > surface.luminance()) {
+            base
+        } else {
+            colorScheme.surfaceContainerHighest
+        }
+    }
+
+    @Composable
+    fun colors(): CardColors = CardDefaults.cardColors(containerColor = containerColor())
+
+    @Composable
+    fun elevation(): CardElevation = CardDefaults.cardElevation(defaultElevation = 6.dp)
+}

--- a/app/src/main/java/com/tutorly/ui/theme/Theme.kt
+++ b/app/src/main/java/com/tutorly/ui/theme/Theme.kt
@@ -61,9 +61,9 @@ private val LightColorScheme = lightColorScheme(
     onTertiary = OnTertiaryTeal,
     tertiaryContainer = TertiaryTealContainer,
     onTertiaryContainer = OnTertiaryTealContainer,
-    background = NeutralBackground,
+    background = SurfaceContainer,
     onBackground = NeutralOnBackground,
-    surface = NeutralBackground,
+    surface = SurfaceContainer,
     onSurface = NeutralOnBackground,
     surfaceTint = PrimaryBlue,
     surfaceVariant = NeutralSurfaceVariant,
@@ -111,8 +111,10 @@ fun TutorlyTheme(
 private val LightColors = lightColorScheme(
     primary = RoyalBlue,
     onPrimary = OnRoyal,
-    surface = Color(0xFFF9FAFB),
+    surface = SurfaceContainer,
     onSurface = Color(0xFF111827),
+    background = SurfaceContainer,
+    onBackground = Color(0xFF111827),
     secondary = Color(0xFF5B7CFA)
 )
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -18,11 +18,6 @@
     <string name="student_editor_edit_title">Редактировать ученика</string>
     <string name="student_editor_close">Закрыть</string>
     <string name="student_editor_save">Сохранить</string>
-    <string name="student_editor_profile_title">Профиль ученика</string>
-    <string name="student_editor_rate_title">Ставка</string>
-    <string name="student_editor_phone_title">Телефон</string>
-    <string name="student_editor_messenger_title">Мессенджер</string>
-    <string name="student_editor_notes_title">Заметки</string>
     <string name="student_editor_name">Имя*</string>
     <string name="student_editor_name_required">Имя обязательно</string>
     <string name="student_editor_phone">Телефон</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -18,6 +18,11 @@
     <string name="student_editor_edit_title">Редактировать ученика</string>
     <string name="student_editor_close">Закрыть</string>
     <string name="student_editor_save">Сохранить</string>
+    <string name="student_editor_profile_title">Профиль ученика</string>
+    <string name="student_editor_rate_title">Ставка</string>
+    <string name="student_editor_phone_title">Телефон</string>
+    <string name="student_editor_messenger_title">Мессенджер</string>
+    <string name="student_editor_notes_title">Заметки</string>
     <string name="student_editor_name">Имя*</string>
     <string name="student_editor_name_required">Имя обязательно</string>
     <string name="student_editor_phone">Телефон</string>


### PR DESCRIPTION
## Summary
- replace the student profile field editors with compact alert-style windows when editing individual fields from the profile
- add dedicated string resources for the dialog titles

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68ec2b2c609c8320b050964144a2e56a