### PR TITLE
Align student editor bottom sheet with lesson styling

### DIFF
--- a/app/src/main/java/com/tutorly/navigation/AppNav.kt
+++ b/app/src/main/java/com/tutorly/navigation/AppNav.kt
@@ -187,6 +187,11 @@ fun AppNavRoot() {
                 val creationViewModel: LessonCreationViewModel = hiltViewModel(calendarEntry)
                 StudentDetailsScreen(
                     onBack = { nav.popBackStack() },
+                    onEdit = { id, target ->
+                        nav.navigate(studentEditRoute(id, target)) {
+                            launchSingleTop = true
+                        }
+                    },
                     onAddStudentFromCreation = {
                         nav.navigate("$ROUTE_STUDENTS?$ARG_STUDENT_EDITOR_ORIGIN=${StudentEditorOrigin.LESSON_CREATION.name}") {
                             launchSingleTop = true

--- a/app/src/main/java/com/tutorly/navigation/AppNav.kt
+++ b/app/src/main/java/com/tutorly/navigation/AppNav.kt
@@ -187,11 +187,6 @@ fun AppNavRoot() {
                 val creationViewModel: LessonCreationViewModel = hiltViewModel(calendarEntry)
                 StudentDetailsScreen(
                     onBack = { nav.popBackStack() },
-                    onEdit = { id, target ->
-                        nav.navigate(studentEditRoute(id, target)) {
-                            launchSingleTop = true
-                        }
-                    },
                     onAddStudentFromCreation = {
                         nav.navigate("$ROUTE_STUDENTS?$ARG_STUDENT_EDITOR_ORIGIN=${StudentEditorOrigin.LESSON_CREATION.name}") {
                             launchSingleTop = true

--- a/app/src/main/java/com/tutorly/ui/screens/StudentDetailsScreen.kt
+++ b/app/src/main/java/com/tutorly/ui/screens/StudentDetailsScreen.kt
@@ -108,6 +108,11 @@ fun StudentDetailsScreen(
     var showStudentEditor by rememberSaveable { mutableStateOf(false) }
     var editorTarget by rememberSaveable { mutableStateOf<StudentEditTarget?>(null) }
     val editorSheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    val closeStudentEditor = {
+        showStudentEditor = false
+        editorTarget = null
+        vm.resetStudentEditor()
+    }
     LessonCardSheet(
         state = lessonCardState,
         onDismissRequest = lessonCardViewModel::dismiss,
@@ -148,6 +153,26 @@ fun StudentDetailsScreen(
         if (message != null) {
             snackbarHostState.showSnackbar(message)
             creationViewModel.consumeSnackbar()
+        }
+    }
+
+    val handleStudentSave = {
+        if (!editorFormState.isSaving) {
+            vm.submitStudent(
+                onSuccess = { name ->
+                    closeStudentEditor()
+                    val message = context.getString(R.string.student_updated_message, name)
+                    coroutineScope.launch { snackbarHostState.showSnackbar(message) }
+                },
+                onError = { error ->
+                    val message = if (error.isNotBlank()) {
+                        error
+                    } else {
+                        context.getString(R.string.student_editor_save_error)
+                    }
+                    coroutineScope.launch { snackbarHostState.showSnackbar(message) }
+                }
+            )
         }
     }
 
@@ -213,32 +238,6 @@ fun StudentDetailsScreen(
                 origin = LessonCreationOrigin.STUDENT
             )
         )
-    }
-
-    val closeStudentEditor = {
-        showStudentEditor = false
-        editorTarget = null
-        vm.resetStudentEditor()
-    }
-
-    val handleStudentSave = {
-        if (!editorFormState.isSaving) {
-            vm.submitStudent(
-                onSuccess = { name ->
-                    closeStudentEditor()
-                    val message = context.getString(R.string.student_updated_message, name)
-                    coroutineScope.launch { snackbarHostState.showSnackbar(message) }
-                },
-                onError = { error ->
-                    val message = if (error.isNotBlank()) {
-                        error
-                    } else {
-                        context.getString(R.string.student_editor_save_error)
-                    }
-                    coroutineScope.launch { snackbarHostState.showSnackbar(message) }
-                }
-            )
-        }
     }
 
     Scaffold(

--- a/app/src/main/java/com/tutorly/ui/screens/StudentDetailsViewModel.kt
+++ b/app/src/main/java/com/tutorly/ui/screens/StudentDetailsViewModel.kt
@@ -3,24 +3,15 @@ package com.tutorly.ui.screens
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.tutorly.domain.model.StudentProfile
 import com.tutorly.domain.repo.StudentsRepository
-import com.tutorly.models.Student
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
-import java.time.Instant
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.stateIn
-import kotlinx.coroutines.flow.update
-import kotlinx.coroutines.launch
-
-@Suppress("TooManyFunctions")
 
 @HiltViewModel
 class StudentDetailsViewModel @Inject constructor(
@@ -30,12 +21,6 @@ class StudentDetailsViewModel @Inject constructor(
 
     private val studentId: Long = savedStateHandle.get<Long>("studentId")
         ?: error("studentId is required")
-
-    private val repo = studentsRepository
-
-    private val _editorFormState = MutableStateFlow(StudentEditorFormState())
-    val editorFormState: StateFlow<StudentEditorFormState> = _editorFormState.asStateFlow()
-    private var editingStudent: Student? = null
 
     val uiState: StateFlow<StudentProfileUiState> = studentsRepository
         .observeStudentProfile(studentId)
@@ -53,135 +38,4 @@ class StudentDetailsViewModel @Inject constructor(
             started = SharingStarted.WhileSubscribed(5_000),
             initialValue = StudentProfileUiState.Loading
         )
-
-    fun startStudentEditor(profile: StudentProfile) {
-        val student = profile.student
-        editingStudent = student
-        _editorFormState.value = StudentEditorFormState(
-            studentId = student.id,
-            name = student.name,
-            phone = student.phone.orEmpty(),
-            messenger = student.messenger.orEmpty(),
-            rate = formatMoneyInput(student.rateCents),
-            subject = student.subject.orEmpty(),
-            grade = student.grade.orEmpty(),
-            note = student.note.orEmpty(),
-            isArchived = student.isArchived,
-            isActive = student.active
-        )
-    }
-
-    fun resetStudentEditor() {
-        editingStudent = null
-        _editorFormState.value = StudentEditorFormState()
-    }
-
-    fun onEditorNameChange(value: String) {
-        _editorFormState.update { it.copy(name = value, nameError = false) }
-    }
-
-    fun onEditorPhoneChange(value: String) {
-        _editorFormState.update { it.copy(phone = value) }
-    }
-
-    fun onEditorMessengerChange(value: String) {
-        _editorFormState.update { it.copy(messenger = value) }
-    }
-
-    fun onEditorRateChange(value: String) {
-        _editorFormState.update { it.copy(rate = value) }
-    }
-
-    fun onEditorSubjectChange(value: String) {
-        _editorFormState.update { it.copy(subject = value) }
-    }
-
-    fun onEditorGradeChange(value: String) {
-        _editorFormState.update { it.copy(grade = value) }
-    }
-
-    fun onEditorNoteChange(value: String) {
-        _editorFormState.update { it.copy(note = value) }
-    }
-
-    fun onEditorArchivedChange(value: Boolean) {
-        _editorFormState.update { it.copy(isArchived = value) }
-    }
-
-    fun onEditorActiveChange(value: Boolean) {
-        _editorFormState.update { it.copy(isActive = value) }
-    }
-
-    fun submitStudent(
-        onSuccess: (String) -> Unit,
-        onError: (String) -> Unit,
-    ) {
-        val state = _editorFormState.value
-        val trimmedName = state.name.trim()
-        if (trimmedName.isEmpty()) {
-            _editorFormState.update { it.copy(nameError = true) }
-            return
-        }
-
-        val trimmedPhone = state.phone.trim().ifBlank { null }
-        val trimmedMessenger = state.messenger.trim().ifBlank { null }
-        val trimmedSubject = state.subject.trim().ifBlank { null }
-        val trimmedGrade = state.grade.trim().ifBlank { null }
-        val trimmedNote = state.note.trim().ifBlank { null }
-        val rateInput = state.rate.trim()
-        val parsedRate = parseMoneyInput(rateInput)
-        val normalizedRate = if (rateInput.isNotEmpty() && parsedRate != null) {
-            formatMoneyInput(parsedRate)
-        } else {
-            rateInput
-        }
-
-        viewModelScope.launch {
-            _editorFormState.update {
-                it.copy(
-                    name = trimmedName,
-                    phone = trimmedPhone.orEmpty(),
-                    messenger = trimmedMessenger.orEmpty(),
-                    rate = normalizedRate,
-                    subject = trimmedSubject.orEmpty(),
-                    grade = trimmedGrade.orEmpty(),
-                    note = trimmedNote.orEmpty(),
-                    nameError = false,
-                    isSaving = true
-                )
-            }
-
-            val base = editingStudent ?: state.studentId?.let { repo.getByIdSafe(it) }
-            if (base == null) {
-                editingStudent = null
-                _editorFormState.update { it.copy(studentId = null, isSaving = false) }
-                onError("")
-                return@launch
-            }
-
-            val updated = base.copy(
-                name = trimmedName,
-                phone = trimmedPhone,
-                messenger = trimmedMessenger,
-                rateCents = parsedRate,
-                subject = trimmedSubject,
-                grade = trimmedGrade,
-                note = trimmedNote,
-                isArchived = state.isArchived,
-                active = state.isActive,
-                updatedAt = Instant.now()
-            )
-
-            runCatching { repo.upsert(updated) }
-                .onSuccess { id ->
-                    editingStudent = updated.copy(id = id)
-                    _editorFormState.update { it.copy(isSaving = false) }
-                    onSuccess(trimmedName)
-                }
-                .onFailure { throwable ->
-                    _editorFormState.update { it.copy(isSaving = false) }
-                    onError(throwable.message ?: "")
-                }
-        }
-    }
 }

--- a/app/src/main/java/com/tutorly/ui/screens/StudentDetailsViewModel.kt
+++ b/app/src/main/java/com/tutorly/ui/screens/StudentDetailsViewModel.kt
@@ -3,15 +3,24 @@ package com.tutorly.ui.screens
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.tutorly.domain.model.StudentProfile
 import com.tutorly.domain.repo.StudentsRepository
+import com.tutorly.models.Student
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
+import java.time.Instant
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+@Suppress("TooManyFunctions")
 
 @HiltViewModel
 class StudentDetailsViewModel @Inject constructor(
@@ -21,6 +30,12 @@ class StudentDetailsViewModel @Inject constructor(
 
     private val studentId: Long = savedStateHandle.get<Long>("studentId")
         ?: error("studentId is required")
+
+    private val repo = studentsRepository
+
+    private val _editorFormState = MutableStateFlow(StudentEditorFormState())
+    val editorFormState: StateFlow<StudentEditorFormState> = _editorFormState.asStateFlow()
+    private var editingStudent: Student? = null
 
     val uiState: StateFlow<StudentProfileUiState> = studentsRepository
         .observeStudentProfile(studentId)
@@ -38,4 +53,135 @@ class StudentDetailsViewModel @Inject constructor(
             started = SharingStarted.WhileSubscribed(5_000),
             initialValue = StudentProfileUiState.Loading
         )
+
+    fun startStudentEditor(profile: StudentProfile) {
+        val student = profile.student
+        editingStudent = student
+        _editorFormState.value = StudentEditorFormState(
+            studentId = student.id,
+            name = student.name,
+            phone = student.phone.orEmpty(),
+            messenger = student.messenger.orEmpty(),
+            rate = formatMoneyInput(student.rateCents),
+            subject = student.subject.orEmpty(),
+            grade = student.grade.orEmpty(),
+            note = student.note.orEmpty(),
+            isArchived = student.isArchived,
+            isActive = student.active
+        )
+    }
+
+    fun resetStudentEditor() {
+        editingStudent = null
+        _editorFormState.value = StudentEditorFormState()
+    }
+
+    fun onEditorNameChange(value: String) {
+        _editorFormState.update { it.copy(name = value, nameError = false) }
+    }
+
+    fun onEditorPhoneChange(value: String) {
+        _editorFormState.update { it.copy(phone = value) }
+    }
+
+    fun onEditorMessengerChange(value: String) {
+        _editorFormState.update { it.copy(messenger = value) }
+    }
+
+    fun onEditorRateChange(value: String) {
+        _editorFormState.update { it.copy(rate = value) }
+    }
+
+    fun onEditorSubjectChange(value: String) {
+        _editorFormState.update { it.copy(subject = value) }
+    }
+
+    fun onEditorGradeChange(value: String) {
+        _editorFormState.update { it.copy(grade = value) }
+    }
+
+    fun onEditorNoteChange(value: String) {
+        _editorFormState.update { it.copy(note = value) }
+    }
+
+    fun onEditorArchivedChange(value: Boolean) {
+        _editorFormState.update { it.copy(isArchived = value) }
+    }
+
+    fun onEditorActiveChange(value: Boolean) {
+        _editorFormState.update { it.copy(isActive = value) }
+    }
+
+    fun submitStudent(
+        onSuccess: (String) -> Unit,
+        onError: (String) -> Unit,
+    ) {
+        val state = _editorFormState.value
+        val trimmedName = state.name.trim()
+        if (trimmedName.isEmpty()) {
+            _editorFormState.update { it.copy(nameError = true) }
+            return
+        }
+
+        val trimmedPhone = state.phone.trim().ifBlank { null }
+        val trimmedMessenger = state.messenger.trim().ifBlank { null }
+        val trimmedSubject = state.subject.trim().ifBlank { null }
+        val trimmedGrade = state.grade.trim().ifBlank { null }
+        val trimmedNote = state.note.trim().ifBlank { null }
+        val rateInput = state.rate.trim()
+        val parsedRate = parseMoneyInput(rateInput)
+        val normalizedRate = if (rateInput.isNotEmpty() && parsedRate != null) {
+            formatMoneyInput(parsedRate)
+        } else {
+            rateInput
+        }
+
+        viewModelScope.launch {
+            _editorFormState.update {
+                it.copy(
+                    name = trimmedName,
+                    phone = trimmedPhone.orEmpty(),
+                    messenger = trimmedMessenger.orEmpty(),
+                    rate = normalizedRate,
+                    subject = trimmedSubject.orEmpty(),
+                    grade = trimmedGrade.orEmpty(),
+                    note = trimmedNote.orEmpty(),
+                    nameError = false,
+                    isSaving = true
+                )
+            }
+
+            val base = editingStudent ?: state.studentId?.let { repo.getByIdSafe(it) }
+            if (base == null) {
+                editingStudent = null
+                _editorFormState.update { it.copy(studentId = null, isSaving = false) }
+                onError("")
+                return@launch
+            }
+
+            val updated = base.copy(
+                name = trimmedName,
+                phone = trimmedPhone,
+                messenger = trimmedMessenger,
+                rateCents = parsedRate,
+                subject = trimmedSubject,
+                grade = trimmedGrade,
+                note = trimmedNote,
+                isArchived = state.isArchived,
+                active = state.isActive,
+                updatedAt = Instant.now()
+            )
+
+            runCatching { repo.upsert(updated) }
+                .onSuccess { id ->
+                    editingStudent = updated.copy(id = id)
+                    _editorFormState.update { it.copy(isSaving = false) }
+                    onSuccess(trimmedName)
+                }
+                .onFailure { throwable ->
+                    _editorFormState.update { it.copy(isSaving = false) }
+                    onError(throwable.message ?: "")
+                }
+        }
+    }
 }

--- a/app/src/main/java/com/tutorly/ui/screens/StudentDetailsViewModel.kt
+++ b/app/src/main/java/com/tutorly/ui/screens/StudentDetailsViewModel.kt
@@ -4,26 +4,50 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.tutorly.domain.repo.StudentsRepository
+import com.tutorly.models.Student
 import dagger.hilt.android.lifecycle.HiltViewModel
+import java.time.Instant
 import javax.inject.Inject
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
 
 @HiltViewModel
 class StudentDetailsViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
-    studentsRepository: StudentsRepository
+    private val studentsRepository: StudentsRepository
 ) : ViewModel() {
 
     private val studentId: Long = savedStateHandle.get<Long>("studentId")
         ?: error("studentId is required")
 
+    private val _editorFormState = MutableStateFlow(StudentEditorFormState())
+    val editorFormState: StateFlow<StudentEditorFormState> = _editorFormState.asStateFlow()
+
+    private val _isEditorVisible = MutableStateFlow(false)
+    val isEditorVisible: StateFlow<Boolean> = _isEditorVisible.asStateFlow()
+
+    private val _editorTarget = MutableStateFlow<StudentEditTarget?>(null)
+    val editorTarget: StateFlow<StudentEditTarget?> = _editorTarget.asStateFlow()
+
+    private val _editorInitialFocus = MutableStateFlow<StudentEditTarget?>(null)
+    val editorInitialFocus: StateFlow<StudentEditTarget?> = _editorInitialFocus.asStateFlow()
+
+    private var loadedStudent: Student? = null
+
     val uiState: StateFlow<StudentProfileUiState> = studentsRepository
         .observeStudentProfile(studentId)
+        .onEach { profile ->
+            loadedStudent = profile?.student
+        }
         .map { profile ->
             if (profile != null) {
                 StudentProfileUiState.Content(profile)
@@ -38,4 +62,132 @@ class StudentDetailsViewModel @Inject constructor(
             started = SharingStarted.WhileSubscribed(5_000),
             initialValue = StudentProfileUiState.Loading
         )
+
+    fun openEditor(target: StudentEditTarget) {
+        val student = loadedStudent ?: return
+        _editorFormState.value = StudentEditorFormState(
+            studentId = student.id,
+            name = student.name,
+            phone = student.phone.orEmpty(),
+            messenger = student.messenger.orEmpty(),
+            rate = formatMoneyInput(student.rateCents),
+            subject = student.subject.orEmpty(),
+            grade = student.grade.orEmpty(),
+            note = student.note.orEmpty(),
+            isArchived = student.isArchived,
+            isActive = student.active
+        )
+        _editorTarget.value = target
+        _editorInitialFocus.value = target
+        _isEditorVisible.value = true
+    }
+
+    fun onEditorNameChange(value: String) {
+        _editorFormState.update { it.copy(name = value, nameError = false) }
+    }
+
+    fun onEditorPhoneChange(value: String) {
+        _editorFormState.update { it.copy(phone = value) }
+    }
+
+    fun onEditorMessengerChange(value: String) {
+        _editorFormState.update { it.copy(messenger = value) }
+    }
+
+    fun onEditorRateChange(value: String) {
+        _editorFormState.update { it.copy(rate = value) }
+    }
+
+    fun onEditorSubjectChange(value: String) {
+        _editorFormState.update { it.copy(subject = value) }
+    }
+
+    fun onEditorGradeChange(value: String) {
+        _editorFormState.update { it.copy(grade = value) }
+    }
+
+    fun onEditorNoteChange(value: String) {
+        _editorFormState.update { it.copy(note = value) }
+    }
+
+    fun onEditorArchivedChange(value: Boolean) {
+        _editorFormState.update { it.copy(isArchived = value) }
+    }
+
+    fun onEditorActiveChange(value: Boolean) {
+        _editorFormState.update { it.copy(isActive = value) }
+    }
+
+    fun submitEditor(
+        onSuccess: (Long, String) -> Unit,
+        onError: (String) -> Unit,
+    ) {
+        val student = loadedStudent ?: return
+        val state = _editorFormState.value
+        val trimmedName = state.name.trim()
+        if (trimmedName.isEmpty()) {
+            _editorFormState.update { it.copy(nameError = true) }
+            return
+        }
+
+        val trimmedPhone = state.phone.trim().ifBlank { null }
+        val trimmedMessenger = state.messenger.trim().ifBlank { null }
+        val trimmedSubject = state.subject.trim().ifBlank { null }
+        val trimmedGrade = state.grade.trim().ifBlank { null }
+        val trimmedNote = state.note.trim().ifBlank { null }
+        val rateInput = state.rate.trim()
+        val parsedRate = parseMoneyInput(rateInput)
+        val normalizedRate = if (rateInput.isNotEmpty() && parsedRate != null) {
+            formatMoneyInput(parsedRate)
+        } else {
+            rateInput
+        }
+
+        viewModelScope.launch {
+            _editorFormState.update {
+                it.copy(
+                    name = trimmedName,
+                    phone = trimmedPhone.orEmpty(),
+                    messenger = trimmedMessenger.orEmpty(),
+                    rate = normalizedRate,
+                    subject = trimmedSubject.orEmpty(),
+                    grade = trimmedGrade.orEmpty(),
+                    note = trimmedNote.orEmpty(),
+                    nameError = false,
+                    isSaving = true
+                )
+            }
+
+            val updatedStudent = student.copy(
+                name = trimmedName,
+                phone = trimmedPhone,
+                messenger = trimmedMessenger,
+                rateCents = parsedRate,
+                subject = trimmedSubject,
+                grade = trimmedGrade,
+                note = trimmedNote,
+                isArchived = state.isArchived,
+                active = state.isActive,
+                updatedAt = Instant.now()
+            )
+
+            runCatching { studentsRepository.upsert(updatedStudent) }
+                .onSuccess { id ->
+                    loadedStudent = updatedStudent.copy(id = id)
+                    _editorFormState.update { it.copy(isSaving = false) }
+                    onSuccess(id, trimmedName)
+                }
+                .onFailure { throwable ->
+                    _editorFormState.update { it.copy(isSaving = false) }
+                    onError(throwable.message ?: "")
+                }
+        }
+    }
+
+    fun onEditorDismissed() {
+        _isEditorVisible.value = false
+        _editorTarget.value = null
+        _editorInitialFocus.value = null
+        _editorFormState.value = StudentEditorFormState()
+    }
 }

--- a/app/src/main/java/com/tutorly/ui/screens/StudentEditorScreen.kt
+++ b/app/src/main/java/com/tutorly/ui/screens/StudentEditorScreen.kt
@@ -237,7 +237,7 @@ fun StudentEditorDialog(
         contentColor = Color.Unspecified,
         scrimColor = Color.Black.copy(alpha = 0.32f),
     ) {
-        TutorlyBottomSheetContainer {
+        TutorlyBottomSheetContainer(dragHandle = null) {
             StudentEditorSheet(
                 state = formState,
                 onNameChange = vm::onNameChange,
@@ -253,7 +253,12 @@ fun StudentEditorDialog(
                 modifier = Modifier.fillMaxWidth(),
                 editTarget = editTarget,
                 initialFocus = editTarget,
-                snackbarHostState = snackbarHostState
+                snackbarHostState = snackbarHostState,
+                onDismiss = {
+                    if (!formState.isSaving) {
+                        closeEditor(currentOnDismiss)
+                    }
+                }
             )
         }
     }


### PR DESCRIPTION
## Summary
- update the student editor sheet layout to match the lesson editor styling, including consistent header, spacing, and minimum height handling
- add optional dismiss handling and shared drag handle behavior for the student editor bottom sheets used across list and profile screens

## Testing
- `./gradlew lint` *(fails: missing Android SDK in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ecbf404b4c8320be6f3dc390b755cd