### PR TITLE
Refine lesson editor UI and student picker

### DIFF
--- a/app/src/main/java/com/tutorly/navigation/AppNav.kt
+++ b/app/src/main/java/com/tutorly/navigation/AppNav.kt
@@ -127,7 +127,15 @@ fun AppNavRoot() {
                     creationViewModel = creationViewModel
                 )
             }
-            composable(ROUTE_TODAY)    { TodayScreen() }      // сам рисует свой верх (заголовок + счетчики)
+            composable(ROUTE_TODAY) {
+                TodayScreen(
+                    onAddStudent = {
+                        nav.navigate("$ROUTE_STUDENTS?$ARG_STUDENT_EDITOR_ORIGIN=${StudentEditorOrigin.LESSON_CREATION.name}") {
+                            launchSingleTop = true
+                        }
+                    }
+                )
+            }      // сам рисует свой верх (заголовок + счетчики)
             composable(
                 route = ROUTE_STUDENTS_PATTERN,
                 arguments = listOf(

--- a/app/src/main/java/com/tutorly/ui/lessoncreation/LessonCreationSheet.kt
+++ b/app/src/main/java/com/tutorly/ui/lessoncreation/LessonCreationSheet.kt
@@ -107,7 +107,7 @@ fun LessonCreationSheet(
         contentColor = Color.Unspecified,
         scrimColor = Color.Black.copy(alpha = 0.32f)
     ) {
-        TutorlyBottomSheetContainer(dragHandle = null) {
+        TutorlyBottomSheetContainer(color = Color.White, dragHandle = null) {
             Column(
                 modifier = Modifier
                     .fillMaxWidth()

--- a/app/src/main/java/com/tutorly/ui/screens/CalendarScreen.kt
+++ b/app/src/main/java/com/tutorly/ui/screens/CalendarScreen.kt
@@ -94,6 +94,10 @@ fun CalendarScreen(
         state = lessonCardState,
         onDismissRequest = lessonCardViewModel::dismiss,
         onStudentSelect = lessonCardViewModel::onStudentSelected,
+        onAddStudent = {
+            lessonCardViewModel.dismiss()
+            onAddStudent()
+        },
         onDateSelect = lessonCardViewModel::onDateSelected,
         onTimeSelect = lessonCardViewModel::onTimeSelected,
         onDurationSelect = lessonCardViewModel::onDurationSelected,

--- a/app/src/main/java/com/tutorly/ui/screens/StudentDetailsScreen.kt
+++ b/app/src/main/java/com/tutorly/ui/screens/StudentDetailsScreen.kt
@@ -105,6 +105,10 @@ fun StudentDetailsScreen(
         state = lessonCardState,
         onDismissRequest = lessonCardViewModel::dismiss,
         onStudentSelect = lessonCardViewModel::onStudentSelected,
+        onAddStudent = {
+            lessonCardViewModel.dismiss()
+            onAddStudentFromCreation()
+        },
         onDateSelect = lessonCardViewModel::onDateSelected,
         onTimeSelect = lessonCardViewModel::onTimeSelected,
         onDurationSelect = lessonCardViewModel::onDurationSelected,

--- a/app/src/main/java/com/tutorly/ui/screens/StudentsScreen.kt
+++ b/app/src/main/java/com/tutorly/ui/screens/StudentsScreen.kt
@@ -262,7 +262,7 @@ fun StudentEditorSheet(
         contentColor = Color.Unspecified,
         scrimColor = Color.Black.copy(alpha = 0.32f)
     ) {
-        TutorlyBottomSheetContainer(dragHandle = null) {
+        TutorlyBottomSheetContainer(color = Color.White, dragHandle = null) {
             Column(
                 modifier = modifier
                     .fillMaxWidth()

--- a/app/src/main/java/com/tutorly/ui/screens/TodayScreen.kt
+++ b/app/src/main/java/com/tutorly/ui/screens/TodayScreen.kt
@@ -76,6 +76,7 @@ import java.util.Locale
 @Composable
 fun TodayScreen(
     modifier: Modifier = Modifier,
+    onAddStudent: () -> Unit = {},
     viewModel: TodayViewModel = hiltViewModel()
 ) {
     val uiState by viewModel.uiState.collectAsState()
@@ -89,6 +90,10 @@ fun TodayScreen(
         state = lessonCardState,
         onDismissRequest = lessonCardViewModel::dismiss,
         onStudentSelect = lessonCardViewModel::onStudentSelected,
+        onAddStudent = {
+            lessonCardViewModel.dismiss()
+            onAddStudent()
+        },
         onDateSelect = lessonCardViewModel::onDateSelected,
         onTimeSelect = lessonCardViewModel::onTimeSelected,
         onDurationSelect = lessonCardViewModel::onDurationSelected,


### PR DESCRIPTION
## Summary
- format lesson prices as whole rubles and present the payment status as a raised card within the lesson editor
- refresh the student picker with card-styled entries, an add-student action, and updated duration presets
- ensure editor sheets use a white surface and route add-student actions from lesson editor dialogs to the student editor

## Testing
- `bash gradlew lint` *(fails: Android SDK is not configured in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68ed04a01d748320b3128ee2d7540ebe