### PR TITLE
Show close day button once lessons are marked

### DIFF
--- a/app/src/main/java/com/tutorly/ui/screens/TodayViewModel.kt
+++ b/app/src/main/java/com/tutorly/ui/screens/TodayViewModel.kt
@@ -188,7 +188,7 @@ class TodayViewModel @Inject constructor(
             completedLessons = completedLessons,
             totalLessons = todaySorted.size,
             remainingLessons = remainingLessons,
-            showCloseDayCallout = allLessonsCompleted && allMarked,
+            showCloseDayCallout = allMarked,
             pastDueLessonsPreview = pastDueLessonsPreview,
             hasMorePastDueLessons = hasMorePastLessons
         )


### PR DESCRIPTION
## Summary
- display the close day callout as soon as every lesson receives a payment status so tutors can finish the day without waiting for lessons to complete

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fe8816662c832089a41ea9071c12b4