### PR TITLE
Refine add lesson student and subject selection

### DIFF
--- a/app/src/main/java/com/tutorly/ui/lessoncreation/LessonCreationModels.kt
+++ b/app/src/main/java/com/tutorly/ui/lessoncreation/LessonCreationModels.kt
@@ -14,6 +14,7 @@ data class LessonCreationUiState(
     val students: List<StudentOption> = emptyList(),
     val selectedStudent: StudentOption? = null,
     val subjects: List<SubjectOption> = emptyList(),
+    val availableSubjects: List<SubjectOption> = emptyList(),
     val selectedSubjectId: Long? = null,
     val date: LocalDate = LocalDate.now(),
     val time: LocalTime = LocalTime.now(),

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -118,11 +118,13 @@
     <string name="lesson_create_student_placeholder">Начните вводить имя</string>
     <string name="lesson_create_new_student">+ Новый ученик</string>
     <string name="lesson_create_subject_label">Предмет</string>
+    <string name="lesson_create_subject_placeholder">Выберите ученика, чтобы выбрать предмет</string>
+    <string name="lesson_create_subject_empty">Для ученика не найдены предметы</string>
     <string name="lesson_create_duration_label">Длительность</string>
     <string name="lesson_create_duration_chip">%1$d мин</string>
     <string name="lesson_create_duration_custom_label">Своя длительность</string>
     <string name="lesson_create_minutes_suffix">мин</string>
-    <string name="lesson_create_price_label">Стоимость (%1$s)</string>
+    <string name="lesson_create_price_label">Стоимость</string>
     <string name="lesson_create_note_label">Заметка</string>
     <string name="lesson_create_cancel">Отмена</string>
     <string name="lesson_create_submit">Добавить</string>


### PR DESCRIPTION
## Summary
- update the add-lesson student picker styling with a white background and no duration label
- surface student-specific subject options and filter presets accordingly when choosing a subject
- ensure the duration input no longer shows the "Длительность" label on the sheet

## Testing
- ./gradlew :app:lintDebug *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ecea88cb588320a25ffd1b15052c34