### PR TITLE
Adjust calendar schedule top bar and highlight styling

### DIFF
--- a/app/src/main/java/com/tutorly/ui/components/WeekMosaic.kt
+++ b/app/src/main/java/com/tutorly/ui/components/WeekMosaic.kt
@@ -89,8 +89,12 @@ private fun DayTile(
         else model.brief.partition { it.isOngoingOn(model.date, now) }
     }
 
-    // белая подложка для всех дней
-    val bg: Color = Color.White
+    // Белая подложка только для сегодняшнего дня
+    val bg: Color = if (isToday) {
+        Color.White
+    } else {
+        MaterialTheme.colorScheme.surfaceContainerLowest
+    }
 
     val dayShape = MaterialTheme.shapes.medium
     Surface(

--- a/app/src/main/java/com/tutorly/ui/screens/CalendarScreen.kt
+++ b/app/src/main/java/com/tutorly/ui/screens/CalendarScreen.kt
@@ -398,31 +398,20 @@ private fun CalendarTopBar(
                 .fillMaxWidth()
                 .height(80.dp)
                 .padding(horizontal = 16.dp),
-            horizontalArrangement = Arrangement.SpaceBetween,
+            horizontalArrangement = Arrangement.Start,
             verticalAlignment = Alignment.CenterVertically
         ) {
-            Text(
-                text = stringResource(id = R.string.calendar_title),
-                style = MaterialTheme.typography.titleLarge,
-                color = MaterialTheme.colorScheme.onPrimary,
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis
+            CalendarModeToggle(
+                selected = displayMode,
+                onSelect = onSelectMode
             )
-
-            Row(
-                horizontalArrangement = Arrangement.spacedBy(12.dp),
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                CalendarModeToggle(
-                    selected = displayMode,
-                    onSelect = onSelectMode
+            Spacer(modifier = Modifier.weight(1f))
+            IconButton(onClick = onOpenSettings) {
+                Icon(
+                    imageVector = Icons.Outlined.Settings,
+                    contentDescription = stringResource(id = R.string.calendar_open_settings),
+                    tint = Color.White
                 )
-                IconButton(onClick = onOpenSettings) {
-                    Icon(
-                        imageVector = Icons.Outlined.Settings,
-                        contentDescription = stringResource(id = R.string.calendar_open_settings)
-                    )
-                }
             }
         }
     }

--- a/app/src/main/java/com/tutorly/ui/screens/CalendarScreen.kt
+++ b/app/src/main/java/com/tutorly/ui/screens/CalendarScreen.kt
@@ -572,7 +572,7 @@ fun PlanScreenHeader(
                 Surface(
                     onClick = { showDatePicker = true },
                     shape = RoundedCornerShape(24.dp),
-                    color = MaterialTheme.colorScheme.surface,
+                    color = Color.White,
                     contentColor = MaterialTheme.colorScheme.onSurface,
                     tonalElevation = 2.dp,
                     shadowElevation = 4.dp


### PR DESCRIPTION
## Summary
- remove the calendar title from the schedule top bar, move the mode toggle to the left, and tint the settings icon white
- update the week mosaic to keep today's card on a white background

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f62690ecac8320b64d823533be001e