### PR TITLE
Add splash screen for app launch

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -37,7 +37,7 @@
         <activity
             android:name=".MainActivity"
             android:exported="true"
-            android:theme="@style/Theme.Tutorly"> <!-- Или отдельная тема для сплэша/активити -->
+            android:theme="@style/Theme.Tutorly.Splash">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />

--- a/app/src/main/java/com/tutorly/MainActivity.kt
+++ b/app/src/main/java/com/tutorly/MainActivity.kt
@@ -4,6 +4,7 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.runtime.getValue
+import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.tutorly.navigation.AppNavRoot
@@ -16,6 +17,7 @@ import dagger.hilt.android.AndroidEntryPoint
 class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
+        installSplashScreen()
         super.onCreate(savedInstanceState)
         setContent {
             val profileViewModel: UserProfileViewModel = hiltViewModel()

--- a/app/src/main/res/drawable/splash_background.xml
+++ b/app/src/main/res/drawable/splash_background.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <gradient
+        android:angle="270"
+        android:startColor="@color/splash_background_top"
+        android:endColor="@color/splash_background_bottom" />
+</shape>

--- a/app/src/main/res/drawable/splash_logo.xml
+++ b/app/src/main/res/drawable/splash_logo.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="108dp"
+    android:height="108dp"
+    android:viewportWidth="108"
+    android:viewportHeight="108">
+
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:fillAlpha="0.18"
+        android:pathData="M34,20h40a12,12 0 0 1 12,12v44a12,12 0 0 1 -12,12H34a12,12 0 0 1 -12,-12V32a12,12 0 0 1 12,-12z" />
+
+    <path
+        android:strokeColor="#FFFFFFFF"
+        android:strokeWidth="8"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round"
+        android:pathData="M30,36H78M54,36V78" />
+
+    <path
+        android:strokeColor="#AEE5D3"
+        android:strokeWidth="6"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round"
+        android:pathData="M40,66l14,-8 14,8" />
+</vector>

--- a/app/src/main/res/drawable/splash_logo.xml
+++ b/app/src/main/res/drawable/splash_logo.xml
@@ -1,67 +1,150 @@
 <?xml version="1.0" encoding="utf-8"?>
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
     android:width="240dp"
-    android:height="240dp"
+    android:height="360dp"
     android:viewportWidth="240"
-    android:viewportHeight="240">
+    android:viewportHeight="360">
 
+    <!-- Calendar emblem -->
     <group
-        android:translateX="48"
-        android:translateY="32"
-        android:scaleX="0.92"
-        android:scaleY="0.92">
+        android:translateX="60"
+        android:translateY="64">
+        <path
+            android:fillColor="#5CD7C6"
+            android:pathData="M16,0h88a16,16 0 0 1 16,16v88a16,16 0 0 1 -16,16H16A16,16 0 0 1 0,104V16A16,16 0 0 1 16,0Z" />
+        <path
+            android:fillColor="#6FE1D2"
+            android:pathData="M16,0h88a16,16 0 0 1 16,16v20H0V16A16,16 0 0 1 16,0Z"
+            android:fillAlpha="0.6" />
+        <path
+            android:fillColor="#FFFFFFFF"
+            android:pathData="M24,32h72a12,12 0 0 1 12,12v56a12,12 0 0 1 -12,12H24A12,12 0 0 1 12,100V44A12,12 0 0 1 24,32Z" />
         <path
             android:fillColor="#33FFFFFF"
-            android:pathData="M16,36h144a16,16 0 0 1 16,16v96a16,16 0 0 1 -16,16H16a16,16 0 0 1 -16,-16V52A16,16 0 0 1 16,36Z" />
-        <path
-            android:fillColor="#E6FFFFFF"
-            android:pathData="M24,24h128a18,18 0 0 1 18,18v108a18,18 0 0 1 -18,18H24a18,18 0 0 1 -18,-18V42A18,18 0 0 1 24,24Z" />
-        <path
-            android:fillColor="#33FFFFFF"
-            android:pathData="M6,58h164v20H6Z" />
+            android:pathData="M16,48h88v10H16Z" />
         <path
             android:strokeColor="#FFFFFF"
-            android:strokeWidth="7"
+            android:strokeWidth="6"
             android:strokeLineCap="round"
-            android:pathData="M48,16v28" />
+            android:pathData="M44,18v20" />
         <path
             android:strokeColor="#FFFFFF"
-            android:strokeWidth="7"
+            android:strokeWidth="6"
             android:strokeLineCap="round"
-            android:pathData="M128,16v28" />
+            android:pathData="M96,18v20" />
         <path
-            android:strokeColor="#FFFFFF"
-            android:strokeWidth="8"
-            android:strokeLineCap="round"
-            android:strokeLineJoin="round"
-            android:pathData="M56,108l24,24 44,-44" />
+            android:fillColor="#FFFFFFFF"
+            android:pathData="M36,66h48v10H36Z" />
+        <path
+            android:fillColor="#FFFFFFFF"
+            android:pathData="M36,88h32v10H36Z" />
     </group>
 
+    <!-- Tutorly wordmark -->
     <group
-        android:translateX="18"
-        android:translateY="162"
-        android:scaleX="0.54"
-        android:scaleY="0.54">
+        android:translateX="60"
+        android:translateY="214"
+        android:scaleX="0.45"
+        android:scaleY="0.45">
         <path
-            android:fillColor="#FFFFFF"
+            android:fillColor="#FFFFFFFF"
             android:pathData="M0,0h44v12H28v68H16V12H0Z" />
         <path
-            android:fillColor="#FFFFFF"
+            android:fillColor="#FFFFFFFF"
             android:pathData="M60,0h12v40c0,12 6,18 18,18s18,-6 18,-18V0h12v40c0,24 -14,36 -30,36s-30,-12 -30,-36Z" />
         <path
-            android:fillColor="#FFFFFF"
+            android:fillColor="#FFFFFFFF"
             android:pathData="M140,0h48v12h-16v68h-12V12h-20Z" />
         <path
-            android:fillColor="#FFFFFF"
+            android:fillColor="#FFFFFFFF"
             android:pathData="M204,0h44c16,0 22,10 22,22v36c0,12 -6,22 -22,22h-44c-16,0 -22,-10 -22,-22V22c0,-12 6,-22 22,-22ZM204,12c-8,0 -10,4 -10,10v36c0,6 2,10 10,10h44c8,0 10,-4 10,-10V22c0,-6 -2,-10 -10,-10Z" />
         <path
-            android:fillColor="#FFFFFF"
+            android:fillColor="#FFFFFFFF"
             android:pathData="M288,0h12v26h22c14,0 22,8 22,22 0,10 -6,20 -18,22l20,30h-14l-18,-28h-14v28h-12Zm12,38v22h20c8,0 12,-4 12,-10 0,-8 -4,-12 -12,-12Z" />
         <path
-            android:fillColor="#FFFFFF"
+            android:fillColor="#FFFFFFFF"
             android:pathData="M348,0h12v68h28v12h-40Z" />
         <path
-            android:fillColor="#FFFFFF"
+            android:fillColor="#FFFFFFFF"
             android:pathData="M400,0h14l20,30 20,-30h14l-24,36v44h-12V36Z" />
+    </group>
+
+    <!-- Progress spinner -->
+    <group
+        android:translateX="108"
+        android:translateY="272">
+        <path
+            android:strokeColor="#B3FFFFFF"
+            android:strokeWidth="6"
+            android:strokeLineCap="round"
+            android:pathData="M24,12A12,12 0 1,1 12,0" />
+        <path
+            android:strokeColor="#FFFFFFFF"
+            android:strokeWidth="6"
+            android:strokeLineCap="round"
+            android:pathData="M24,12A12,12 0 0,0 12,0" />
+    </group>
+
+    <!-- Loading label -->
+    <group
+        android:translateX="24"
+        android:translateY="316"
+        android:scaleX="0.34"
+        android:scaleY="0.34">
+        <group android:translateX="0">
+            <path
+                android:fillColor="#CCFFFFFF"
+                android:pathData="M0,0h60v12H12v18h40v12H12v18h48v12H0Z" />
+        </group>
+        <group android:translateX="72">
+            <path
+                android:fillColor="#CCFFFFFF"
+                android:pathData="M0,72l22,-72h16l22,72h-14l-5,-16H19l-5,16Zm24,-26h18l-9,-28Z" />
+        </group>
+        <group android:translateX="144">
+            <path
+                android:fillColor="#CCFFFFFF"
+                android:pathData="M0,0h60v12H12v60H0Z" />
+        </group>
+        <group android:translateX="216">
+            <path
+                android:fillColor="#CCFFFFFF"
+                android:pathData="M0,0h46c12,0 18,8 18,20 0,12 -6,20 -18,20H12v32H0Zm12,12v16h28c4,0 6,-2 6,-6 0,-4 -2,-6 -6,-6Z" />
+        </group>
+        <group android:translateX="288">
+            <path
+                android:fillColor="#CCFFFFFF"
+                android:pathData="M0,0h14l16,28 16,-28h14l-24,42v30H20v-30Z" />
+        </group>
+        <group android:translateX="360">
+            <path
+                android:fillColor="#CCFFFFFF"
+                android:pathData="M0,0h60v12H12v18h40v12H12v18h48v12H0Z" />
+        </group>
+        <group android:translateX="432">
+            <path
+                android:fillColor="#CCFFFFFF"
+                android:pathData="M0,0h12v28l20,-28h18l-26,34 28,38H42l-22,-30v30H0Z" />
+        </group>
+        <group android:translateX="504">
+            <path
+                android:fillColor="#CCFFFFFF"
+                android:pathData="M0,72l22,-72h16l22,72h-14l-5,-16H19l-5,16Zm24,-26h18l-9,-28Z" />
+        </group>
+        <group android:translateX="588">
+            <path
+                android:fillColor="#CCFFFFFF"
+                android:pathData="M0,0a9,9 0 1,1 18,0 9,9 0 1,1 -18,0Z" />
+        </group>
+        <group android:translateX="636">
+            <path
+                android:fillColor="#CCFFFFFF"
+                android:pathData="M0,0a9,9 0 1,1 18,0 9,9 0 1,1 -18,0Z" />
+        </group>
+        <group android:translateX="684">
+            <path
+                android:fillColor="#CCFFFFFF"
+                android:pathData="M0,0a9,9 0 1,1 18,0 9,9 0 1,1 -18,0Z" />
+        </group>
     </group>
 </vector>

--- a/app/src/main/res/drawable/splash_logo.xml
+++ b/app/src/main/res/drawable/splash_logo.xml
@@ -5,22 +5,36 @@
     android:viewportWidth="108"
     android:viewportHeight="108">
 
-    <path
-        android:fillColor="#FFFFFFFF"
-        android:fillAlpha="0.18"
-        android:pathData="M34,20h40a12,12 0 0 1 12,12v44a12,12 0 0 1 -12,12H34a12,12 0 0 1 -12,-12V32a12,12 0 0 1 12,-12z" />
+    <group
+        android:pivotX="54"
+        android:pivotY="54"
+        android:translateX="12"
+        android:translateY="18">
 
-    <path
-        android:strokeColor="#FFFFFFFF"
-        android:strokeWidth="8"
-        android:strokeLineCap="round"
-        android:strokeLineJoin="round"
-        android:pathData="M30,36H78M54,36V78" />
+        <path
+            android:fillColor="@android:color/transparent"
+            android:strokeColor="@color/splash_background_top"
+            android:strokeWidth="8"
+            android:strokeLineJoin="round"
+            android:strokeLineCap="round"
+            android:pathData="M6,30l36,-14 36,14 -36,14z" />
 
-    <path
-        android:strokeColor="#AEE5D3"
-        android:strokeWidth="6"
-        android:strokeLineCap="round"
-        android:strokeLineJoin="round"
-        android:pathData="M40,66l14,-8 14,8" />
+        <path
+            android:fillColor="@color/splash_background_top"
+            android:pathData="M18,38v14c0,10.493 13.431,19 30,19s30,-8.507 30,-19V38l-30,12 -30,-12z" />
+
+        <path
+            android:strokeColor="@color/splash_background_top"
+            android:strokeWidth="8"
+            android:strokeLineCap="round"
+            android:pathData="M66,30v20" />
+
+        <path
+            android:fillColor="@android:color/transparent"
+            android:strokeColor="@color/splash_background_top"
+            android:strokeWidth="8"
+            android:strokeLineCap="round"
+            android:strokeLineJoin="round"
+            android:pathData="M24,60l16,16 24,-24" />
+    </group>
 </vector>

--- a/app/src/main/res/drawable/splash_logo.xml
+++ b/app/src/main/res/drawable/splash_logo.xml
@@ -1,40 +1,97 @@
 <?xml version="1.0" encoding="utf-8"?>
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="108dp"
-    android:height="108dp"
-    android:viewportWidth="108"
-    android:viewportHeight="108">
+    android:width="240dp"
+    android:height="240dp"
+    android:viewportWidth="240"
+    android:viewportHeight="240">
 
     <group
-        android:pivotX="54"
-        android:pivotY="54"
+        android:translateX="52"
+        android:translateY="24"
+        android:scaleX="0.9"
+        android:scaleY="0.9">
+        <group android:translateX="8" android:translateY="8">
+            <path
+                android:fillColor="#FFFFFFFF"
+                android:pathData="M28,24H116A20,20 0 0 1 136,44V116A20,20 0 0 1 116,136H28A20,20 0 0 1 8,116V44A20,20 0 0 1 28,24Z" />
+
+            <path
+                android:fillColor="#1A000000"
+                android:pathData="M8,52H136V68H8Z" />
+
+            <path
+                android:fillColor="#FFFFFFFF"
+                android:pathData="M36,8H52V32H36Z" />
+            <path
+                android:fillColor="#FFFFFFFF"
+                android:pathData="M92,8H108V32H92Z" />
+
+            <path
+                android:strokeWidth="6"
+                android:strokeColor="#FFFFFFFF"
+                android:strokeLineCap="round"
+                android:pathData="M44,12V24" />
+            <path
+                android:strokeWidth="6"
+                android:strokeColor="#FFFFFFFF"
+                android:strokeLineCap="round"
+                android:pathData="M100,12V24" />
+
+            <path
+                android:fillColor="#1A000000"
+                android:pathData="M36,84H56V104H36Z" />
+            <path
+                android:fillColor="#1A000000"
+                android:pathData="M68,84H88V104H68Z" />
+            <path
+                android:fillColor="#1A000000"
+                android:pathData="M100,84H120V104H100Z" />
+            <path
+                android:fillColor="#1A000000"
+                android:pathData="M36,112H56V132H36Z" />
+            <path
+                android:fillColor="#1A000000"
+                android:pathData="M68,112H88V132H68Z" />
+            <path
+                android:fillColor="#1A000000"
+                android:pathData="M100,112H120V132H100Z" />
+        </group>
+    </group>
+
+    <group
         android:translateX="12"
-        android:translateY="18">
+        android:translateY="160"
+        android:scaleX="0.52"
+        android:scaleY="0.52">
+        <group android:translateX="6" android:translateY="10">
+            <path
+                android:fillColor="#FFFFFFFF"
+                android:pathData="M0,0H48V10H32V70H20V10H0Z" />
 
-        <path
-            android:fillColor="@android:color/transparent"
-            android:strokeColor="@color/splash_background_top"
-            android:strokeWidth="8"
-            android:strokeLineJoin="round"
-            android:strokeLineCap="round"
-            android:pathData="M6,30l36,-14 36,14 -36,14z" />
+            <path
+                android:fillColor="#FFFFFFFF"
+                android:pathData="M60,0H72V40Q72,54 86,54H90Q104,54 104,40V0H116V42Q116,70 90,70H86Q60,70 60,42Z" />
 
-        <path
-            android:fillColor="@color/splash_background_top"
-            android:pathData="M18,38v14c0,10.493 13.431,19 30,19s30,-8.507 30,-19V38l-30,12 -30,-12z" />
+            <path
+                android:fillColor="#FFFFFFFF"
+                android:pathData="M128,0H176V10H160V70H148V10H128Z" />
 
-        <path
-            android:strokeColor="@color/splash_background_top"
-            android:strokeWidth="8"
-            android:strokeLineCap="round"
-            android:pathData="M66,30v20" />
+            <path
+                android:fillColor="#FFFFFFFF"
+                android:fillType="evenOdd"
+                android:pathData="M188,0H228Q240,0 240,12V58Q240,70 228,70H188Q176,70 176,58V12Q176,0 188,0ZM188,12Q184,12 184,16V54Q184,58 188,58H228Q232,58 232,54V16Q232,12 228,12Z" />
 
-        <path
-            android:fillColor="@android:color/transparent"
-            android:strokeColor="@color/splash_background_top"
-            android:strokeWidth="8"
-            android:strokeLineCap="round"
-            android:strokeLineJoin="round"
-            android:pathData="M24,60l16,16 24,-24" />
+            <path
+                android:fillColor="#FFFFFFFF"
+                android:pathData="M252,0H264V26H284C298,26 306,34 306,46C306,56 300,62 290,64L308,90H292L272,64H264V70H252ZM264,38V52H284C290,52 294,48 294,46C294,40 290,38 284,38Z" />
+
+            <path
+                android:fillColor="#FFFFFFFF"
+                android:pathData="M312,0H324V58H356V70H312Z" />
+
+            <path
+                android:fillColor="#FFFFFFFF"
+                android:pathData="M368,0H382L398,24L414,0H428L404,34V70H392V34Z" />
+        </group>
     </group>
 </vector>

--- a/app/src/main/res/drawable/splash_logo.xml
+++ b/app/src/main/res/drawable/splash_logo.xml
@@ -6,92 +6,62 @@
     android:viewportHeight="240">
 
     <group
-        android:translateX="52"
-        android:translateY="24"
-        android:scaleX="0.9"
-        android:scaleY="0.9">
-        <group android:translateX="8" android:translateY="8">
-            <path
-                android:fillColor="#FFFFFFFF"
-                android:pathData="M28,24H116A20,20 0 0 1 136,44V116A20,20 0 0 1 116,136H28A20,20 0 0 1 8,116V44A20,20 0 0 1 28,24Z" />
-
-            <path
-                android:fillColor="#1A000000"
-                android:pathData="M8,52H136V68H8Z" />
-
-            <path
-                android:fillColor="#FFFFFFFF"
-                android:pathData="M36,8H52V32H36Z" />
-            <path
-                android:fillColor="#FFFFFFFF"
-                android:pathData="M92,8H108V32H92Z" />
-
-            <path
-                android:strokeWidth="6"
-                android:strokeColor="#FFFFFFFF"
-                android:strokeLineCap="round"
-                android:pathData="M44,12V24" />
-            <path
-                android:strokeWidth="6"
-                android:strokeColor="#FFFFFFFF"
-                android:strokeLineCap="round"
-                android:pathData="M100,12V24" />
-
-            <path
-                android:fillColor="#1A000000"
-                android:pathData="M36,84H56V104H36Z" />
-            <path
-                android:fillColor="#1A000000"
-                android:pathData="M68,84H88V104H68Z" />
-            <path
-                android:fillColor="#1A000000"
-                android:pathData="M100,84H120V104H100Z" />
-            <path
-                android:fillColor="#1A000000"
-                android:pathData="M36,112H56V132H36Z" />
-            <path
-                android:fillColor="#1A000000"
-                android:pathData="M68,112H88V132H68Z" />
-            <path
-                android:fillColor="#1A000000"
-                android:pathData="M100,112H120V132H100Z" />
-        </group>
+        android:translateX="48"
+        android:translateY="32"
+        android:scaleX="0.92"
+        android:scaleY="0.92">
+        <path
+            android:fillColor="#33FFFFFF"
+            android:pathData="M16,36h144a16,16 0 0 1 16,16v96a16,16 0 0 1 -16,16H16a16,16 0 0 1 -16,-16V52A16,16 0 0 1 16,36Z" />
+        <path
+            android:fillColor="#E6FFFFFF"
+            android:pathData="M24,24h128a18,18 0 0 1 18,18v108a18,18 0 0 1 -18,18H24a18,18 0 0 1 -18,-18V42A18,18 0 0 1 24,24Z" />
+        <path
+            android:fillColor="#33FFFFFF"
+            android:pathData="M6,58h164v20H6Z" />
+        <path
+            android:strokeColor="#FFFFFF"
+            android:strokeWidth="7"
+            android:strokeLineCap="round"
+            android:pathData="M48,16v28" />
+        <path
+            android:strokeColor="#FFFFFF"
+            android:strokeWidth="7"
+            android:strokeLineCap="round"
+            android:pathData="M128,16v28" />
+        <path
+            android:strokeColor="#FFFFFF"
+            android:strokeWidth="8"
+            android:strokeLineCap="round"
+            android:strokeLineJoin="round"
+            android:pathData="M56,108l24,24 44,-44" />
     </group>
 
     <group
-        android:translateX="12"
-        android:translateY="160"
-        android:scaleX="0.52"
-        android:scaleY="0.52">
-        <group android:translateX="6" android:translateY="10">
-            <path
-                android:fillColor="#FFFFFFFF"
-                android:pathData="M0,0H48V10H32V70H20V10H0Z" />
-
-            <path
-                android:fillColor="#FFFFFFFF"
-                android:pathData="M60,0H72V40Q72,54 86,54H90Q104,54 104,40V0H116V42Q116,70 90,70H86Q60,70 60,42Z" />
-
-            <path
-                android:fillColor="#FFFFFFFF"
-                android:pathData="M128,0H176V10H160V70H148V10H128Z" />
-
-            <path
-                android:fillColor="#FFFFFFFF"
-                android:fillType="evenOdd"
-                android:pathData="M188,0H228Q240,0 240,12V58Q240,70 228,70H188Q176,70 176,58V12Q176,0 188,0ZM188,12Q184,12 184,16V54Q184,58 188,58H228Q232,58 232,54V16Q232,12 228,12Z" />
-
-            <path
-                android:fillColor="#FFFFFFFF"
-                android:pathData="M252,0H264V26H284C298,26 306,34 306,46C306,56 300,62 290,64L308,90H292L272,64H264V70H252ZM264,38V52H284C290,52 294,48 294,46C294,40 290,38 284,38Z" />
-
-            <path
-                android:fillColor="#FFFFFFFF"
-                android:pathData="M312,0H324V58H356V70H312Z" />
-
-            <path
-                android:fillColor="#FFFFFFFF"
-                android:pathData="M368,0H382L398,24L414,0H428L404,34V70H392V34Z" />
-        </group>
+        android:translateX="18"
+        android:translateY="162"
+        android:scaleX="0.54"
+        android:scaleY="0.54">
+        <path
+            android:fillColor="#FFFFFF"
+            android:pathData="M0,0h44v12H28v68H16V12H0Z" />
+        <path
+            android:fillColor="#FFFFFF"
+            android:pathData="M60,0h12v40c0,12 6,18 18,18s18,-6 18,-18V0h12v40c0,24 -14,36 -30,36s-30,-12 -30,-36Z" />
+        <path
+            android:fillColor="#FFFFFF"
+            android:pathData="M140,0h48v12h-16v68h-12V12h-20Z" />
+        <path
+            android:fillColor="#FFFFFF"
+            android:pathData="M204,0h44c16,0 22,10 22,22v36c0,12 -6,22 -22,22h-44c-16,0 -22,-10 -22,-22V22c0,-12 6,-22 22,-22ZM204,12c-8,0 -10,4 -10,10v36c0,6 2,10 10,10h44c8,0 10,-4 10,-10V22c0,-6 -2,-10 -10,-10Z" />
+        <path
+            android:fillColor="#FFFFFF"
+            android:pathData="M288,0h12v26h22c14,0 22,8 22,22 0,10 -6,20 -18,22l20,30h-14l-18,-28h-14v28h-12Zm12,38v22h20c8,0 12,-4 12,-10 0,-8 -4,-12 -12,-12Z" />
+        <path
+            android:fillColor="#FFFFFF"
+            android:pathData="M348,0h12v68h28v12h-40Z" />
+        <path
+            android:fillColor="#FFFFFF"
+            android:pathData="M400,0h14l20,30 20,-30h14l-24,36v44h-12V36Z" />
     </group>
 </vector>

--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <color name="splash_background_top">#2B5E55</color>
-    <color name="splash_background_bottom">#214840</color>
+    <color name="splash_background_top">#214840</color>
+    <color name="splash_background_bottom">#2B5E55</color>
 </resources>

--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <color name="splash_background_top">#2B5E55</color>
+    <color name="splash_background_bottom">#214840</color>
+</resources>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -7,4 +7,5 @@
     <color name="teal_700">#FF018786</color>
     <color name="black">#FF000000</color>
     <color name="white">#FFFFFFFF</color>
+    <color name="splash_background">#FFFFFFFF</color>
 </resources>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -7,6 +7,6 @@
     <color name="teal_700">#FF018786</color>
     <color name="black">#FF000000</color>
     <color name="white">#FFFFFFFF</color>
-    <color name="splash_background_top">#4E998C</color>
-    <color name="splash_background_bottom">#3B7D72</color>
+    <color name="splash_background_top">#3B7D72</color>
+    <color name="splash_background_bottom">#4E998C</color>
 </resources>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -7,5 +7,6 @@
     <color name="teal_700">#FF018786</color>
     <color name="black">#FF000000</color>
     <color name="white">#FFFFFFFF</color>
-    <color name="splash_background">#FFFFFFFF</color>
+    <color name="splash_background_top">#4E998C</color>
+    <color name="splash_background_bottom">#3B7D72</color>
 </resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -4,8 +4,9 @@
     <style name="Theme.Tutorly" parent="android:Theme.Material.Light.NoActionBar" />
 
     <style name="Theme.Tutorly.Splash" parent="Theme.SplashScreen">
-        <item name="windowSplashScreenBackground">@color/splash_background</item>
-        <item name="windowSplashScreenAnimatedIcon">@mipmap/ic_launcher</item>
+        <item name="windowSplashScreenBackground">@drawable/splash_background</item>
+        <item name="windowSplashScreenAnimatedIcon">@drawable/splash_logo</item>
+        <item name="windowSplashScreenAnimationDuration">400</item>
         <item name="postSplashScreenTheme">@style/Theme.Tutorly</item>
     </style>
 </resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -2,4 +2,10 @@
 <resources>
 
     <style name="Theme.Tutorly" parent="android:Theme.Material.Light.NoActionBar" />
+
+    <style name="Theme.Tutorly.Splash" parent="Theme.SplashScreen">
+        <item name="windowSplashScreenBackground">@color/splash_background</item>
+        <item name="windowSplashScreenAnimatedIcon">@mipmap/ic_launcher</item>
+        <item name="postSplashScreenTheme">@style/Theme.Tutorly</item>
+    </style>
 </resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -7,6 +7,7 @@
         <item name="windowSplashScreenBackground">@drawable/splash_background</item>
         <item name="windowSplashScreenAnimatedIcon">@drawable/splash_logo</item>
         <item name="windowSplashScreenAnimationDuration">400</item>
+        <item name="windowSplashScreenIconBackgroundColor">@android:color/transparent</item>
         <item name="postSplashScreenTheme">@style/Theme.Tutorly</item>
     </style>
 </resources>


### PR DESCRIPTION
## Summary
- integrate the AndroidX Splash Screen API into MainActivity
- introduce a dedicated splash theme and background color for the launcher activity
- point the launcher activity to the new splash theme in the manifest

## Testing
- ./gradlew :app:assembleDebug (fails: SDK location not found in CI environment)


------
https://chatgpt.com/codex/tasks/task_e_68f39dba0204832080bc82790b01c19a