### PR TITLE
Update lesson creation student picker UI

### DIFF
--- a/app/src/main/java/com/tutorly/ui/lessoncreation/LessonCreationModels.kt
+++ b/app/src/main/java/com/tutorly/ui/lessoncreation/LessonCreationModels.kt
@@ -64,7 +64,8 @@ data class SubjectOption(
 data class StudentOption(
     val id: Long,
     val name: String,
-    val rateCents: Int?
+    val rateCents: Int?,
+    val subjects: List<String> = emptyList()
 )
 
 data class ConflictInfo(

--- a/app/src/main/java/com/tutorly/ui/lessoncreation/LessonCreationSheet.kt
+++ b/app/src/main/java/com/tutorly/ui/lessoncreation/LessonCreationSheet.kt
@@ -194,12 +194,26 @@ private fun StudentSection(
                         )
                     }
                 },
-                isError = state.errors.containsKey(LessonCreationField.STUDENT)
+                isError = state.errors.containsKey(LessonCreationField.STUDENT),
+                supportingText = {
+                    state.selectedStudent?.subjects
+                        ?.takeIf { it.isNotEmpty() }
+                        ?.joinToString(separator = ", ")
+                        ?.let { subjects ->
+                            Text(
+                                text = subjects,
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                maxLines = 2
+                            )
+                        }
+                }
             )
             DropdownMenu(
                 expanded = expanded,
                 onDismissRequest = { expanded = false },
-                modifier = dropdownModifier
+                modifier = dropdownModifier,
+                containerColor = Color.White
             ) {
                 DropdownMenuItem(
                     text = { Text(text = stringResource(id = R.string.lesson_create_new_student)) },
@@ -211,11 +225,21 @@ private fun StudentSection(
                 state.students.forEach { option ->
                     DropdownMenuItem(
                         text = {
-                            Text(
-                                text = option.name,
-                                style = LocalTextStyle.current,
-                                maxLines = 1
-                            )
+                            Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
+                                Text(
+                                    text = option.name,
+                                    style = LocalTextStyle.current,
+                                    maxLines = 1
+                                )
+                                if (option.subjects.isNotEmpty()) {
+                                    Text(
+                                        text = option.subjects.joinToString(separator = ", "),
+                                        style = MaterialTheme.typography.bodySmall,
+                                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                        maxLines = 2
+                                    )
+                                }
+                            }
                         },
                         leadingIcon = {
                             StudentAvatar(name = option.name, size = 32.dp)
@@ -385,7 +409,6 @@ private fun DurationPriceSection(
 
     Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
         Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
-            Text(text = stringResource(id = R.string.lesson_create_duration_label), fontWeight = FontWeight.Medium)
             OutlinedTextField(
                 value = customDurationInput,
                 onValueChange = { value ->

--- a/app/src/main/java/com/tutorly/ui/lessoncreation/LessonCreationViewModel.kt
+++ b/app/src/main/java/com/tutorly/ui/lessoncreation/LessonCreationViewModel.kt
@@ -501,7 +501,22 @@ private fun SubjectPreset.toOption(): SubjectOption = SubjectOption(
     defaultPriceCents = defaultPriceCents
 )
 
-private fun Student.toOption(): StudentOption = StudentOption(id = id, name = name, rateCents = rateCents)
+private fun Student.toOption(): StudentOption {
+    val subjects = subject
+        ?.split(',', ';', '\n')
+        ?.map { it.trim() }
+        ?.filter { it.isNotEmpty() }
+        ?.distinct()
+        ?: emptyList()
+
+    return StudentOption(
+        id = id,
+        name = name,
+        rateCents = rateCents,
+        subjects = subjects
+    )
+}
+
 
 private fun roundToStep(start: ZonedDateTime, stepMinutes: Int): ZonedDateTime {
     val minute = start.minute


### PR DESCRIPTION
## Summary
- display student subjects inside the picker and beneath the selected student field
- style the student dropdown with a white background and supporting copy
- remove the redundant duration caption from the lesson creation sheet

## Testing
- ./gradlew test *(fails: Android SDK not available in CI image)*

------
https://chatgpt.com/codex/tasks/task_e_68ece689f4bc8320beb27d3aa05c265a