### PR TITLE
Adjust top and bottom bar styling

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -68,6 +68,7 @@ dependencies {
 
 // Навигация (Compose)
     implementation(libs.androidx.navigation.compose)
+    implementation(libs.accompanist.navigation.animation)
 
 // Коррутины
     implementation(libs.kotlinx.coroutines.android)

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -53,6 +53,7 @@ dependencies {
     implementation(libs.androidx.lifecycle.runtime.ktx)
     implementation(libs.androidx.activity.compose)
     implementation(platform(libs.androidx.compose.bom))
+    implementation(libs.androidx.compose.animation)
     implementation(libs.androidx.compose.ui)
     implementation(libs.androidx.compose.ui.graphics)
     implementation(libs.androidx.compose.ui.tooling.preview)

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -54,6 +54,8 @@ dependencies {
     implementation(libs.androidx.activity.compose)
     implementation(platform(libs.androidx.compose.bom))
     implementation(libs.androidx.compose.animation)
+    implementation(libs.androidx.compose.animation.core)
+    implementation(libs.androidx.compose.animation.graphics)
     implementation(libs.androidx.compose.ui)
     implementation(libs.androidx.compose.ui.graphics)
     implementation(libs.androidx.compose.ui.tooling.preview)

--- a/app/src/main/java/com/tutorly/navigation/AppNav.kt
+++ b/app/src/main/java/com/tutorly/navigation/AppNav.kt
@@ -17,15 +17,15 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.window.DialogProperties
+import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavHostController
 import androidx.navigation.NavType
-import androidx.navigation.compose.AnimatedNavHost
-import androidx.navigation.compose.composable
 import androidx.navigation.compose.currentBackStackEntryAsState
-import androidx.navigation.compose.dialog
-import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navArgument
-import androidx.hilt.navigation.compose.hiltViewModel
+import com.google.accompanist.navigation.animation.AnimatedNavHost
+import com.google.accompanist.navigation.animation.composable
+import com.google.accompanist.navigation.animation.dialog
+import com.google.accompanist.navigation.animation.rememberAnimatedNavController
 import com.tutorly.ui.CalendarMode
 import com.tutorly.ui.CalendarScreen
 import com.tutorly.ui.CalendarViewModel
@@ -67,7 +67,7 @@ private fun studentEditRoute(studentId: Long, target: StudentEditTarget? = null)
 )
 @Composable
 fun AppNavRoot() {
-    val nav = rememberNavController()
+    val nav = rememberAnimatedNavController()
     val backStack by nav.currentBackStackEntryAsState()
     val destinationRoute = backStack?.destination?.route ?: ROUTE_CALENDAR
     val route = destinationRoute.substringBefore("?")

--- a/app/src/main/java/com/tutorly/navigation/AppNav.kt
+++ b/app/src/main/java/com/tutorly/navigation/AppNav.kt
@@ -1,25 +1,27 @@
 package com.tutorly.navigation
 
+import androidx.compose.animation.ExperimentalSharedTransitionApi
+import androidx.compose.animation.SharedTransitionLayout
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.systemBars
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.ui.graphics.Brush
-import androidx.compose.ui.graphics.Color
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.window.DialogProperties
 import androidx.navigation.NavHostController
 import androidx.navigation.NavType
-import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.AnimatedNavHost
 import androidx.navigation.compose.composable
-import androidx.navigation.compose.dialog
 import androidx.navigation.compose.currentBackStackEntryAsState
+import androidx.navigation.compose.dialog
 import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navArgument
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -58,6 +60,7 @@ private fun studentEditRoute(studentId: Long, target: StudentEditTarget? = null)
     }
 }
 
+@OptIn(ExperimentalSharedTransitionApi::class)
 @Composable
 fun AppNavRoot() {
     val nav = rememberNavController()
@@ -114,11 +117,13 @@ fun AppNavRoot() {
             // чтобы контент корректно учитывал статус/навигационные панели
             contentWindowInsets = WindowInsets.systemBars
         ) { innerPadding ->
-            NavHost(
-                navController = nav,
-                startDestination = ROUTE_CALENDAR_PATTERN,
-                modifier = Modifier.padding(innerPadding)
-            ) {
+            SharedTransitionLayout {
+                val sharedScope = this
+                AnimatedNavHost(
+                    navController = nav,
+                    startDestination = ROUTE_CALENDAR_PATTERN,
+                    modifier = Modifier.padding(innerPadding)
+                ) {
                 composable(
                     route = ROUTE_CALENDAR_PATTERN,
                     arguments = listOf(
@@ -202,7 +207,9 @@ fun AppNavRoot() {
                                 creationViewModel.dismiss()
                             }
                         },
-                        initialEditorOrigin = origin
+                        initialEditorOrigin = origin,
+                        sharedTransitionScope = sharedScope,
+                        animatedVisibilityScope = this
                     )
                 }
                 composable(
@@ -225,7 +232,9 @@ fun AppNavRoot() {
                                 launchSingleTop = true
                             }
                         },
-                        creationViewModel = creationViewModel
+                        creationViewModel = creationViewModel,
+                        sharedTransitionScope = sharedScope,
+                        animatedVisibilityScope = this
                     )
                 }
                 dialog(

--- a/app/src/main/java/com/tutorly/navigation/AppNav.kt
+++ b/app/src/main/java/com/tutorly/navigation/AppNav.kt
@@ -1,5 +1,6 @@
 package com.tutorly.navigation
 
+import androidx.compose.animation.ExperimentalAnimationApi
 import androidx.compose.animation.ExperimentalSharedTransitionApi
 import androidx.compose.animation.SharedTransitionLayout
 import androidx.compose.foundation.background
@@ -60,7 +61,10 @@ private fun studentEditRoute(studentId: Long, target: StudentEditTarget? = null)
     }
 }
 
-@OptIn(ExperimentalSharedTransitionApi::class)
+@OptIn(
+    ExperimentalSharedTransitionApi::class,
+    ExperimentalAnimationApi::class
+)
 @Composable
 fun AppNavRoot() {
     val nav = rememberNavController()

--- a/app/src/main/java/com/tutorly/ui/components/AppBottomBar.kt
+++ b/app/src/main/java/com/tutorly/ui/components/AppBottomBar.kt
@@ -15,7 +15,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -75,8 +74,8 @@ fun AppBottomBar(currentRoute: String, onSelect:(String)->Unit) {
                     Spacer(modifier = Modifier.height(3.dp))
                     Box(
                         modifier = Modifier
+                            .fillMaxWidth()
                             .height(3.dp)
-                            .width(30.dp)
                             .clip(RoundedCornerShape(2.dp))
                             .background(if (selected) primaryColor else Color.Transparent)
                     )

--- a/app/src/main/java/com/tutorly/ui/components/TopBar.kt
+++ b/app/src/main/java/com/tutorly/ui/components/TopBar.kt
@@ -3,12 +3,15 @@ package com.tutorly.ui.components
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.asPaddingValues
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.statusBars
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -20,15 +23,16 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.tutorly.R
-import com.tutorly.ui.theme.PrimaryTextColor
 import com.tutorly.ui.theme.TopBarGradientEnd
 import com.tutorly.ui.theme.TopBarGradientStart
 
@@ -41,17 +45,24 @@ fun AppTopBar(title: String, onAddClick: (() -> Unit)? = null) {
                 .fillMaxWidth()
                 .height(90.dp),
             title = {
-                Text(
-                    title,
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis,
-                    color = PrimaryTextColor
-                )
+                Box(
+                    modifier = Modifier
+                        .fillMaxHeight()
+                        .padding(start = 30.dp),
+                    contentAlignment = Alignment.CenterStart
+                ) {
+                    Text(
+                        title,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                        color = Color.White
+                    )
+                }
             },
             colors = TopAppBarDefaults.topAppBarColors(
                 containerColor = Color.Transparent,
                 scrolledContainerColor = Color.Transparent,
-                titleContentColor = PrimaryTextColor
+                titleContentColor = Color.White
             ),
             windowInsets = WindowInsets(0, 0, 0, 0),
             actions = {
@@ -74,10 +85,12 @@ fun AppTopBar(title: String, onAddClick: (() -> Unit)? = null) {
 @Composable
 fun GradientTopBarContainer(content: @Composable () -> Unit) {
     val statusBarPadding = WindowInsets.statusBars.asPaddingValues().calculateTopPadding()
+    val shape = RoundedCornerShape(bottomStart = 40.dp, bottomEnd = 40.dp)
     Column(
         modifier = Modifier
             .fillMaxWidth()
-            .clip(RoundedCornerShape(bottomStart = 20.dp, bottomEnd = 20.dp))
+            .shadow(elevation = 12.dp, shape = shape, clip = false)
+            .clip(shape)
             .background(
                 Brush.horizontalGradient(
                     colors = listOf(TopBarGradientStart, TopBarGradientEnd)

--- a/app/src/main/java/com/tutorly/ui/components/TopBar.kt
+++ b/app/src/main/java/com/tutorly/ui/components/TopBar.kt
@@ -5,27 +5,25 @@ import androidx.compose.material.icons.filled.Add
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
-import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.statusBars
+import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FilledTonalIconButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButtonDefaults
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
@@ -48,6 +46,7 @@ fun AppTopBar(title: String, onAddClick: (() -> Unit)? = null) {
                 Box(
                     modifier = Modifier
                         .fillMaxHeight()
+                        .fillMaxWidth()
                         .padding(start = 30.dp),
                     contentAlignment = Alignment.CenterStart
                 ) {
@@ -84,20 +83,27 @@ fun AppTopBar(title: String, onAddClick: (() -> Unit)? = null) {
 
 @Composable
 fun GradientTopBarContainer(content: @Composable () -> Unit) {
-    val statusBarPadding = WindowInsets.statusBars.asPaddingValues().calculateTopPadding()
     val shape = RoundedCornerShape(bottomStart = 40.dp, bottomEnd = 40.dp)
-    Column(
+    Surface(
         modifier = Modifier
             .fillMaxWidth()
-            .shadow(elevation = 12.dp, shape = shape, clip = false)
-            .clip(shape)
-            .background(
-                Brush.horizontalGradient(
-                    colors = listOf(TopBarGradientStart, TopBarGradientEnd)
-                )
-            )
+            .shadow(elevation = 12.dp, shape = shape, clip = false),
+        color = Color.Transparent,
+        shape = shape,
+        tonalElevation = 0.dp,
+        shadowElevation = 0.dp
     ) {
-        Spacer(modifier = Modifier.height(statusBarPadding))
-        content()
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(
+                    Brush.horizontalGradient(
+                        colors = listOf(TopBarGradientStart, TopBarGradientEnd)
+                    )
+                )
+                .statusBarsPadding()
+        ) {
+            content()
+        }
     }
 }

--- a/app/src/main/java/com/tutorly/ui/screens/StudentDetailsScreen.kt
+++ b/app/src/main/java/com/tutorly/ui/screens/StudentDetailsScreen.kt
@@ -5,7 +5,6 @@ import androidx.compose.animation.ExperimentalSharedTransitionApi
 import androidx.compose.animation.SharedTransitionScope
 import androidx.compose.animation.core.FastOutSlowInEasing
 import androidx.compose.animation.core.tween
-import androidx.compose.animation.rememberSharedContentState
 import androidx.compose.animation.sharedBounds
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -548,13 +547,13 @@ private fun StudentProfileHeader(
     animatedVisibilityScope: AnimatedVisibilityScope? = null,
     sharedContentKey: String? = null,
 ) {
-    val sharedState = sharedContentKey?.let { rememberSharedContentState(key = it) }
     val sharedModifier = if (
         sharedTransitionScope != null &&
         animatedVisibilityScope != null &&
-        sharedState != null
+        sharedContentKey != null
     ) {
         with(sharedTransitionScope) {
+            val sharedState = rememberSharedContentState(key = sharedContentKey)
             Modifier.sharedBounds(
                 sharedContentState = sharedState,
                 animatedVisibilityScope = animatedVisibilityScope,

--- a/app/src/main/java/com/tutorly/ui/screens/StudentDetailsScreen.kt
+++ b/app/src/main/java/com/tutorly/ui/screens/StudentDetailsScreen.kt
@@ -5,8 +5,8 @@ import androidx.compose.animation.ExperimentalSharedTransitionApi
 import androidx.compose.animation.SharedTransitionScope
 import androidx.compose.animation.core.FastOutSlowInEasing
 import androidx.compose.animation.core.tween
-import androidx.compose.animation.rememberSharedContentState
-import androidx.compose.animation.sharedBounds
+import androidx.compose.animation.SharedTransitionScope.rememberSharedContentState
+import androidx.compose.animation.SharedTransitionScope.sharedBounds
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement

--- a/app/src/main/java/com/tutorly/ui/screens/StudentDetailsScreen.kt
+++ b/app/src/main/java/com/tutorly/ui/screens/StudentDetailsScreen.kt
@@ -5,8 +5,8 @@ import androidx.compose.animation.ExperimentalSharedTransitionApi
 import androidx.compose.animation.SharedTransitionScope
 import androidx.compose.animation.core.FastOutSlowInEasing
 import androidx.compose.animation.core.tween
-import androidx.compose.animation.SharedTransitionScope.rememberSharedContentState
-import androidx.compose.animation.SharedTransitionScope.sharedBounds
+import androidx.compose.animation.rememberSharedContentState
+import androidx.compose.animation.sharedBounds
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement

--- a/app/src/main/java/com/tutorly/ui/screens/StudentsScreen.kt
+++ b/app/src/main/java/com/tutorly/ui/screens/StudentsScreen.kt
@@ -5,8 +5,8 @@ import androidx.compose.animation.ExperimentalSharedTransitionApi
 import androidx.compose.animation.SharedTransitionScope
 import androidx.compose.animation.core.FastOutSlowInEasing
 import androidx.compose.animation.core.tween
-import androidx.compose.animation.SharedTransitionScope.rememberSharedContentState
-import androidx.compose.animation.SharedTransitionScope.sharedBounds
+import androidx.compose.animation.rememberSharedContentState
+import androidx.compose.animation.sharedBounds
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement

--- a/app/src/main/java/com/tutorly/ui/screens/StudentsScreen.kt
+++ b/app/src/main/java/com/tutorly/ui/screens/StudentsScreen.kt
@@ -5,7 +5,6 @@ import androidx.compose.animation.ExperimentalSharedTransitionApi
 import androidx.compose.animation.SharedTransitionScope
 import androidx.compose.animation.core.FastOutSlowInEasing
 import androidx.compose.animation.core.tween
-import androidx.compose.animation.rememberSharedContentState
 import androidx.compose.animation.sharedBounds
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
@@ -383,13 +382,13 @@ private fun StudentCard(
     val note = item.student.note?.takeIf { it.isNotBlank() }?.trim()
     val showTrailingRow = phone != null || email != null || item.hasDebt
 
-    val sharedState = sharedContentKey?.let { rememberSharedContentState(key = it) }
     val sharedModifier = if (
         sharedTransitionScope != null &&
         animatedVisibilityScope != null &&
-        sharedState != null
+        sharedContentKey != null
     ) {
         with(sharedTransitionScope) {
+            val sharedState = rememberSharedContentState(key = sharedContentKey)
             Modifier.sharedBounds(
                 sharedContentState = sharedState,
                 animatedVisibilityScope = animatedVisibilityScope,

--- a/app/src/main/java/com/tutorly/ui/screens/StudentsScreen.kt
+++ b/app/src/main/java/com/tutorly/ui/screens/StudentsScreen.kt
@@ -5,8 +5,8 @@ import androidx.compose.animation.ExperimentalSharedTransitionApi
 import androidx.compose.animation.SharedTransitionScope
 import androidx.compose.animation.core.FastOutSlowInEasing
 import androidx.compose.animation.core.tween
-import androidx.compose.animation.rememberSharedContentState
-import androidx.compose.animation.sharedBounds
+import androidx.compose.animation.SharedTransitionScope.rememberSharedContentState
+import androidx.compose.animation.SharedTransitionScope.sharedBounds
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -32,6 +32,8 @@ androidx-activity-compose = { group = "androidx.activity", name = "activity-comp
 androidx-compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "composeBom" }
 androidx-compose-ui = { group = "androidx.compose.ui", name = "ui" }
 androidx-compose-animation = { group = "androidx.compose.animation", name = "animation" }
+androidx-compose-animation-core = { group = "androidx.compose.animation", name = "animation-core" }
+androidx-compose-animation-graphics = { group = "androidx.compose.animation", name = "animation-graphics" }
 androidx-compose-ui-graphics = { group = "androidx.compose.ui", name = "ui-graphics" }
 androidx-compose-ui-tooling = { group = "androidx.compose.ui", name = "ui-tooling" }
 androidx-compose-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-tooling-preview" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -31,6 +31,7 @@ androidx-lifecycle-runtime-ktx = { group = "androidx.lifecycle", name = "lifecyc
 androidx-activity-compose = { group = "androidx.activity", name = "activity-compose", version.ref = "activityCompose" }
 androidx-compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "composeBom" }
 androidx-compose-ui = { group = "androidx.compose.ui", name = "ui" }
+androidx-compose-animation = { group = "androidx.compose.animation", name = "animation" }
 androidx-compose-ui-graphics = { group = "androidx.compose.ui", name = "ui-graphics" }
 androidx-compose-ui-tooling = { group = "androidx.compose.ui", name = "ui-tooling" }
 androidx-compose-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-tooling-preview" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,6 +17,7 @@ room = "2.8.1"
 hilt = "2.57.2"
 hilt-navigation-compose = "1.3.0"
 kotlinx-metadata-jvm = "0.9.0"
+accompanist-navigation-animation = "0.36.0"
 foundation = "1.9.3"
 
 
@@ -38,6 +39,7 @@ androidx-compose-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-te
 androidx-compose-foundation = { group = "androidx.compose.foundation", name = "foundation" }
 androidx-compose-material3 = { group = "androidx.compose.material3", name = "material3" }
 androidx-navigation-compose = { module = "androidx.navigation:navigation-compose", version.ref = "navigation" }
+accompanist-navigation-animation = { module = "com.google.accompanist:accompanist-navigation-animation", version.ref = "accompanist-navigation-animation" }
 kotlinx-coroutines-android = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version.ref = "coroutines" }
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "coroutines" }
 androidx-lifecycle-viewmodel-compose = { module = "androidx.lifecycle:lifecycle-viewmodel-compose", version.ref = "lifecycle" }


### PR DESCRIPTION
## Summary
- round the top bar corners more aggressively, add a drop shadow, and update the title layout to match the new spacing and color requirements
- expand the bottom bar indicator to span the full width of each tab for better emphasis

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f0166198808320bf8e5cc66283d728