### PR TITLE
Update Today screen layout

### DIFF
--- a/app/src/main/java/com/tutorly/ui/screens/TodayScreen.kt
+++ b/app/src/main/java/com/tutorly/ui/screens/TodayScreen.kt
@@ -314,6 +314,7 @@ private fun DayInProgressContent(
         state.totalLessons > 0 && state.completedLessons == state.totalLessons
     }
     val showProgressSummary = !state.showCloseDayCallout
+    var lessonsHeaderShown = false
     LazyColumn(
         modifier = Modifier.fillMaxSize(),
         state = listState,
@@ -336,6 +337,12 @@ private fun DayInProgressContent(
             }
         }
         if (pendingLessons.isNotEmpty()) {
+            if (!lessonsHeaderShown) {
+                lessonsHeaderShown = true
+                item(key = "lessons_header") {
+                    TodayLessonsHeader()
+                }
+            }
             item(key = "pending_lessons") {
                 LessonsList(
                     lessons = pendingLessons,
@@ -343,12 +350,17 @@ private fun DayInProgressContent(
                     onSwipeLeft = onSwipeLeft,
                     onLessonOpen = onLessonOpen,
                     onOpenStudentProfile = onOpenStudentProfile,
-                    showTimeline = true,
                     onLessonLongPress = { lesson -> onLessonOpen(lesson.id) }
                 )
             }
         }
         if (markedLessons.isNotEmpty()) {
+            if (!lessonsHeaderShown) {
+                lessonsHeaderShown = true
+                item(key = "lessons_header") {
+                    TodayLessonsHeader()
+                }
+            }
             item(key = "marked_header") {
                 SectionHeader(text = stringResource(id = R.string.today_marked_section_title))
             }
@@ -359,7 +371,6 @@ private fun DayInProgressContent(
                     onSwipeLeft = onSwipeLeft,
                     onLessonOpen = onLessonOpen,
                     onOpenStudentProfile = onOpenStudentProfile,
-                    showTimeline = true,
                     onLessonLongPress = { lesson -> onLessonOpen(lesson.id) }
                 )
             }
@@ -425,8 +436,7 @@ private fun ReviewPendingContent(
                     onSwipeRight = onSwipeRight,
                     onSwipeLeft = onSwipeLeft,
                     onLessonOpen = onLessonOpen,
-                    onOpenStudentProfile = onOpenStudentProfile,
-                    showTimeline = true
+                    onOpenStudentProfile = onOpenStudentProfile
                 )
             }
         }
@@ -596,6 +606,17 @@ private fun SectionHeader(text: String) {
         modifier = Modifier
             .fillMaxWidth()
             .padding(horizontal = 4.dp, vertical = 4.dp)
+    )
+}
+
+@Composable
+private fun TodayLessonsHeader() {
+    Text(
+        text = stringResource(id = R.string.today_lessons_today_title),
+        style = MaterialTheme.typography.titleMedium,
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 20.dp)
     )
 }
 
@@ -856,8 +877,7 @@ private fun TodayDebtorsSection(
                 onSwipeRight = onSwipeRight,
                 onSwipeLeft = onSwipeLeft,
                 onLessonOpen = onLessonOpen,
-                onOpenStudentProfile = onOpenStudentProfile,
-                showTimeline = true
+                onOpenStudentProfile = onOpenStudentProfile
             )
         }
     }
@@ -1342,7 +1362,7 @@ private fun LessonCard(
 
     Card(
         modifier = modifier,
-        shape = MaterialTheme.shapes.large,
+        shape = RoundedCornerShape(16.dp),
         colors = cardColors,
         elevation = cardElevation
     ) {

--- a/app/src/main/java/com/tutorly/ui/screens/TodayScreen.kt
+++ b/app/src/main/java/com/tutorly/ui/screens/TodayScreen.kt
@@ -314,7 +314,7 @@ private fun DayInProgressContent(
         state.totalLessons > 0 && state.completedLessons == state.totalLessons
     }
     val showProgressSummary = !state.showCloseDayCallout
-    var lessonsHeaderShown = false
+    val hasLessons = pendingLessons.isNotEmpty() || markedLessons.isNotEmpty()
     LazyColumn(
         modifier = Modifier.fillMaxSize(),
         state = listState,
@@ -336,13 +336,12 @@ private fun DayInProgressContent(
                 CloseDayCallout(onRequestCloseDay = onRequestCloseDay)
             }
         }
-        if (pendingLessons.isNotEmpty()) {
-            if (!lessonsHeaderShown) {
-                lessonsHeaderShown = true
-                item(key = "lessons_header") {
-                    TodayLessonsHeader()
-                }
+        if (hasLessons) {
+            item(key = "lessons_header") {
+                TodayLessonsHeader()
             }
+        }
+        if (pendingLessons.isNotEmpty()) {
             item(key = "pending_lessons") {
                 LessonsList(
                     lessons = pendingLessons,
@@ -355,12 +354,6 @@ private fun DayInProgressContent(
             }
         }
         if (markedLessons.isNotEmpty()) {
-            if (!lessonsHeaderShown) {
-                lessonsHeaderShown = true
-                item(key = "lessons_header") {
-                    TodayLessonsHeader()
-                }
-            }
             item(key = "marked_header") {
                 SectionHeader(text = stringResource(id = R.string.today_marked_section_title))
             }
@@ -400,6 +393,7 @@ private fun ReviewPendingContent(
     onOpenDebtors: () -> Unit,
     onRequestCloseDay: () -> Unit
 ) {
+    val hasLessons = state.reviewLessons.isNotEmpty() || state.markedLessons.isNotEmpty()
     LazyColumn(
         modifier = Modifier.fillMaxSize(),
         contentPadding = PaddingValues(horizontal = 16.dp, vertical = 24.dp),
@@ -412,6 +406,11 @@ private fun ReviewPendingContent(
                 showCloseDayButton = state.showCloseDayButton,
                 onRequestCloseDay = onRequestCloseDay
             )
+        }
+        if (hasLessons) {
+            item(key = "lessons_header") {
+                TodayLessonsHeader()
+            }
         }
         if (state.reviewLessons.isNotEmpty()) {
             item(key = "review_carousel") {
@@ -614,6 +613,7 @@ private fun TodayLessonsHeader() {
     Text(
         text = stringResource(id = R.string.today_lessons_today_title),
         style = MaterialTheme.typography.titleMedium,
+        color = MaterialTheme.colorScheme.onSurface,
         modifier = Modifier
             .fillMaxWidth()
             .padding(horizontal = 20.dp)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -180,6 +180,7 @@
     <string name="today_empty_subtitle">Отличный день для отдыха!</string>
     <string name="today_progress_summary">Проведено %1$d из %2$d занятий</string>
     <string name="today_progress_all_done">Все уроки прошли</string>
+    <string name="today_lessons_today_title">Занятия на сегодня</string>
     <string name="today_closed_income_label">Доход</string>
     <string name="today_closed_debt_label">Долг</string>
     <string name="today_marked_section_title">Отмечено</string>


### PR DESCRIPTION
## Summary
- remove the lesson timeline from Today screen lists
- add the "Занятия на сегодня" heading with padding above the lesson cards
- set the lesson card corner radius to 16dp for consistent styling

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68fea336c42c8320a508544c73b8d209