### PR TITLE
Fix paid cents mapping for Today tab lessons

### DIFF
--- a/app/src/main/java/com/tutorly/data/db/projections/LessonWithStudent.kt
+++ b/app/src/main/java/com/tutorly/data/db/projections/LessonWithStudent.kt
@@ -95,7 +95,7 @@ fun LessonWithStudent.toLessonForToday(): LessonForToday {
         seriesId = lesson.seriesId,
         originalStartAt = lesson.startAt,
         recurrenceLabel = null,
-        paidCents = TODO(),
+        paidCents = lesson.paidCents,
     )
 }
 

--- a/app/src/main/java/com/tutorly/data/repo/memory/InMemoryLessonsRepository.kt
+++ b/app/src/main/java/com/tutorly/data/repo/memory/InMemoryLessonsRepository.kt
@@ -460,6 +460,6 @@ private fun Lesson.toTodayStub(): LessonForToday {
         seriesId = seriesId,
         originalStartAt = startAt,
         recurrenceLabel = recurrenceLabel,
-        paidCents = TODO(),
+        paidCents = paidCents,
     )
 }

--- a/app/src/main/java/com/tutorly/data/repo/room/RoomLessonsRepository.kt
+++ b/app/src/main/java/com/tutorly/data/repo/room/RoomLessonsRepository.kt
@@ -86,7 +86,7 @@ class RoomLessonsRepository(
                     seriesId = detail.seriesId,
                     originalStartAt = detail.originalStartAt,
                     recurrenceLabel = detail.recurrenceLabel,
-                    paidCents = TODO(),
+                    paidCents = detail.paidCents,
                 )
             }
         }
@@ -126,7 +126,7 @@ class RoomLessonsRepository(
                     seriesId = detail.seriesId,
                     originalStartAt = detail.originalStartAt,
                     recurrenceLabel = detail.recurrenceLabel,
-                    paidCents = TODO(),
+                    paidCents = detail.paidCents,
                 )
             }
         }


### PR DESCRIPTION
### Motivation
- The Today screen could crash because `paidCents` was left as `TODO()` in several projections, which throws at runtime when lesson models are built. 
- The change ensures the stored paid amount is forwarded into `LessonForToday` so summaries and debt lists render correctly.

### Description
- Replaced `TODO()` placeholders with actual `paidCents` values when constructing `LessonForToday` in the Room repository mappings. 
- Propagated `paidCents` in the `LessonWithStudent.toLessonForToday()` projection so Room query results include the stored paid amount. 
- Fixed the in-memory repository stub to return the stored `paidCents` as well. 
- Files changed: `RoomLessonsRepository.kt`, `LessonWithStudent.kt`, and `InMemoryLessonsRepository.kt`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6981f322b94083209656ac5a44e8fee3)