### PR TITLE
Let student profile header overlap the top bar

### DIFF
--- a/app/src/main/java/com/tutorly/ui/screens/StudentDetailsScreen.kt
+++ b/app/src/main/java/com/tutorly/ui/screens/StudentDetailsScreen.kt
@@ -954,12 +954,10 @@ private fun StudentProfileLessonCard(
     val start = remember(lesson.startAt, zoneId) { lesson.startAt.atZone(zoneId) }
     val end = remember(lesson.endAt, zoneId) { lesson.endAt.atZone(zoneId) }
     val dateText = remember(start) { dateFormatter.format(start) }
-    val timeText = stringResource(
-        id = R.string.student_details_history_time_range,
-        timeFormatter.format(start),
-        timeFormatter.format(end),
-        lesson.durationMinutes
-    )
+    val minutesSuffix = stringResource(id = R.string.lesson_create_minutes_suffix)
+    val timeText = remember(start, end, lesson.durationMinutes, minutesSuffix) {
+        "${timeFormatter.format(start)} — ${timeFormatter.format(end)} · ${lesson.durationMinutes} $minutesSuffix"
+    }
     val fallbackSubjectText = fallbackSubject?.takeIf { it.isNotBlank() }?.trim()
     val title = lesson.title?.takeIf { it.isNotBlank() }?.trim()
         ?: lesson.subjectName?.takeIf { it.isNotBlank() }?.trim()

--- a/app/src/main/java/com/tutorly/ui/screens/StudentDetailsScreen.kt
+++ b/app/src/main/java/com/tutorly/ui/screens/StudentDetailsScreen.kt
@@ -20,7 +20,6 @@ import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.matchParentSize
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -397,7 +396,7 @@ private fun StudentProfileTopBar(
             if (!showGradientBackground) {
                 Box(
                     modifier = Modifier
-                        .matchParentSize()
+                        .fillMaxSize()
                         .background(color = backgroundColor)
                 )
             }

--- a/app/src/main/java/com/tutorly/ui/screens/StudentDetailsScreen.kt
+++ b/app/src/main/java/com/tutorly/ui/screens/StudentDetailsScreen.kt
@@ -76,6 +76,7 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.tutorly.R
@@ -308,7 +309,7 @@ fun StudentDetailsScreen(
                     modifier = modifier
                         .fillMaxSize()
                         .padding(innerPadding)
-                        .padding(top = -StudentProfileTopBarOverlap),
+                        .offset { IntOffset(x = 0, y = -overlapPx) },
                     listState = listState,
                     sharedTransitionScope = sharedTransitionScope,
                     animatedVisibilityScope = animatedVisibilityScope

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -106,7 +106,6 @@
     <string name="student_details_history_title">История занятий</string>
     <string name="student_card_progress">Оплачено %1$d/%2$d</string>
     <string name="student_details_history_empty">Пока нет занятий</string>
-    <string name="student_details_history_time_range">%1$s — %2$s · %3$d мин</string>
     <string name="student_details_create_lesson">Создать занятие</string>
     <string name="student_details_open_profile">Открыть профиль</string>
     <string name="lesson_status_paid">Оплачено</string>


### PR DESCRIPTION
## Summary
- allow the student profile header to overlap the top bar when entering the details screen
- drive the top bar background and icon colors from the list scroll state so they match the visible background

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f0db839a4883209afd4d3f2474c737