### PR TITLE
Revamp primary surfaces with gradient top bar and bottom nav

### DIFF
--- a/app/src/main/java/com/tutorly/navigation/AppNav.kt
+++ b/app/src/main/java/com/tutorly/navigation/AppNav.kt
@@ -1,9 +1,13 @@
 package com.tutorly.navigation
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.systemBars
-import androidx.compose.material3.MaterialTheme
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -30,6 +34,8 @@ import com.tutorly.ui.components.AppTopBar
 import com.tutorly.ui.screens.*
 import java.time.LocalDate
 import java.time.ZonedDateTime
+import com.tutorly.ui.theme.ScreenGradientEnd
+import com.tutorly.ui.theme.ScreenGradientStart
 
 const val ROUTE_CALENDAR = "calendar"
 private const val ROUTE_CALENDAR_PATTERN = "${ROUTE_CALENDAR}?${CalendarViewModel.ARG_ANCHOR_DATE}={${CalendarViewModel.ARG_ANCHOR_DATE}}&${CalendarViewModel.ARG_CALENDAR_MODE}={${CalendarViewModel.ARG_CALENDAR_MODE}}"
@@ -65,8 +71,17 @@ fun AppNavRoot() {
         else -> false                   // calendar/today рисуют верх сами
     }
 
-    Scaffold(
-        topBar = {
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(
+                Brush.verticalGradient(
+                    colors = listOf(ScreenGradientStart, ScreenGradientEnd)
+                )
+            )
+    ) {
+        Scaffold(
+            topBar = {
             if (showGlobalTopBar) {
                 AppTopBar(
                     title = when (route) {
@@ -77,8 +92,8 @@ fun AppNavRoot() {
                     onAddClick = null
                 )
             }
-        },
-        bottomBar = {
+            },
+            bottomBar = {
             AppBottomBar(
                 currentRoute = route,
                 onSelect = { dest ->
@@ -95,10 +110,10 @@ fun AppNavRoot() {
                 }
             )
         },
-        containerColor = MaterialTheme.colorScheme.surfaceContainerHighest,
-        // чтобы контент корректно учитывал статус/навигационные панели
-        contentWindowInsets = WindowInsets.systemBars
-    ) { innerPadding ->
+            containerColor = Color.Transparent,
+            // чтобы контент корректно учитывал статус/навигационные панели
+            contentWindowInsets = WindowInsets.systemBars
+        ) { innerPadding ->
         NavHost(
             navController = nav,
             startDestination = ROUTE_CALENDAR_PATTERN,

--- a/app/src/main/java/com/tutorly/ui/components/AppBottomBar.kt
+++ b/app/src/main/java/com/tutorly/ui/components/AppBottomBar.kt
@@ -2,21 +2,42 @@ package com.tutorly.ui.components
 
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.*
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.weight
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.NavigationBar
-import androidx.compose.material3.NavigationBarDefaults
-import androidx.compose.material3.NavigationBarItem
-import androidx.compose.material3.NavigationBarItemDefaults
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
 import com.tutorly.navigation.ROUTE_CALENDAR
 import com.tutorly.navigation.ROUTE_FINANCE
 import com.tutorly.navigation.ROUTE_STUDENTS
 import com.tutorly.navigation.ROUTE_TODAY
+import com.tutorly.ui.theme.SecondaryTextColor
 
 enum class Tab(val route:String, val label:String, val icon: androidx.compose.ui.graphics.vector.ImageVector){
-    Calendar(ROUTE_CALENDAR, "Календарь", Icons.Outlined.CalendarMonth),
+    Calendar(ROUTE_CALENDAR, "Расписание", Icons.Outlined.CalendarMonth),
     Today(ROUTE_TODAY, "Сегодня", Icons.Outlined.AssignmentTurnedIn),
     Students(ROUTE_STUDENTS, "Ученики", Icons.Outlined.People),
     Finance(ROUTE_FINANCE, "Финансы", Icons.Outlined.AttachMoney),
@@ -24,25 +45,60 @@ enum class Tab(val route:String, val label:String, val icon: androidx.compose.ui
 
 @Composable
 fun AppBottomBar(currentRoute: String, onSelect:(String)->Unit) {
-    NavigationBar(
-        containerColor = MaterialTheme.colorScheme.surface,
-        tonalElevation = NavigationBarDefaults.Elevation
+    val primaryColor = MaterialTheme.colorScheme.primary
+    Surface(
+        color = Color.White,
+        tonalElevation = 0.dp,
+        shadowElevation = 8.dp
     ) {
-        Tab.entries.forEach { tab ->
-            val selected = tab.route == currentRoute
-            NavigationBarItem(
-                selected = selected,
-                onClick = { onSelect(tab.route) },
-                icon = { Icon(tab.icon, contentDescription = tab.label) },
-                label = { Text(tab.label) },
-                colors = NavigationBarItemDefaults.colors(
-                    selectedIconColor = MaterialTheme.colorScheme.onPrimaryContainer,
-                    selectedTextColor = MaterialTheme.colorScheme.onPrimaryContainer,
-                    unselectedIconColor = MaterialTheme.colorScheme.onSurfaceVariant,
-                    unselectedTextColor = MaterialTheme.colorScheme.onSurfaceVariant,
-                    indicatorColor = MaterialTheme.colorScheme.primaryContainer
-                )
-            )
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(80.dp)
+                .padding(horizontal = 12.dp),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Tab.entries.forEach { tab ->
+                val selected = tab.route == currentRoute
+                val interactionSource = remember { MutableInteractionSource() }
+                Column(
+                    modifier = Modifier
+                        .weight(1f)
+                        .fillMaxHeight()
+                        .clip(RoundedCornerShape(16.dp))
+                        .clickable(
+                            interactionSource = interactionSource,
+                            indication = null
+                        ) { onSelect(tab.route) },
+                    horizontalAlignment = Alignment.CenterHorizontally
+                ) {
+                    Spacer(modifier = Modifier.height(3.dp))
+                    Box(
+                        modifier = Modifier
+                            .height(3.dp)
+                            .width(30.dp)
+                            .clip(RoundedCornerShape(2.dp))
+                            .background(if (selected) primaryColor else Color.Transparent)
+                    )
+                    Spacer(modifier = Modifier.height(9.dp))
+                    Icon(
+                        imageVector = tab.icon,
+                        contentDescription = tab.label,
+                        tint = if (selected) primaryColor else SecondaryTextColor,
+                        modifier = Modifier.size(24.dp)
+                    )
+                    Spacer(modifier = Modifier.height(4.dp))
+                    Text(
+                        text = tab.label,
+                        color = if (selected) primaryColor else SecondaryTextColor,
+                        style = MaterialTheme.typography.labelMedium,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis
+                    )
+                    Spacer(modifier = Modifier.weight(1f))
+                }
+            }
         }
     }
 }

--- a/app/src/main/java/com/tutorly/ui/components/TopBar.kt
+++ b/app/src/main/java/com/tutorly/ui/components/TopBar.kt
@@ -2,6 +2,16 @@ package com.tutorly.ui.components
 
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.asPaddingValues
+import androidx.compose.foundation.layout.calculateTopPadding
+import androidx.compose.foundation.layout.statusBars
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FilledTonalIconButton
 import androidx.compose.material3.Icon
@@ -11,38 +21,71 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
 import com.tutorly.R
+import com.tutorly.ui.theme.PrimaryTextColor
+import com.tutorly.ui.theme.TopBarGradientEnd
+import com.tutorly.ui.theme.TopBarGradientStart
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun AppTopBar(title: String, onAddClick: (() -> Unit)? = null) {
-    TopAppBar(
-        title = {
-            Text(
-                title,
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis,
-                color = MaterialTheme.colorScheme.onSurface
-            )
-        },
-        colors = TopAppBarDefaults.topAppBarColors(
-            containerColor = MaterialTheme.colorScheme.surfaceContainerHighest,
-            titleContentColor = MaterialTheme.colorScheme.onSurface
-        ),
-        actions = {
-            onAddClick?.let {
-                FilledTonalIconButton(
-                    onClick = it,
-                    colors = IconButtonDefaults.filledTonalIconButtonColors(
-                        containerColor = MaterialTheme.colorScheme.primaryContainer,
-                        contentColor = MaterialTheme.colorScheme.onPrimaryContainer
-                    )
-                ) {
-                    Icon(Icons.Default.Add, contentDescription = stringResource(id = R.string.add_student))
+    GradientTopBarContainer {
+        TopAppBar(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(90.dp),
+            title = {
+                Text(
+                    title,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    color = PrimaryTextColor
+                )
+            },
+            colors = TopAppBarDefaults.topAppBarColors(
+                containerColor = Color.Transparent,
+                scrolledContainerColor = Color.Transparent,
+                titleContentColor = PrimaryTextColor
+            ),
+            windowInsets = WindowInsets(0, 0, 0, 0),
+            actions = {
+                onAddClick?.let {
+                    FilledTonalIconButton(
+                        onClick = it,
+                        colors = IconButtonDefaults.filledTonalIconButtonColors(
+                            containerColor = MaterialTheme.colorScheme.primaryContainer,
+                            contentColor = MaterialTheme.colorScheme.onPrimaryContainer
+                        )
+                    ) {
+                        Icon(Icons.Default.Add, contentDescription = stringResource(id = R.string.add_student))
+                    }
                 }
             }
-        }
-    )
+        )
+    }
+}
+
+@Composable
+fun GradientTopBarContainer(content: @Composable () -> Unit) {
+    val statusBarPadding = WindowInsets.statusBars.asPaddingValues().calculateTopPadding()
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(bottomStart = 20.dp, bottomEnd = 20.dp))
+            .background(
+                Brush.horizontalGradient(
+                    colors = listOf(TopBarGradientStart, TopBarGradientEnd)
+                )
+            )
+    ) {
+        Spacer(modifier = Modifier.height(statusBarPadding))
+        content()
+    }
 }

--- a/app/src/main/java/com/tutorly/ui/screens/CalendarScreen.kt
+++ b/app/src/main/java/com/tutorly/ui/screens/CalendarScreen.kt
@@ -226,7 +226,7 @@ fun CalendarScreen(
                 )
             }
         },
-        containerColor = MaterialTheme.colorScheme.surfaceContainerHighest
+        containerColor = Color.Transparent
     ) { padding ->
         Column(
             Modifier

--- a/app/src/main/java/com/tutorly/ui/screens/StudentDetailsScreen.kt
+++ b/app/src/main/java/com/tutorly/ui/screens/StudentDetailsScreen.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -57,6 +58,7 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalContext
@@ -69,6 +71,7 @@ import com.tutorly.R
 import com.tutorly.domain.model.StudentProfile
 import com.tutorly.domain.model.StudentProfileLesson
 import com.tutorly.models.PaymentStatus
+import com.tutorly.ui.components.GradientTopBarContainer
 import com.tutorly.ui.components.PaymentBadge
 import com.tutorly.ui.components.PaymentBadgeStatus
 import com.tutorly.ui.lessoncard.LessonCardSheet
@@ -77,6 +80,7 @@ import com.tutorly.ui.lessoncreation.LessonCreationConfig
 import com.tutorly.ui.lessoncreation.LessonCreationOrigin
 import com.tutorly.ui.lessoncreation.LessonCreationSheet
 import com.tutorly.ui.lessoncreation.LessonCreationViewModel
+import com.tutorly.ui.theme.PrimaryTextColor
 import com.tutorly.ui.theme.TutorlyCardDefaults
 import java.text.NumberFormat
 import java.time.Instant
@@ -236,7 +240,7 @@ fun StudentDetailsScreen(
                 }
             }
         },
-        containerColor = MaterialTheme.colorScheme.background
+        containerColor = Color.Transparent
     ) { innerPadding ->
         when (val currentState = state) {
             StudentProfileUiState.Hidden, StudentProfileUiState.Loading -> {
@@ -340,47 +344,57 @@ private fun StudentProfileTopBar(
     archiveEnabled: Boolean = true,
     deleteEnabled: Boolean = true,
 ) {
-    TopAppBar(
-        title = {
-            Text(
-                text = title,
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis
-            )
-        },
-        navigationIcon = {
-            IconButton(onClick = onBack) {
-                Icon(
-                    imageVector = Icons.Filled.ArrowBack,
-                    contentDescription = stringResource(id = R.string.student_details_back)
+    GradientTopBarContainer {
+        TopAppBar(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(90.dp),
+            title = {
+                Text(
+                    text = title,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    color = PrimaryTextColor
                 )
-            }
-        },
-        actions = {
-            if (onArchiveClick != null && isArchived != null) {
-                IconButton(onClick = onArchiveClick, enabled = archiveEnabled) {
-                    val (icon, description) = if (isArchived) {
-                        Icons.Outlined.Unarchive to stringResource(id = R.string.student_details_unarchive)
-                    } else {
-                        Icons.Outlined.Archive to stringResource(id = R.string.student_details_archive)
-                    }
-                    Icon(imageVector = icon, contentDescription = description)
-                }
-            }
-            if (onDeleteClick != null) {
-                IconButton(onClick = onDeleteClick, enabled = deleteEnabled) {
+            },
+            navigationIcon = {
+                IconButton(onClick = onBack) {
                     Icon(
-                        imageVector = Icons.Outlined.Delete,
-                        contentDescription = stringResource(id = R.string.student_details_delete)
+                        imageVector = Icons.Filled.ArrowBack,
+                        contentDescription = stringResource(id = R.string.student_details_back)
                     )
                 }
-            }
-        },
-        colors = TopAppBarDefaults.topAppBarColors(
-            containerColor = MaterialTheme.colorScheme.surfaceContainerHighest,
-            titleContentColor = MaterialTheme.colorScheme.onSurface
+            },
+            actions = {
+                if (onArchiveClick != null && isArchived != null) {
+                    IconButton(onClick = onArchiveClick, enabled = archiveEnabled) {
+                        val (icon, description) = if (isArchived) {
+                            Icons.Outlined.Unarchive to stringResource(id = R.string.student_details_unarchive)
+                        } else {
+                            Icons.Outlined.Archive to stringResource(id = R.string.student_details_archive)
+                        }
+                        Icon(imageVector = icon, contentDescription = description)
+                    }
+                }
+                if (onDeleteClick != null) {
+                    IconButton(onClick = onDeleteClick, enabled = deleteEnabled) {
+                        Icon(
+                            imageVector = Icons.Outlined.Delete,
+                            contentDescription = stringResource(id = R.string.student_details_delete)
+                        )
+                    }
+                }
+            },
+            colors = TopAppBarDefaults.topAppBarColors(
+                containerColor = Color.Transparent,
+                scrolledContainerColor = Color.Transparent,
+                titleContentColor = PrimaryTextColor,
+                navigationIconContentColor = PrimaryTextColor,
+                actionIconContentColor = PrimaryTextColor
+            ),
+            windowInsets = WindowInsets(0, 0, 0, 0)
         )
-    )
+    }
 }
 
 @Composable

--- a/app/src/main/java/com/tutorly/ui/screens/StudentsScreen.kt
+++ b/app/src/main/java/com/tutorly/ui/screens/StudentsScreen.kt
@@ -147,7 +147,7 @@ fun StudentsScreen(
     Scaffold(
         modifier = modifier,
         snackbarHost = { SnackbarHost(hostState = snackbarHostState) },
-        containerColor = MaterialTheme.colorScheme.background,
+        containerColor = Color.Transparent,
         floatingActionButton = {
             FloatingActionButton(
                 onClick = { openCreationEditor(StudentEditorOrigin.STUDENTS) },

--- a/app/src/main/java/com/tutorly/ui/screens/TodayScreen.kt
+++ b/app/src/main/java/com/tutorly/ui/screens/TodayScreen.kt
@@ -59,6 +59,9 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.compose.foundation.layout.WindowInsets
+import com.tutorly.ui.components.GradientTopBarContainer
+import com.tutorly.ui.theme.PrimaryTextColor
 import com.tutorly.ui.theme.SuccessGreen
 import com.tutorly.ui.theme.TutorlyCardDefaults
 import com.tutorly.R
@@ -129,7 +132,7 @@ fun TodayScreen(
         modifier = modifier,
         topBar = { TodayTopBar(state = uiState) },
         snackbarHost = { SnackbarHost(hostState = snackbarHostState) },
-        containerColor = MaterialTheme.colorScheme.background
+        containerColor = Color.Transparent
     ) { innerPadding ->
         Box(
             modifier = Modifier
@@ -768,27 +771,39 @@ private fun LessonMetaPill(text: String, modifier: Modifier = Modifier) {
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun TodayTopBar(state: TodayUiState) {
-    TopAppBar(
-        title = { Text(text = stringResource(R.string.today_title)) },
-        actions = {
-            if (state is TodayUiState.Content && !state.isAllMarked) {
-                AssistChip(
-                    onClick = {},
-                    label = {
-                        Text(text = stringResource(R.string.today_remaining_count, state.pendingCount))
-                    },
-                    colors = AssistChipDefaults.assistChipColors(
-                        containerColor = MaterialTheme.colorScheme.surfaceVariant,
-                        labelColor = MaterialTheme.colorScheme.onSurfaceVariant
-                    )
+    GradientTopBarContainer {
+        TopAppBar(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(90.dp),
+            title = {
+                Text(
+                    text = stringResource(R.string.today_title),
+                    color = PrimaryTextColor
                 )
-            }
-        },
-        colors = TopAppBarDefaults.topAppBarColors(
-            containerColor = MaterialTheme.colorScheme.surfaceContainerHighest,
-            titleContentColor = MaterialTheme.colorScheme.onSurface
+            },
+            actions = {
+                if (state is TodayUiState.Content && !state.isAllMarked) {
+                    AssistChip(
+                        onClick = {},
+                        label = {
+                            Text(text = stringResource(R.string.today_remaining_count, state.pendingCount))
+                        },
+                        colors = AssistChipDefaults.assistChipColors(
+                            containerColor = MaterialTheme.colorScheme.surfaceVariant,
+                            labelColor = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    )
+                }
+            },
+            colors = TopAppBarDefaults.topAppBarColors(
+                containerColor = Color.Transparent,
+                scrolledContainerColor = Color.Transparent,
+                titleContentColor = PrimaryTextColor
+            ),
+            windowInsets = WindowInsets(0, 0, 0, 0)
         )
-    )
+    }
 }
 
 @Composable

--- a/app/src/main/java/com/tutorly/ui/theme/Color.kt
+++ b/app/src/main/java/com/tutorly/ui/theme/Color.kt
@@ -3,10 +3,12 @@ package com.tutorly.ui.theme
 import androidx.compose.ui.graphics.Color
 
 // Brand palette
-val PrimaryPurple = Color(0xFF5C2C65)
+val TopBarGradientStart = Color(0xFF3B7D72)
+val TopBarGradientEnd = Color(0xFF4E998C)
+val PrimaryPurple = TopBarGradientStart
 val OnPrimaryPurple = Color(0xFFFFFFFF)
-val PrimaryPurpleContainer = Color(0xFFEADDF0)
-val OnPrimaryPurpleContainer = Color(0xFF22102A)
+val PrimaryPurpleContainer = TopBarGradientEnd
+val OnPrimaryPurpleContainer = Color(0xFF0F2C26)
 
 val SecondaryCoral = Color(0xFFC1477F)
 val OnSecondaryCoral = Color(0xFFFFFFFF)
@@ -19,12 +21,17 @@ val TertiaryPeachContainer = Color(0xFFFFDCD3)
 val OnTertiaryPeachContainer = Color(0xFF55180B)
 
 // Neutral surfaces and content
-val SurfaceBlush = Color(0xFFFCFAFC)
-val OnSurfaceBlush = Color(0xFF2E2A35)
-val SurfaceVariantSoft = Color(0xFFF0E5F1)
-val OnSurfaceVariantSoft = Color(0xFF7A6D80)
-val OutlineLavender = Color(0xFFC5B6C9)
-val OutlineVariantLavender = Color(0xFFE5DAE6)
+val ScreenGradientStart = Color(0xFFF3F8F6)
+val ScreenGradientEnd = Color(0xFFF1F6F6)
+val PrimaryTextColor = Color(0xFF2C2C33)
+val SecondaryTextColor = Color(0xFF49484E)
+val AvatarFill = Color(0xFFDDE9E5)
+val SurfaceBlush = ScreenGradientStart
+val OnSurfaceBlush = PrimaryTextColor
+val SurfaceVariantSoft = AvatarFill
+val OnSurfaceVariantSoft = SecondaryTextColor
+val OutlineLavender = Color(0xFFB9C9C4)
+val OutlineVariantLavender = Color(0xFFE3ECE8)
 
 val SuccessGreen = Color(0xFF2DBE72)
 val OnSuccessGreen = Color(0xFFFFFFFF)
@@ -32,10 +39,10 @@ val SuccessGreenContainer = Color(0xFFD9F5E6)
 val OnSuccessGreenContainer = Color(0xFF0F3E25)
 
 val SurfaceContainerLowest = Color(0xFFFFFFFF)
-val SurfaceContainerLow = Color(0xFFFEF9FF)
-val SurfaceContainer = Color(0xFFF6ECF6)
-val SurfaceContainerHigh = Color(0xFFEDE1EF)
-val SurfaceContainerHighest = Color(0xFFE4D6E6)
+val SurfaceContainerLow = Color(0xFFF8FCFB)
+val SurfaceContainer = Color(0xFFF1F6F5)
+val SurfaceContainerHigh = Color(0xFFE8F0EE)
+val SurfaceContainerHighest = Color(0xFFDDE9E5)
 
 // Semantic
 val ErrorRed = Color(0xFFBA1A1A)


### PR DESCRIPTION
## Summary
- add a reusable gradient top bar container and apply it across the global, today, and student profile toolbars
- introduce the new light palette with updated text, surface, and background gradient colors while letting scaffolds show the gradient
- rebuild the bottom navigation into a custom bar with the new labels, indicator strip, and color states

## Testing
- ./gradlew :app:compileDebugKotlin *(fails: proxy returned HTTP/1.1 403 Forbidden while downloading Gradle)*

------
https://chatgpt.com/codex/tasks/task_e_68f00ebcd7b48320b69151cedf421702