### PR TITLE
Ensure week calendar day cards have minimum height

### DIFF
--- a/app/src/main/java/com/tutorly/ui/components/WeekMosaic.kt
+++ b/app/src/main/java/com/tutorly/ui/components/WeekMosaic.kt
@@ -83,18 +83,13 @@ private fun DayTile(
     onLessonClick: (LessonBrief) -> Unit
 ) {
     val isToday = model.date == today
-    val hasLessons = model.totalLessons > 0
-
     val (ongoing, others) = remember(model, isToday, now) {
         if (!isToday) emptyList<LessonBrief>() to model.brief
         else model.brief.partition { it.isOngoingOn(model.date, now) }
     }
 
-    // лёгкая подложка только если есть занятия
-    val bg: Color = if (hasLessons)
-        MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.35f)
-    else
-        Color.Transparent
+    // белая подложка для всех дней
+    val bg: Color = Color.White
 
     val dayShape = MaterialTheme.shapes.medium
     Surface(

--- a/app/src/main/java/com/tutorly/ui/components/WeekMosaic.kt
+++ b/app/src/main/java/com/tutorly/ui/components/WeekMosaic.kt
@@ -1,5 +1,6 @@
 package com.tutorly.ui.components
 
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
@@ -27,7 +28,7 @@ import java.time.format.TextStyle
 import java.time.ZoneId
 import java.util.Locale
 
-private val DayTileMinHeight = 56.dp
+private val DayTileMinHeight = 112.dp
 
 /* =====================  WEEK MOSAIC (single column list)  ===================== */
 
@@ -170,11 +171,17 @@ private fun LessonRowCompact(
     currentDateTime: ZonedDateTime,
     onClick: () -> Unit
 ) {
-    val (bg, fg) = when (tone) {
-        LessonTone.Default -> MaterialTheme.colorScheme.surface.copy(alpha = 0.6f) to
-                MaterialTheme.colorScheme.onSurface
-        LessonTone.Ongoing -> MaterialTheme.colorScheme.primaryContainer to
-                MaterialTheme.colorScheme.onPrimaryContainer
+    val (bg, fg, border) = when (tone) {
+        LessonTone.Default -> Triple(
+            MaterialTheme.colorScheme.surface.copy(alpha = 0.6f),
+            MaterialTheme.colorScheme.onSurface,
+            BorderStroke(1.dp, MaterialTheme.colorScheme.outline)
+        )
+        LessonTone.Ongoing -> Triple(
+            MaterialTheme.colorScheme.primaryContainer,
+            MaterialTheme.colorScheme.onPrimaryContainer,
+            BorderStroke(1.dp, MaterialTheme.colorScheme.primary)
+        )
     }
 
     val shape = RoundedCornerShape(8.dp)
@@ -182,6 +189,7 @@ private fun LessonRowCompact(
         color = bg,
         contentColor = fg,
         shape = shape,
+        border = border,
         modifier = Modifier
             .fillMaxWidth()
             .defaultMinSize(minHeight = 40.dp)

--- a/app/src/main/java/com/tutorly/ui/components/WeekMosaic.kt
+++ b/app/src/main/java/com/tutorly/ui/components/WeekMosaic.kt
@@ -27,7 +27,7 @@ import java.time.format.TextStyle
 import java.time.ZoneId
 import java.util.Locale
 
-private val DayTileMinHeight = 132.dp
+private val DayTileMinHeight = 56.dp
 
 /* =====================  WEEK MOSAIC (single column list)  ===================== */
 

--- a/app/src/main/java/com/tutorly/ui/components/WeekMosaic.kt
+++ b/app/src/main/java/com/tutorly/ui/components/WeekMosaic.kt
@@ -27,6 +27,8 @@ import java.time.format.TextStyle
 import java.time.ZoneId
 import java.util.Locale
 
+private val DayTileMinHeight = 132.dp
+
 /* =====================  WEEK MOSAIC (single column list)  ===================== */
 
 @Composable
@@ -105,6 +107,7 @@ private fun DayTile(
         Column(
             Modifier
                 .fillMaxWidth()
+                .heightIn(min = DayTileMinHeight)
                 .padding(8.dp), // компакт
             verticalArrangement = Arrangement.spacedBy(6.dp)
         ) {


### PR DESCRIPTION
## Summary
- add a predefined minimum height for week view day cards
- ensure the day tile column respects the minimum height so empty days stay tall enough

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f2c4d1182883209b9f4ea917f7c7f7