### PR TITLE
feat: open student profile from lesson card

### DIFF
--- a/app/src/main/java/com/tutorly/navigation/AppNav.kt
+++ b/app/src/main/java/com/tutorly/navigation/AppNav.kt
@@ -150,6 +150,11 @@ fun AppNavRoot() {
                                 launchSingleTop = true
                             }
                         },
+                        onOpenStudentProfile = { studentId ->
+                            nav.navigate(studentDetailsRoute(studentId)) {
+                                launchSingleTop = true
+                            }
+                        },
                         onOpenSettings = {
                             nav.navigate(ROUTE_SETTINGS) {
                                 launchSingleTop = true

--- a/app/src/main/java/com/tutorly/navigation/AppNav.kt
+++ b/app/src/main/java/com/tutorly/navigation/AppNav.kt
@@ -150,6 +150,11 @@ fun AppNavRoot() {
                                 launchSingleTop = true
                             }
                         },
+                        onEditStudent = { studentId ->
+                            nav.navigate(studentEditRoute(studentId, StudentEditTarget.PROFILE)) {
+                                launchSingleTop = true
+                            }
+                        },
                         onOpenStudentProfile = { studentId ->
                             nav.navigate(studentDetailsRoute(studentId)) {
                                 launchSingleTop = true
@@ -167,6 +172,11 @@ fun AppNavRoot() {
                     TodayScreen(
                         onAddStudent = {
                             nav.navigate(studentsRoute(StudentEditorOrigin.LESSON_CREATION)) {
+                                launchSingleTop = true
+                            }
+                        },
+                        onEditStudent = { studentId ->
+                            nav.navigate(studentEditRoute(studentId, StudentEditTarget.PROFILE)) {
                                 launchSingleTop = true
                             }
                         },

--- a/app/src/main/java/com/tutorly/ui/lessoncard/LessonCardSheet.kt
+++ b/app/src/main/java/com/tutorly/ui/lessoncard/LessonCardSheet.kt
@@ -149,12 +149,14 @@ internal fun LessonCardSheet(
 
     val onStudentEditClick: () -> Unit = { showStudentPicker = true }
     val onStudentProfileClick: () -> Unit = {
-        val studentId = state.studentId ?: return@onStudentProfileClick
-        scope.launch {
-            sheetState.hide()
-        }.invokeOnCompletion {
-            onDismissRequest()
-            onOpenStudentProfile(studentId)
+        val studentId = state.studentId
+        if (studentId != null) {
+            scope.launch {
+                sheetState.hide()
+            }.invokeOnCompletion {
+                onDismissRequest()
+                onOpenStudentProfile(studentId)
+            }
         }
     }
     val onDateClick: () -> Unit = {

--- a/app/src/main/java/com/tutorly/ui/lessoncard/LessonCardSheet.kt
+++ b/app/src/main/java/com/tutorly/ui/lessoncard/LessonCardSheet.kt
@@ -144,15 +144,10 @@ internal fun LessonCardSheet(
 
     val onStudentEditClick: () -> Unit = {
         val studentId = state.studentId
-        scope.launch {
-            sheetState.hide()
-        }.invokeOnCompletion {
-            onDismissRequest()
-            if (studentId != null) {
-                onEditStudent(studentId)
-            } else {
-                onAddStudent()
-            }
+        if (studentId != null) {
+            onEditStudent(studentId)
+        } else {
+            onAddStudent()
         }
     }
     val onStudentProfileClick: () -> Unit = {

--- a/app/src/main/java/com/tutorly/ui/screens/CalendarScreen.kt
+++ b/app/src/main/java/com/tutorly/ui/screens/CalendarScreen.kt
@@ -85,6 +85,7 @@ enum class CalendarMode { DAY, WEEK }
 fun CalendarScreen(
     modifier: Modifier = Modifier,
     onAddStudent: () -> Unit = {},
+    onOpenStudentProfile: (Long) -> Unit = {},
     onOpenSettings: () -> Unit = {},
     creationViewModel: LessonCreationViewModel,
     viewModel: CalendarViewModel = hiltViewModel()
@@ -111,6 +112,7 @@ fun CalendarScreen(
             creationViewModel.prepareForStudentCreation()
             onAddStudent()
         },
+        onOpenStudentProfile = onOpenStudentProfile,
         onDateSelect = lessonCardViewModel::onDateSelected,
         onTimeSelect = lessonCardViewModel::onTimeSelected,
         onDurationSelect = lessonCardViewModel::onDurationSelected,

--- a/app/src/main/java/com/tutorly/ui/screens/CalendarScreen.kt
+++ b/app/src/main/java/com/tutorly/ui/screens/CalendarScreen.kt
@@ -85,6 +85,7 @@ enum class CalendarMode { DAY, WEEK }
 fun CalendarScreen(
     modifier: Modifier = Modifier,
     onAddStudent: () -> Unit = {},
+    onEditStudent: (Long) -> Unit = {},
     onOpenStudentProfile: (Long) -> Unit = {},
     onOpenSettings: () -> Unit = {},
     creationViewModel: LessonCreationViewModel,
@@ -106,12 +107,12 @@ fun CalendarScreen(
     LessonCardSheet(
         state = lessonCardState,
         onDismissRequest = lessonCardViewModel::dismiss,
-        onStudentSelect = lessonCardViewModel::onStudentSelected,
         onAddStudent = {
             lessonCardViewModel.dismiss()
             creationViewModel.prepareForStudentCreation()
             onAddStudent()
         },
+        onEditStudent = onEditStudent,
         onOpenStudentProfile = onOpenStudentProfile,
         onDateSelect = lessonCardViewModel::onDateSelected,
         onTimeSelect = lessonCardViewModel::onTimeSelected,

--- a/app/src/main/java/com/tutorly/ui/screens/StudentDetailsScreen.kt
+++ b/app/src/main/java/com/tutorly/ui/screens/StudentDetailsScreen.kt
@@ -46,7 +46,6 @@ import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.IconButtonDefaults
-import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
@@ -76,12 +75,10 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import com.tutorly.R
 import com.tutorly.domain.model.StudentProfile
 import com.tutorly.domain.model.StudentProfileLesson
-import com.tutorly.models.SubjectPreset
 import com.tutorly.models.PaymentStatus
 import com.tutorly.ui.components.TopBarContainer
 import com.tutorly.ui.components.PaymentBadge
 import com.tutorly.ui.components.PaymentBadgeStatus
-import com.tutorly.ui.components.TutorlyDialog
 import com.tutorly.ui.theme.extendedColors
 import com.tutorly.ui.lessoncard.LessonCardSheet
 import com.tutorly.ui.lessoncard.LessonCardViewModel
@@ -558,105 +555,6 @@ private fun StudentProfileTopBar(
                 }
             }
         }
-    }
-}
-
-@Composable
-private fun StudentEditorDialogContent(
-    state: StudentEditorFormState,
-    onNameChange: (String) -> Unit,
-    onPhoneChange: (String) -> Unit,
-    onMessengerChange: (String) -> Unit,
-    onRateChange: (String) -> Unit,
-    subjectPresets: List<SubjectPreset>,
-    onSubjectChange: (String) -> Unit,
-    onGradeChange: (String) -> Unit,
-    onNoteChange: (String) -> Unit,
-    onSave: () -> Unit,
-    onDismiss: () -> Unit,
-    editTarget: StudentEditTarget?,
-    initialFocus: StudentEditTarget?,
-    snackbarHostState: SnackbarHostState,
-) {
-    val titleRes = when {
-        state.studentId == null -> R.string.add_student
-        editTarget == StudentEditTarget.RATE -> R.string.student_editor_title_rate
-        editTarget == StudentEditTarget.PHONE -> R.string.student_editor_title_phone
-        editTarget == StudentEditTarget.MESSENGER -> R.string.student_editor_title_messenger
-        editTarget == StudentEditTarget.NOTES -> R.string.student_editor_title_note
-        else -> R.string.student_editor_title
-    }
-    val title = stringResource(id = titleRes)
-
-    TutorlyDialog(
-        onDismissRequest = {
-            if (!state.isSaving) {
-                onDismiss()
-            }
-        },
-        modifier = Modifier.imePadding()
-    ) {
-        Text(
-            text = title,
-            style = MaterialTheme.typography.titleLarge
-        )
-
-        if (state.isSaving) {
-            LinearProgressIndicator(
-                modifier = Modifier.fillMaxWidth(),
-                color = MaterialTheme.colorScheme.secondary
-            )
-        }
-
-        StudentEditorForm(
-            state = state,
-            onNameChange = onNameChange,
-            onPhoneChange = onPhoneChange,
-            onMessengerChange = onMessengerChange,
-            onRateChange = onRateChange,
-            subjectPresets = subjectPresets,
-            onSubjectChange = onSubjectChange,
-            onGradeChange = onGradeChange,
-            onNoteChange = onNoteChange,
-            modifier = Modifier.fillMaxWidth(),
-            editTarget = editTarget,
-            initialFocus = initialFocus,
-            enableScrolling = true,
-            enabled = !state.isSaving,
-            onSubmit = onSave
-        )
-
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.End,
-            verticalAlignment = Alignment.CenterVertically
-        ) {
-            val accent = MaterialTheme.extendedColors.accent
-            val actionColors = ButtonDefaults.textButtonColors(
-                contentColor = accent,
-                disabledContentColor = accent.copy(alpha = 0.5f)
-            )
-            TextButton(
-                onClick = onDismiss,
-                enabled = !state.isSaving,
-                colors = actionColors
-            ) {
-                Text(text = stringResource(id = R.string.student_editor_cancel))
-            }
-            Spacer(modifier = Modifier.width(8.dp))
-            TextButton(
-                onClick = onSave,
-                enabled = !state.isSaving && state.name.isNotBlank(),
-                colors = actionColors
-            ) {
-                Text(text = stringResource(id = R.string.student_editor_save))
-            }
-        }
-
-        SnackbarHost(
-            hostState = snackbarHostState,
-            modifier = Modifier.fillMaxWidth()
-        )
     }
 }
 

--- a/app/src/main/java/com/tutorly/ui/screens/StudentDetailsScreen.kt
+++ b/app/src/main/java/com/tutorly/ui/screens/StudentDetailsScreen.kt
@@ -19,6 +19,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Archive
+import androidx.compose.material.icons.outlined.ArrowBack
 import androidx.compose.material.icons.outlined.CalendarToday
 import androidx.compose.material.icons.outlined.CreditCard
 import androidx.compose.material.icons.outlined.Delete
@@ -258,6 +259,7 @@ fun StudentDetailsScreen(
             StudentProfileTopBar(
                 title = title,
                 subtitle = subtitle,
+                onBackClick = onBack,
                 onEditProfileClick = contentState?.let {
                     { openEditor(StudentEditTarget.PROFILE) }
                 },
@@ -415,6 +417,7 @@ fun StudentDetailsScreen(
 private fun StudentProfileTopBar(
     title: String,
     subtitle: String?,
+    onBackClick: (() -> Unit)? = null,
     onEditProfileClick: (() -> Unit)? = null,
     isArchived: Boolean?,
     onArchiveClick: (() -> Unit)? = null,
@@ -423,21 +426,38 @@ private fun StudentProfileTopBar(
     deleteEnabled: Boolean = true,
 ) {
     TopBarContainer {
+        val hasBack = onBackClick != null
         val hasActions = listOfNotNull(
             onEditProfileClick,
             if (onArchiveClick != null && isArchived != null) onArchiveClick else null,
             onDeleteClick
         ).isNotEmpty()
+        val horizontalPadding = if (hasBack || hasActions) 72.dp else 0.dp
         Box(
             modifier = Modifier
                 .fillMaxWidth()
                 .height(80.dp)
                 .padding(horizontal = 16.dp)
         ) {
+            if (hasBack) {
+                IconButton(
+                    onClick = onBackClick!!,
+                    modifier = Modifier.align(Alignment.CenterStart),
+                    colors = IconButtonDefaults.iconButtonColors(
+                        contentColor = MaterialTheme.colorScheme.surface
+                    )
+                ) {
+                    Icon(
+                        imageVector = Icons.Outlined.ArrowBack,
+                        contentDescription = stringResource(id = R.string.student_details_back)
+                    )
+                }
+            }
+
             Column(
                 modifier = Modifier
                     .align(Alignment.Center)
-                    .padding(horizontal = if (hasActions) 72.dp else 0.dp),
+                    .padding(horizontal = horizontalPadding),
                 horizontalAlignment = Alignment.CenterHorizontally
             ) {
                 Text(

--- a/app/src/main/java/com/tutorly/ui/screens/StudentDetailsScreen.kt
+++ b/app/src/main/java/com/tutorly/ui/screens/StudentDetailsScreen.kt
@@ -165,12 +165,12 @@ fun StudentDetailsScreen(
     LessonCardSheet(
         state = lessonCardState,
         onDismissRequest = lessonCardViewModel::dismiss,
-        onStudentSelect = lessonCardViewModel::onStudentSelected,
         onAddStudent = {
             lessonCardViewModel.dismiss()
             creationViewModel.prepareForStudentCreation()
             onAddStudentFromCreation()
         },
+        onEditStudent = { openEditor(StudentEditTarget.PROFILE) },
         onOpenStudentProfile = {},
         onDateSelect = lessonCardViewModel::onDateSelected,
         onTimeSelect = lessonCardViewModel::onTimeSelected,

--- a/app/src/main/java/com/tutorly/ui/screens/StudentDetailsScreen.kt
+++ b/app/src/main/java/com/tutorly/ui/screens/StudentDetailsScreen.kt
@@ -170,6 +170,7 @@ fun StudentDetailsScreen(
             creationViewModel.prepareForStudentCreation()
             onAddStudentFromCreation()
         },
+        onOpenStudentProfile = {},
         onDateSelect = lessonCardViewModel::onDateSelected,
         onTimeSelect = lessonCardViewModel::onTimeSelected,
         onDurationSelect = lessonCardViewModel::onDurationSelected,

--- a/app/src/main/java/com/tutorly/ui/screens/StudentEditorScreen.kt
+++ b/app/src/main/java/com/tutorly/ui/screens/StudentEditorScreen.kt
@@ -23,6 +23,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel

--- a/app/src/main/java/com/tutorly/ui/screens/StudentEditorScreen.kt
+++ b/app/src/main/java/com/tutorly/ui/screens/StudentEditorScreen.kt
@@ -1,13 +1,28 @@
 package com.tutorly.ui.screens
 
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.imePadding
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
@@ -17,11 +32,13 @@ import com.tutorly.domain.repo.StudentsRepository
 import com.tutorly.domain.repo.SubjectPresetsRepository
 import com.tutorly.models.SubjectPreset
 import com.tutorly.models.Student
+import com.tutorly.ui.components.TutorlyDialog
 import dagger.hilt.android.lifecycle.HiltViewModel
 import java.time.Instant
 import javax.inject.Inject
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
+import com.tutorly.ui.theme.extendedColors
 
 @HiltViewModel
 class StudentEditorVM @Inject constructor(
@@ -225,7 +242,7 @@ fun StudentEditorDialog(
         }
     }
 
-    StudentEditorSheet(
+    StudentEditorDialogContent(
         state = formState,
         onNameChange = vm::onNameChange,
         onPhoneChange = vm::onPhoneChange,
@@ -245,4 +262,103 @@ fun StudentEditorDialog(
         initialFocus = editTarget,
         snackbarHostState = snackbarHostState
     )
+}
+
+@Composable
+fun StudentEditorDialogContent(
+    state: StudentEditorFormState,
+    onNameChange: (String) -> Unit,
+    onPhoneChange: (String) -> Unit,
+    onMessengerChange: (String) -> Unit,
+    onRateChange: (String) -> Unit,
+    subjectPresets: List<SubjectPreset>,
+    onSubjectChange: (String) -> Unit,
+    onGradeChange: (String) -> Unit,
+    onNoteChange: (String) -> Unit,
+    onSave: () -> Unit,
+    onDismiss: () -> Unit,
+    editTarget: StudentEditTarget?,
+    initialFocus: StudentEditTarget?,
+    snackbarHostState: SnackbarHostState,
+) {
+    val titleRes = when {
+        state.studentId == null -> R.string.add_student
+        editTarget == StudentEditTarget.RATE -> R.string.student_editor_title_rate
+        editTarget == StudentEditTarget.PHONE -> R.string.student_editor_title_phone
+        editTarget == StudentEditTarget.MESSENGER -> R.string.student_editor_title_messenger
+        editTarget == StudentEditTarget.NOTES -> R.string.student_editor_title_note
+        else -> R.string.student_editor_title
+    }
+    val title = stringResource(id = titleRes)
+
+    TutorlyDialog(
+        onDismissRequest = {
+            if (!state.isSaving) {
+                onDismiss()
+            }
+        },
+        modifier = Modifier.imePadding()
+    ) {
+        Text(
+            text = title,
+            style = MaterialTheme.typography.titleLarge
+        )
+
+        if (state.isSaving) {
+            LinearProgressIndicator(
+                modifier = Modifier.fillMaxWidth(),
+                color = MaterialTheme.colorScheme.secondary
+            )
+        }
+
+        StudentEditorForm(
+            state = state,
+            onNameChange = onNameChange,
+            onPhoneChange = onPhoneChange,
+            onMessengerChange = onMessengerChange,
+            onRateChange = onRateChange,
+            subjectPresets = subjectPresets,
+            onSubjectChange = onSubjectChange,
+            onGradeChange = onGradeChange,
+            onNoteChange = onNoteChange,
+            modifier = Modifier.fillMaxWidth(),
+            editTarget = editTarget,
+            initialFocus = initialFocus,
+            enableScrolling = true,
+            enabled = !state.isSaving,
+            onSubmit = onSave
+        )
+
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.End,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            val accent = MaterialTheme.extendedColors.accent
+            val actionColors = ButtonDefaults.textButtonColors(
+                contentColor = accent,
+                disabledContentColor = accent.copy(alpha = 0.5f)
+            )
+            TextButton(
+                onClick = onDismiss,
+                enabled = !state.isSaving,
+                colors = actionColors
+            ) {
+                Text(text = stringResource(id = R.string.student_editor_cancel))
+            }
+            Spacer(modifier = Modifier.width(8.dp))
+            TextButton(
+                onClick = onSave,
+                enabled = !state.isSaving && state.name.isNotBlank(),
+                colors = actionColors
+            ) {
+                Text(text = stringResource(id = R.string.student_editor_save))
+            }
+        }
+
+        SnackbarHost(
+            hostState = snackbarHostState,
+            modifier = Modifier.fillMaxWidth()
+        )
+    }
 }

--- a/app/src/main/java/com/tutorly/ui/screens/TodayScreen.kt
+++ b/app/src/main/java/com/tutorly/ui/screens/TodayScreen.kt
@@ -121,6 +121,7 @@ fun TodayScreen(
             lessonCardViewModel.dismiss()
             onAddStudent()
         },
+        onOpenStudentProfile = onOpenStudentProfile,
         onDateSelect = lessonCardViewModel::onDateSelected,
         onTimeSelect = lessonCardViewModel::onTimeSelected,
         onDurationSelect = lessonCardViewModel::onDurationSelected,

--- a/app/src/main/java/com/tutorly/ui/screens/TodayScreen.kt
+++ b/app/src/main/java/com/tutorly/ui/screens/TodayScreen.kt
@@ -101,6 +101,7 @@ import kotlinx.coroutines.flow.distinctUntilChanged
 fun TodayScreen(
     modifier: Modifier = Modifier,
     onAddStudent: () -> Unit = {},
+    onEditStudent: (Long) -> Unit = {},
     onOpenStudentProfile: (Long) -> Unit = {},
     onOpenDebtors: () -> Unit = {},
     viewModel: TodayViewModel = hiltViewModel()
@@ -116,11 +117,11 @@ fun TodayScreen(
     LessonCardSheet(
         state = lessonCardState,
         onDismissRequest = lessonCardViewModel::dismiss,
-        onStudentSelect = lessonCardViewModel::onStudentSelected,
         onAddStudent = {
             lessonCardViewModel.dismiss()
             onAddStudent()
         },
+        onEditStudent = onEditStudent,
         onOpenStudentProfile = onOpenStudentProfile,
         onDateSelect = lessonCardViewModel::onDateSelected,
         onTimeSelect = lessonCardViewModel::onTimeSelected,

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -140,6 +140,7 @@
     <string name="lesson_card_note_label">Заметка</string>
     <string name="lesson_card_note_placeholder">Добавьте комментарий</string>
     <string name="lesson_card_student_placeholder">Ученик</string>
+    <string name="lesson_card_student_edit">Изменить ученика</string>
     <string name="lesson_card_student_picker_title">Выберите ученика</string>
     <string name="lesson_card_student_picker_empty">Нет доступных учеников</string>
     <string name="lesson_card_date_label">Дата</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -95,6 +95,7 @@
     <string name="student_details_archive_error">Не удалось обновить статус архива</string>
     <string name="student_details_edit">Редактировать</string>
     <string name="student_details_more_actions">Дополнительные действия</string>
+    <string name="student_details_back">Назад</string>
     <string name="student_details_missing">Ученик не найден</string>
     <string name="student_details_payments_title">Платежи</string>
     <string name="student_details_debt_amount">Долг: %1$s</string>


### PR DESCRIPTION
## Summary
- replace the lesson card student dropdown indicator with an edit icon and split profile versus replacement actions
- hide the sheet and navigate to the selected student's profile when their header is tapped
- thread the new student profile callback through calendar, today, and student detail flows and add an accessibility string

## Testing
- bash ./gradlew lint *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68ff63565e008320b9c4b01ab2511f3c