### PR TITLE
Add archive toggle for students screen

### DIFF
--- a/app/src/main/java/com/tutorly/data/db/dao/StudentDao.kt
+++ b/app/src/main/java/com/tutorly/data/db/dao/StudentDao.kt
@@ -11,13 +11,19 @@ import kotlinx.coroutines.flow.Flow
 
 @Dao
 interface StudentDao {
-    @Query("SELECT * FROM students WHERE active = 1 ORDER BY name COLLATE NOCASE")
+    @Query(
+        """
+        SELECT * FROM students
+        WHERE active = 1 AND isArchived = 0
+        ORDER BY name COLLATE NOCASE
+        """
+    )
     suspend fun getAllActive(): List<Student>
 
     @Query(
         """
         SELECT * FROM students
-        WHERE active = 1 AND (
+        WHERE active = 1 AND isArchived = 0 AND (
             :q == '' OR name LIKE '%' || :q || '%' OR phone LIKE '%' || :q || '%'
         )
         ORDER BY name COLLATE NOCASE
@@ -28,14 +34,27 @@ interface StudentDao {
     @Query("SELECT * FROM students WHERE id = :id LIMIT 1")
     suspend fun getById(id: Long): Student?
 
-    @Query("""
+    @Query(
+        """
         SELECT * FROM students
-        WHERE active = 1 AND (
+        WHERE active = 1 AND isArchived = 0 AND (
             :q == '' OR name LIKE '%' || :q || '%' OR phone LIKE '%' || :q || '%'
         )
         ORDER BY name COLLATE NOCASE
-    """)
+        """
+    )
     fun observeStudents(q: String): Flow<List<Student>>
+
+    @Query(
+        """
+        SELECT * FROM students
+        WHERE isArchived = 1 AND (
+            :q == '' OR name LIKE '%' || :q || '%' OR phone LIKE '%' || :q || '%'
+        )
+        ORDER BY name COLLATE NOCASE
+        """
+    )
+    fun observeArchivedStudents(q: String): Flow<List<Student>>
 
     @Query("SELECT * FROM students WHERE id = :id")
     fun observeStudent(id: Long): Flow<Student?>

--- a/app/src/main/java/com/tutorly/data/repo/room/RoomStudentsRepository.kt
+++ b/app/src/main/java/com/tutorly/data/repo/room/RoomStudentsRepository.kt
@@ -37,6 +37,9 @@ class RoomStudentsRepository @Inject constructor(
     override fun observeStudents(query: String): Flow<List<Student>> =
         studentDao.observeStudents(query)
 
+    override fun observeArchivedStudents(query: String): Flow<List<Student>> =
+        studentDao.observeArchivedStudents(query)
+
     override fun observeStudent(id: Long): Flow<Student?> =
         studentDao.observeStudent(id)
 

--- a/app/src/main/java/com/tutorly/domain/repo/StudentsRepository.kt
+++ b/app/src/main/java/com/tutorly/domain/repo/StudentsRepository.kt
@@ -12,6 +12,7 @@ interface StudentsRepository {
 
     // observable — для UI
     fun observeStudents(query: String): Flow<List<Student>>
+    fun observeArchivedStudents(query: String): Flow<List<Student>>
     fun observeStudent(id: Long): Flow<Student?>
 
     fun observeStudentProfile(studentId: Long, recentLessonsLimit: Int = 5): Flow<StudentProfile?>

--- a/app/src/main/java/com/tutorly/navigation/AppNav.kt
+++ b/app/src/main/java/com/tutorly/navigation/AppNav.kt
@@ -13,10 +13,9 @@ import androidx.compose.foundation.layout.systemBars
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Archive
 import androidx.compose.material.icons.outlined.Unarchive
-import androidx.compose.material3.FilledTonalIconButton
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.IconButtonDefaults
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
@@ -314,19 +313,12 @@ private fun RowScope.StudentsArchiveAction(
             R.string.students_archive_show
         }
     )
-    val buttonColors = if (isArchiveMode) {
-        IconButtonDefaults.filledTonalIconButtonColors(
-            containerColor = MaterialTheme.colorScheme.primaryContainer,
-            contentColor = MaterialTheme.colorScheme.onPrimaryContainer
-        )
-    } else {
-        IconButtonDefaults.filledTonalIconButtonColors(
-            containerColor = Color.White.copy(alpha = 0.24f),
-            contentColor = Color.White
-        )
-    }
+    val buttonColors = IconButtonDefaults.iconButtonColors(
+        contentColor = Color.White,
+        disabledContentColor = Color.White.copy(alpha = 0.4f)
+    )
 
-    FilledTonalIconButton(
+    IconButton(
         onClick = onToggle,
         colors = buttonColors
     ) {

--- a/app/src/main/java/com/tutorly/navigation/AppNav.kt
+++ b/app/src/main/java/com/tutorly/navigation/AppNav.kt
@@ -285,8 +285,14 @@ private fun StudentsTopBar(navController: NavHostController) {
     val viewModel: StudentsViewModel = hiltViewModel(backStackEntry)
     val isArchiveMode by viewModel.isArchiveMode.collectAsState()
 
+    val titleRes = if (isArchiveMode) {
+        R.string.students_archive_title
+    } else {
+        R.string.students_title
+    }
+
     AppTopBar(
-        title = stringResource(id = R.string.students_title),
+        title = stringResource(id = titleRes),
         actions = {
             StudentsArchiveAction(
                 isArchiveMode = isArchiveMode,

--- a/app/src/main/java/com/tutorly/navigation/AppNav.kt
+++ b/app/src/main/java/com/tutorly/navigation/AppNav.kt
@@ -5,17 +5,27 @@ import androidx.compose.animation.ExperimentalSharedTransitionApi
 import androidx.compose.animation.SharedTransitionLayout
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.systemBars
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Archive
+import androidx.compose.material.icons.outlined.Unarchive
+import androidx.compose.material3.FilledTonalIconButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButtonDefaults
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.window.DialogProperties
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavHostController
@@ -39,6 +49,7 @@ import java.time.LocalDate
 import java.time.ZonedDateTime
 import com.tutorly.ui.theme.ScreenGradientEnd
 import com.tutorly.ui.theme.ScreenGradientStart
+import com.tutorly.R
 
 const val ROUTE_CALENDAR = "calendar"
 private const val ROUTE_CALENDAR_PATTERN = "${ROUTE_CALENDAR}?${CalendarViewModel.ARG_ANCHOR_DATE}={${CalendarViewModel.ARG_ANCHOR_DATE}}&${CalendarViewModel.ARG_CALENDAR_MODE}={${CalendarViewModel.ARG_CALENDAR_MODE}}"
@@ -72,12 +83,6 @@ fun AppNavRoot() {
     val destinationRoute = backStack?.destination?.route ?: ROUTE_CALENDAR
     val route = destinationRoute.substringBefore("?")
 
-    // какой топбар показывать
-    val showGlobalTopBar = when (route) {
-        ROUTE_STUDENTS, ROUTE_FINANCE -> true   // тут простой заголовок уместен
-        else -> false                   // calendar/today рисуют верх сами
-    }
-
     Box(
         modifier = Modifier
             .fillMaxSize()
@@ -89,15 +94,9 @@ fun AppNavRoot() {
     ) {
         Scaffold(
             topBar = {
-                if (showGlobalTopBar) {
-                    AppTopBar(
-                        title = when (route) {
-                            ROUTE_STUDENTS -> "Ученики"
-                            ROUTE_FINANCE -> "Финансы"
-                            else -> ""
-                        },
-                        onAddClick = null
-                    )
+                when (route) {
+                    ROUTE_STUDENTS -> StudentsTopBar(nav)
+                    ROUTE_FINANCE -> AppTopBar(title = stringResource(id = R.string.finance_title))
                 }
             },
             bottomBar = {
@@ -279,6 +278,60 @@ fun calendarRoute(nav: NavHostController): String {
     val savedDate = entry?.savedStateHandle?.get<String>(CalendarViewModel.ARG_ANCHOR_DATE)
     val savedMode = entry?.savedStateHandle?.get<String>(CalendarViewModel.ARG_CALENDAR_MODE)
     return buildCalendarRoute(savedDate, savedMode)
+}
+
+@Composable
+private fun StudentsTopBar(navController: NavHostController) {
+    val backStackEntry = remember(navController) { navController.getBackStackEntry(ROUTE_STUDENTS_PATTERN) }
+    val viewModel: StudentsViewModel = hiltViewModel(backStackEntry)
+    val isArchiveMode by viewModel.isArchiveMode.collectAsState()
+
+    AppTopBar(
+        title = stringResource(id = R.string.students_title),
+        actions = {
+            StudentsArchiveAction(
+                isArchiveMode = isArchiveMode,
+                onToggle = viewModel::toggleArchiveMode
+            )
+        }
+    )
+}
+
+@Composable
+private fun RowScope.StudentsArchiveAction(
+    isArchiveMode: Boolean,
+    onToggle: () -> Unit
+) {
+    val icon = if (isArchiveMode) {
+        Icons.Outlined.Unarchive
+    } else {
+        Icons.Outlined.Archive
+    }
+    val contentDescription = stringResource(
+        id = if (isArchiveMode) {
+            R.string.students_archive_show_active
+        } else {
+            R.string.students_archive_show
+        }
+    )
+    val buttonColors = if (isArchiveMode) {
+        IconButtonDefaults.filledTonalIconButtonColors(
+            containerColor = MaterialTheme.colorScheme.primaryContainer,
+            contentColor = MaterialTheme.colorScheme.onPrimaryContainer
+        )
+    } else {
+        IconButtonDefaults.filledTonalIconButtonColors(
+            containerColor = Color.White.copy(alpha = 0.24f),
+            contentColor = Color.White
+        )
+    }
+
+    FilledTonalIconButton(
+        onClick = onToggle,
+        colors = buttonColors
+    ) {
+        Icon(imageVector = icon, contentDescription = contentDescription)
+    }
 }
 
 fun buildCalendarRoute(date: String?, mode: String?): String {

--- a/app/src/main/java/com/tutorly/ui/components/TopBar.kt
+++ b/app/src/main/java/com/tutorly/ui/components/TopBar.kt
@@ -5,6 +5,7 @@ import androidx.compose.material.icons.filled.Add
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -36,7 +37,11 @@ import com.tutorly.ui.theme.TopBarGradientStart
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun AppTopBar(title: String, onAddClick: (() -> Unit)? = null) {
+fun AppTopBar(
+    title: String,
+    onAddClick: (() -> Unit)? = null,
+    actions: @Composable RowScope.() -> Unit = {}
+) {
     GradientTopBarContainer {
         TopAppBar(
             modifier = Modifier
@@ -65,6 +70,7 @@ fun AppTopBar(title: String, onAddClick: (() -> Unit)? = null) {
             ),
             windowInsets = WindowInsets(0, 0, 0, 0),
             actions = {
+                actions()
                 onAddClick?.let {
                     FilledTonalIconButton(
                         onClick = it,

--- a/app/src/main/java/com/tutorly/ui/screens/StudentsScreen.kt
+++ b/app/src/main/java/com/tutorly/ui/screens/StudentsScreen.kt
@@ -395,10 +395,7 @@ private fun StudentCard(
         .joinToString(separator = " • ")
         .takeIf { it.isNotBlank() }
 
-    val phone = item.student.phone?.takeIf { it.isNotBlank() }?.trim()
-    val email = item.student.messenger?.takeIf { it.isNotBlank() }?.trim()
     val note = item.student.note?.takeIf { it.isNotBlank() }?.trim()
-    val showTrailingRow = phone != null || email != null
 
     val sharedModifier = if (
         sharedTransitionScope != null &&
@@ -539,37 +536,6 @@ private fun StudentCard(
                                     maxLines = 1,
                                     overflow = TextOverflow.Ellipsis
                                 )
-                            }
-                        }
-                        if (showTrailingRow) {
-                            Row(
-                                modifier = Modifier
-                                    .fillMaxWidth()
-                                    .padding(top = 4.dp),
-                                horizontalArrangement = Arrangement.End,
-                                verticalAlignment = Alignment.CenterVertically
-                            ) {
-                                if (phone != null) {
-                                    Text(
-                                        text = phone,
-                                        style = MaterialTheme.typography.bodySmall,
-                                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                                        maxLines = 1,
-                                        overflow = TextOverflow.Ellipsis
-                                    )
-                                }
-                                if (email != null) {
-                                    if (phone != null) {
-                                        Spacer(Modifier.width(12.dp))
-                                    }
-                                    Text(
-                                        text = email,
-                                        style = MaterialTheme.typography.bodySmall,
-                                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                                        maxLines = 1,
-                                        overflow = TextOverflow.Ellipsis
-                                    )
-                                }
                             }
                         }
                     }

--- a/app/src/main/java/com/tutorly/ui/screens/StudentsScreen.kt
+++ b/app/src/main/java/com/tutorly/ui/screens/StudentsScreen.kt
@@ -98,6 +98,7 @@ fun StudentsScreen(
     val query by vm.query.collectAsState()
     val students by vm.students.collectAsState()
     val formState by vm.editorFormState.collectAsState()
+    val isArchiveMode by vm.isArchiveMode.collectAsState()
     val snackbarHostState = remember { SnackbarHostState() }
     val coroutineScope = rememberCoroutineScope()
     val context = LocalContext.current
@@ -202,7 +203,10 @@ fun StudentsScreen(
             Spacer(Modifier.height(16.dp))
 
             if (students.isEmpty()) {
-                EmptyStudentsState(Modifier.fillMaxSize())
+                EmptyStudentsState(
+                    isArchiveMode = isArchiveMode,
+                    modifier = Modifier.fillMaxSize()
+                )
             } else {
                 LazyColumn(
                     modifier = Modifier.fillMaxSize(),
@@ -360,10 +364,16 @@ fun StudentEditorSheet(
 }
 
 @Composable
-private fun EmptyStudentsState(modifier: Modifier = Modifier) {
+private fun EmptyStudentsState(isArchiveMode: Boolean, modifier: Modifier = Modifier) {
     Box(modifier, contentAlignment = Alignment.Center) {
         Text(
-            text = stringResource(id = R.string.students_empty_state),
+            text = stringResource(
+                id = if (isArchiveMode) {
+                    R.string.students_archive_empty_state
+                } else {
+                    R.string.students_empty_state
+                }
+            ),
             style = MaterialTheme.typography.bodyMedium
         )
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -5,6 +5,7 @@
     <string name="students_empty_state">Добавьте первого ученика</string>
     <string name="students_archive_empty_state">В архиве нет учеников</string>
     <string name="students_title">Ученики</string>
+    <string name="students_archive_title">Архив учеников</string>
     <string name="students_archive_show">Открыть архив учеников</string>
     <string name="students_archive_show_active">Показать активных учеников</string>
     <string name="students_subject_label">Предмет</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -3,6 +3,10 @@
     <string name="add_student">Добавить ученика</string>
     <string name="search_students_hint">Поиск по имени или телефону</string>
     <string name="students_empty_state">Добавьте первого ученика</string>
+    <string name="students_archive_empty_state">В архиве нет учеников</string>
+    <string name="students_title">Ученики</string>
+    <string name="students_archive_show">Открыть архив учеников</string>
+    <string name="students_archive_show_active">Показать активных учеников</string>
     <string name="students_subject_label">Предмет</string>
     <string name="students_subject_placeholder">Не указан</string>
     <string name="students_grade_label">Класс</string>
@@ -221,6 +225,7 @@
     <string name="lesson_details_duration_dialog_title">Длительность занятия</string>
     <string name="lesson_details_duration_custom_hint">Своя длительность</string>
     <string name="lesson_details_save">Сохранить</string>
+    <string name="finance_title">Финансы</string>
     <string name="finance_statistics_title">Статистика</string>
     <string name="finance_period_day">День</string>
     <string name="finance_period_week">Неделя</string>


### PR DESCRIPTION
## Summary
- add an archive toggle button to the students top bar and adjust the empty state copy when viewing archived learners
- extend the students repository and DAO with queries for archived students so the screen can swap between active and archived lists
- update the students view model and screen to react to the new archive mode and reuse the existing list rendering

## Testing
- `bash ./gradlew :app:assembleDebug` *(fails: Unable to tunnel through proxy, HTTP/1.1 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68f2c88a7edc83208dbf4d16f0130c85