### PR TITLE
Calendar import: exclude exam tags from names, append to subjects, and infer grade from tags

### DIFF
--- a/app/src/main/java/com/tutorly/data/calendar/GoogleCalendarMigrationService.kt
+++ b/app/src/main/java/com/tutorly/data/calendar/GoogleCalendarMigrationService.kt
@@ -220,6 +220,10 @@ class GoogleCalendarMigrationService @Inject constructor(
                     continue
                 }
 
+                if (recurrenceRequest != null && anchorCreated) {
+                    continue
+                }
+
                 val id = lessonsRepository.create(
                     LessonCreateRequest(
                         studentId = event.student.id,

--- a/app/src/main/java/com/tutorly/data/calendar/GoogleCalendarMigrationService.kt
+++ b/app/src/main/java/com/tutorly/data/calendar/GoogleCalendarMigrationService.kt
@@ -146,6 +146,7 @@ class GoogleCalendarMigrationService @Inject constructor(
                 normalizedStudentName = normalized,
                 lessonTitle = parsed.lessonTitle ?: parsed.subject,
                 originalTitle = title,
+                eventId = instance.eventId,
                 startAt = startAt,
                 endAt = endAt,
                 note = note,
@@ -329,6 +330,7 @@ class GoogleCalendarMigrationService @Inject constructor(
             null,
             sortOrder
         )?.use { cursor ->
+            val eventIdIndex = cursor.getColumnIndexOrThrow(CalendarContract.Instances.EVENT_ID)
             val startIndex = cursor.getColumnIndexOrThrow(CalendarContract.Instances.BEGIN)
             val endIndex = cursor.getColumnIndexOrThrow(CalendarContract.Instances.END)
             val titleIndex = cursor.getColumnIndexOrThrow(CalendarContract.Instances.TITLE)
@@ -340,6 +342,7 @@ class GoogleCalendarMigrationService @Inject constructor(
             while (cursor.moveToNext()) {
                 instances.add(
                     CalendarInstance(
+                        eventId = cursor.getLong(eventIdIndex),
                         title = cursor.getString(titleIndex),
                         description = cursor.getString(descriptionIndex),
                         location = cursor.getString(locationIndex),
@@ -655,6 +658,7 @@ private data class ParsedLessonDetails(
 )
 
 private data class CalendarInstance(
+    val eventId: Long,
     val title: String?,
     val description: String?,
     val location: String?,
@@ -675,6 +679,7 @@ private data class ImportEvent(
     val normalizedStudentName: String,
     val lessonTitle: String?,
     val originalTitle: String,
+    val eventId: Long,
     val startAt: Instant,
     val endAt: Instant,
     val note: String?,
@@ -690,7 +695,8 @@ private data class ImportEvent(
             startTime = startLocal.toLocalTime(),
             dayOfWeek = startLocal.dayOfWeek,
             durationMinutes = durationMinutes,
-            priceCents = priceCents
+            priceCents = priceCents,
+            eventId = eventId
         )
     }
 }
@@ -701,5 +707,6 @@ private data class SeriesKey(
     val startTime: LocalTime,
     val dayOfWeek: java.time.DayOfWeek,
     val durationMinutes: Int,
-    val priceCents: Int?
+    val priceCents: Int?,
+    val eventId: Long
 )

--- a/app/src/main/java/com/tutorly/data/calendar/GoogleCalendarMigrationService.kt
+++ b/app/src/main/java/com/tutorly/data/calendar/GoogleCalendarMigrationService.kt
@@ -4,15 +4,21 @@ import android.annotation.SuppressLint
 import android.content.Context
 import android.provider.CalendarContract
 import com.tutorly.domain.model.LessonCreateRequest
+import com.tutorly.domain.model.RecurrenceCreateRequest
 import com.tutorly.domain.repo.LessonsRepository
 import com.tutorly.domain.repo.StudentsRepository
+import com.tutorly.models.LessonRecurrence
+import com.tutorly.models.RecurrenceFrequency
 import com.tutorly.models.Student
 import dagger.hilt.android.qualifiers.ApplicationContext
 import java.time.Duration
 import java.time.Instant
 import java.time.LocalDate
+import java.time.LocalTime
 import java.time.Month
 import java.time.ZoneId
+import java.time.temporal.ChronoUnit
+import java.time.temporal.TemporalAdjusters
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -75,6 +81,7 @@ class GoogleCalendarMigrationService @Inject constructor(
         var skippedCanceled = 0
         var totalEvents = 0
         val allowedNormalized = allowedStudentNames?.mapTo(mutableSetOf()) { normalizeStudentName(it) }
+        val events = mutableListOf<ImportEvent>()
 
         queryInstances(rangeStart, rangeEnd).forEach { instance ->
             totalEvents++
@@ -114,7 +121,12 @@ class GoogleCalendarMigrationService @Inject constructor(
             if (allowedNormalized != null && normalized !in allowedNormalized) {
                 return@forEach
             }
-            val (student, wasCreated) = findOrCreateStudent(parsed.studentName)
+            val (student, wasCreated) = findOrCreateStudent(
+                name = parsed.studentName,
+                subject = parsed.subject,
+                grade = parsed.grade,
+                rateCents = parsed.rateCents
+            )
             if (student.id == 0L) {
                 skippedMissingTitle++
                 return@forEach
@@ -127,22 +139,108 @@ class GoogleCalendarMigrationService @Inject constructor(
                 skippedDuplicates++
                 return@forEach
             }
-            val note = buildNote(
-                instance.description,
-                instance.location
+            val note = buildNote(instance.description, instance.location)
+            events += ImportEvent(
+                student = student,
+                studentName = parsed.studentName,
+                normalizedStudentName = normalized,
+                lessonTitle = parsed.lessonTitle ?: parsed.subject,
+                startAt = startAt,
+                endAt = endAt,
+                note = note,
+                priceCents = parsed.rateCents
             )
-            lessonsRepository.create(
-                LessonCreateRequest(
-                    studentId = student.id,
-                    subjectId = null,
-                    title = parsed.lessonTitle,
-                    startAt = startAt,
-                    endAt = endAt,
-                    priceCents = 0,
-                    note = note
+        }
+
+        val zone = ZoneId.systemDefault()
+        val grouped = events.groupBy { it.seriesKey(zone) }.toSortedMap(compareBy { it.studentName.lowercase() })
+        for ((_, group) in grouped) {
+            if (group.isEmpty()) continue
+            val sorted = group.sortedBy { it.startAt }
+            val recurrenceRequest = buildRecurrenceRequest(sorted, zone)
+                ?: buildFallbackRecurrenceRequest(sorted, zone)
+            val recurrence = recurrenceRequest?.let { request ->
+                LessonRecurrence(
+                    frequency = request.frequency,
+                    interval = request.interval,
+                    daysOfWeek = request.daysOfWeek,
+                    startDateTime = sorted.first().startAt,
+                    untilDateTime = request.until,
+                    timezone = request.timezone
                 )
-            )
-            createdLessons++
+            }
+            var seriesId: Long? = null
+            var anchorCreated = false
+
+            for (event in sorted) {
+                val existing = lessonsRepository.findExactLesson(
+                    event.student.id,
+                    event.startAt,
+                    event.endAt
+                )
+                if (existing != null) {
+                    skippedDuplicates++
+                    if (!anchorCreated && recurrence != null) {
+                        if (existing.seriesId != null) {
+                            seriesId = existing.seriesId
+                            anchorCreated = true
+                        } else {
+                            val updatedId = lessonsRepository.upsert(
+                                existing.copy(recurrence = recurrence, updatedAt = Instant.now())
+                            )
+                            val updated = lessonsRepository.getById(updatedId)
+                            seriesId = updated?.seriesId
+                            anchorCreated = true
+                        }
+                    } else if (seriesId != null && existing.seriesId == null) {
+                        lessonsRepository.upsert(
+                            existing.copy(seriesId = seriesId, updatedAt = Instant.now())
+                        )
+                    }
+                    continue
+                }
+
+                if (!anchorCreated && recurrenceRequest != null) {
+                    val id = lessonsRepository.create(
+                        LessonCreateRequest(
+                            studentId = event.student.id,
+                            subjectId = null,
+                            title = event.lessonTitle,
+                            startAt = event.startAt,
+                            endAt = event.endAt,
+                            priceCents = event.priceCents ?: 0,
+                            note = event.note,
+                            recurrence = recurrenceRequest
+                        )
+                    )
+                    createdLessons++
+                    val created = lessonsRepository.getById(id)
+                    seriesId = created?.seriesId
+                    anchorCreated = true
+                    continue
+                }
+
+                val id = lessonsRepository.create(
+                    LessonCreateRequest(
+                        studentId = event.student.id,
+                        subjectId = null,
+                        title = event.lessonTitle,
+                        startAt = event.startAt,
+                        endAt = event.endAt,
+                        priceCents = event.priceCents ?: 0,
+                        note = event.note
+                    )
+                )
+                createdLessons++
+                if (seriesId != null) {
+                    val created = lessonsRepository.getById(id)
+                    if (created != null && created.seriesId == null) {
+                        lessonsRepository.upsert(
+                            created.copy(seriesId = seriesId, updatedAt = Instant.now())
+                        )
+                    }
+                }
+            }
         }
 
         return GoogleCalendarImportResult(
@@ -158,13 +256,37 @@ class GoogleCalendarMigrationService @Inject constructor(
         )
     }
 
-    private suspend fun findOrCreateStudent(name: String): Pair<Student, Boolean> {
+    private suspend fun findOrCreateStudent(
+        name: String,
+        subject: String?,
+        grade: String?,
+        rateCents: Int?
+    ): Pair<Student, Boolean> {
         val normalized = name.trim()
         val existing = studentsRepository.findByName(normalized)
         if (existing != null) {
-            return existing to false
+            val updated = existing.copy(
+                subject = existing.subject ?: subject,
+                grade = existing.grade ?: grade,
+                rateCents = existing.rateCents ?: rateCents,
+                updatedAt = Instant.now()
+            )
+            val resolved = if (updated != existing) {
+                val id = studentsRepository.upsert(updated)
+                studentsRepository.getById(id) ?: updated
+            } else {
+                existing
+            }
+            return resolved to false
         }
-        val id = studentsRepository.upsert(Student(name = normalized))
+        val id = studentsRepository.upsert(
+            Student(
+                name = normalized,
+                subject = subject,
+                grade = grade,
+                rateCents = rateCents
+            )
+        )
         return (studentsRepository.getById(id) ?: Student(id = id, name = normalized)) to true
     }
 
@@ -240,24 +362,260 @@ class GoogleCalendarMigrationService @Inject constructor(
     }
 
     private fun parseEventTitle(title: String): ParsedEventTitle {
-        val separators = listOf(" - ", " – ", " — ", " | ", ": ")
         val normalized = title.trim()
-        val split = separators.firstNotNullOfOrNull { separator ->
-            val idx = normalized.indexOf(separator)
-            if (idx >= 0) idx to separator else null
+        if (normalized.isBlank()) {
+            return ParsedEventTitle(
+                studentName = "",
+                lessonTitle = null,
+                subject = null,
+                grade = null,
+                rateCents = null
+            )
         }
-        if (split != null) {
-            val (idx, separator) = split
-            val studentName = normalized.substring(0, idx).trim()
-            val lessonTitle = normalized.substring(idx + separator.length).trim()
-                .takeIf { it.isNotBlank() && !it.equals(studentName, ignoreCase = true) }
-            return ParsedEventTitle(studentName = studentName, lessonTitle = lessonTitle)
-        }
-        return ParsedEventTitle(studentName = normalized, lessonTitle = null)
+        val rawTokens = normalized.split(Regex("\\s+")).filter { it.isNotBlank() }
+        val cleanedTokens = rawTokens.filterNot { it in setOf("-", "–", "—", "|", ":") }
+        val (studentName, detailTokens) = extractStudentName(cleanedTokens)
+        val details = parseLessonDetails(detailTokens)
+        return ParsedEventTitle(
+            studentName = studentName,
+            lessonTitle = details.title,
+            subject = details.subject,
+            grade = details.grade,
+            rateCents = details.rateCents
+        )
     }
 
     private fun normalizeStudentName(name: String): String =
         name.trim().lowercase()
+
+    private fun parseLessonDetails(tokens: List<String>): ParsedLessonDetails {
+        if (tokens.isEmpty()) {
+            return ParsedLessonDetails(title = null, subject = null, grade = null, rateCents = null)
+        }
+        val mutable = tokens.toMutableList()
+        var rateCents: Int? = null
+        var grade: String? = null
+        val examTags = mutableListOf<String>()
+
+        val rateIndex = mutable.indexOfFirst { it.matches(Regex("\\d{4,5}")) }
+        if (rateIndex >= 0) {
+            rateCents = mutable.removeAt(rateIndex).toIntOrNull()?.let { it * 100 }
+        }
+
+        val gradeIndex = mutable.indexOfFirst { token ->
+            val lowered = token.lowercase()
+            lowered == "студент" ||
+                lowered == "student" ||
+                lowered == "себя" ||
+                lowered == "длясебя" ||
+                lowered == "для" ||
+                token.matches(Regex("^(?:[1-9]|1[01])$"))
+        }
+        if (gradeIndex >= 0) {
+            grade = mutable.removeAt(gradeIndex).let { token ->
+                when (token.lowercase()) {
+                    "student" -> "студент"
+                    "длясебя" -> "для себя"
+                    "себя" -> "для себя"
+                    "для" -> "для себя"
+                    else -> token
+                }
+            }.let { value ->
+                if (value.matches(Regex("^(?:[1-9]|1[01])$"))) "$value класс" else value
+            }
+            if (grade == "для себя") {
+                val selfIndex = mutable.indexOfFirst { it.equals("себя", ignoreCase = true) }
+                if (selfIndex >= 0) {
+                    mutable.removeAt(selfIndex)
+                }
+            }
+        }
+
+        val examTokens = setOf("огэ", "егэ", "гиа", "впр")
+        mutable.removeAll { token ->
+            val lowered = token.lowercase()
+            if (lowered in examTokens) {
+                examTags += lowered.uppercase()
+                true
+            } else {
+                false
+            }
+        }
+
+        val subjectToken = mutable.lastOrNull()?.takeIf { it.isNotBlank() }
+        val subjectBase = subjectToken?.let { normalizeSubject(it) }
+        if (grade == null) {
+            when {
+                examTags.contains("ЕГЭ") -> grade = "11 класс"
+                examTags.contains("ОГЭ") -> grade = "9 класс"
+            }
+        }
+
+        val subject = when {
+            subjectBase == null && examTags.isEmpty() -> null
+            subjectBase == null -> examTags.joinToString(", ")
+            examTags.isEmpty() -> subjectBase
+            else -> listOf(subjectBase, examTags.joinToString(", ")).joinToString(", ")
+        }
+        val title = subject
+
+        return ParsedLessonDetails(
+            title = title,
+            subject = subject,
+            grade = grade,
+            rateCents = rateCents
+        )
+    }
+
+    private fun extractStudentName(tokens: List<String>): Pair<String, List<String>> {
+        if (tokens.isEmpty()) return "" to emptyList()
+        val first = tokens.first()
+        if (tokens.size == 1) return first to emptyList()
+        val second = tokens[1]
+        val examTokens = setOf("огэ", "егэ", "гиа", "впр")
+        val isSecondName = second.matches(Regex("^[\\p{L}\\-]+$")) &&
+            !second.matches(Regex("\\d{4,5}")) &&
+            !second.matches(Regex("^(?:[1-9]|1[01])$")) &&
+            !second.equals("студент", ignoreCase = true) &&
+            !second.equals("student", ignoreCase = true) &&
+            !second.equals("для", ignoreCase = true) &&
+            !second.equals("себя", ignoreCase = true) &&
+            second.lowercase() !in examTokens
+        return if (isSecondName) {
+            "${first} ${second}" to tokens.drop(2)
+        } else {
+            first to tokens.drop(1)
+        }
+    }
+
+    private fun normalizeSubject(raw: String): String {
+        val normalized = raw.lowercase().trim('.', ',', ';', ':')
+        val mapped = when (normalized) {
+            "м", "мат", "матем", "математика", "math" -> "Математика"
+            "а", "анг", "англ", "английский", "english", "eng" -> "Английский язык"
+            "и", "инф", "информ", "информатика", "it" -> "Информатика"
+            "р", "рус", "русский", "русск" -> "Русский язык"
+            "л", "лит", "литература" -> "Литература"
+            "ф", "физ", "физика" -> "Физика"
+            "х", "хим", "химия" -> "Химия"
+            "б", "био", "биология" -> "Биология"
+            "о", "общ", "обществознание", "обществозн" -> "Обществознание"
+            "ист", "история" -> "История"
+            else -> raw
+        }
+        return mapped.replaceFirstChar { if (it.isLowerCase()) it.titlecase() else it.toString() }
+    }
+
+    private fun buildRecurrenceRequest(
+        events: List<ImportEvent>,
+        zone: ZoneId
+    ): RecurrenceCreateRequest? {
+        if (events.size < 2) return null
+        val sorted = events.sortedBy { it.startAt }
+        val first = sorted.first()
+        val last = sorted.last()
+        val startLocal = first.startAt.atZone(zone)
+        val days = sorted.map { it.startAt.atZone(zone).dayOfWeek }.distinct().sortedBy { it.value }
+        if (days.isEmpty()) return null
+
+        val intervalWeeks = determineIntervalWeeks(sorted, zone) ?: return null
+        val expected = generateExpectedStarts(
+            startAt = first.startAt,
+            endAt = last.startAt,
+            intervalWeeks = intervalWeeks,
+            daysOfWeek = days,
+            zone = zone
+        )
+        val actualStarts = sorted.map { it.startAt }.toSet()
+        if (expected != actualStarts) return null
+
+        val frequency = if (intervalWeeks == 2) {
+            RecurrenceFrequency.BIWEEKLY
+        } else {
+            RecurrenceFrequency.WEEKLY
+        }
+        val interval = if (intervalWeeks == 2) 1 else intervalWeeks
+        val until = last.startAt
+
+        return RecurrenceCreateRequest(
+            frequency = frequency,
+            interval = interval,
+            daysOfWeek = days,
+            until = until,
+            timezone = startLocal.zone
+        )
+    }
+
+    private fun buildFallbackRecurrenceRequest(
+        events: List<ImportEvent>,
+        zone: ZoneId
+    ): RecurrenceCreateRequest? {
+        if (events.size < 2) return null
+        val sorted = events.sortedBy { it.startAt }
+        val first = sorted.first()
+        val startLocal = first.startAt.atZone(zone)
+        val days = sorted.map { it.startAt.atZone(zone).dayOfWeek }.distinct().sortedBy { it.value }
+        if (days.isEmpty()) return null
+        return RecurrenceCreateRequest(
+            frequency = RecurrenceFrequency.WEEKLY,
+            interval = 1,
+            daysOfWeek = days,
+            until = first.startAt,
+            timezone = startLocal.zone
+        )
+    }
+
+    private fun determineIntervalWeeks(
+        events: List<ImportEvent>,
+        zone: ZoneId
+    ): Int? {
+        val byDay = events.groupBy { it.startAt.atZone(zone).dayOfWeek }
+        var intervalWeeks: Int? = null
+        for ((_, dayEvents) in byDay) {
+            if (dayEvents.size < 2) continue
+            val sorted = dayEvents.sortedBy { it.startAt }
+            val diffs = sorted.zipWithNext { a, b ->
+                val days = ChronoUnit.DAYS.between(
+                    a.startAt.atZone(zone).toLocalDate(),
+                    b.startAt.atZone(zone).toLocalDate()
+                )
+                if (days <= 0 || days % 7L != 0L) return null
+                (days / 7L).toInt()
+            }
+            val first = diffs.firstOrNull() ?: continue
+            if (diffs.any { it != first }) return null
+            intervalWeeks = when (val current = intervalWeeks) {
+                null -> first
+                else -> if (current == first) current else return null
+            }
+        }
+        return intervalWeeks ?: 1
+    }
+
+    private fun generateExpectedStarts(
+        startAt: Instant,
+        endAt: Instant,
+        intervalWeeks: Int,
+        daysOfWeek: List<java.time.DayOfWeek>,
+        zone: ZoneId
+    ): Set<Instant> {
+        if (startAt > endAt) return emptySet()
+        val base = startAt.atZone(zone)
+        val results = mutableSetOf<Instant>()
+        val endZoned = endAt.atZone(zone)
+        val stepWeeks = intervalWeeks.coerceAtLeast(1).toLong()
+        for (day in daysOfWeek) {
+            var occurrence = base.with(TemporalAdjusters.nextOrSame(day))
+            if (occurrence.isBefore(base)) {
+                occurrence = occurrence.plusWeeks(stepWeeks)
+            }
+            while (!occurrence.isAfter(endZoned)) {
+                results += occurrence.toInstant()
+                occurrence = occurrence.plusWeeks(stepWeeks)
+            }
+        }
+        return results
+    }
 
     private fun defaultRangeStart(): Instant {
         val zone = ZoneId.systemDefault()
@@ -298,7 +656,17 @@ data class GoogleCalendarImportCandidate(
 
 private data class ParsedEventTitle(
     val studentName: String,
-    val lessonTitle: String?
+    val lessonTitle: String?,
+    val subject: String?,
+    val grade: String?,
+    val rateCents: Int?
+)
+
+private data class ParsedLessonDetails(
+    val title: String?,
+    val subject: String?,
+    val grade: String?,
+    val rateCents: Int?
 )
 
 private data class CalendarInstance(
@@ -314,4 +682,35 @@ private data class CalendarInstance(
 private data class CandidateAccumulator(
     val displayName: String,
     var count: Int
+)
+
+private data class ImportEvent(
+    val student: Student,
+    val studentName: String,
+    val normalizedStudentName: String,
+    val lessonTitle: String?,
+    val startAt: Instant,
+    val endAt: Instant,
+    val note: String?,
+    val priceCents: Int?
+) {
+    fun seriesKey(zone: ZoneId): SeriesKey {
+        val startLocal = startAt.atZone(zone)
+        val durationMinutes = Duration.between(startAt, endAt).toMinutes().toInt().coerceAtLeast(0)
+        return SeriesKey(
+            studentName = normalizedStudentName,
+            lessonTitle = lessonTitle?.trim()?.lowercase(),
+            startTime = startLocal.toLocalTime(),
+            durationMinutes = durationMinutes,
+            priceCents = priceCents
+        )
+    }
+}
+
+private data class SeriesKey(
+    val studentName: String,
+    val lessonTitle: String?,
+    val startTime: LocalTime,
+    val durationMinutes: Int,
+    val priceCents: Int?
 )

--- a/app/src/main/java/com/tutorly/data/calendar/GoogleCalendarMigrationService.kt
+++ b/app/src/main/java/com/tutorly/data/calendar/GoogleCalendarMigrationService.kt
@@ -145,6 +145,7 @@ class GoogleCalendarMigrationService @Inject constructor(
                 studentName = parsed.studentName,
                 normalizedStudentName = normalized,
                 lessonTitle = parsed.lessonTitle ?: parsed.subject,
+                originalTitle = title,
                 startAt = startAt,
                 endAt = endAt,
                 note = note,
@@ -673,6 +674,7 @@ private data class ImportEvent(
     val studentName: String,
     val normalizedStudentName: String,
     val lessonTitle: String?,
+    val originalTitle: String,
     val startAt: Instant,
     val endAt: Instant,
     val note: String?,
@@ -683,7 +685,8 @@ private data class ImportEvent(
         val durationMinutes = Duration.between(startAt, endAt).toMinutes().toInt().coerceAtLeast(0)
         return SeriesKey(
             studentName = normalizedStudentName,
-            lessonTitle = lessonTitle?.trim()?.lowercase(),
+            lessonTitle = lessonTitle?.trim()?.lowercase()
+                ?: originalTitle.trim().lowercase(),
             startTime = startLocal.toLocalTime(),
             dayOfWeek = startLocal.dayOfWeek,
             durationMinutes = durationMinutes,

--- a/app/src/main/java/com/tutorly/data/calendar/GoogleCalendarMigrationService.kt
+++ b/app/src/main/java/com/tutorly/data/calendar/GoogleCalendarMigrationService.kt
@@ -158,7 +158,6 @@ class GoogleCalendarMigrationService @Inject constructor(
             if (group.isEmpty()) continue
             val sorted = group.sortedBy { it.startAt }
             val recurrenceRequest = buildRecurrenceRequest(sorted, zone)
-                ?: buildFallbackRecurrenceRequest(sorted, zone)
             val recurrence = recurrenceRequest?.let { request ->
                 LessonRecurrence(
                     frequency = request.frequency,
@@ -546,25 +545,6 @@ class GoogleCalendarMigrationService @Inject constructor(
             interval = interval,
             daysOfWeek = days,
             until = until,
-            timezone = startLocal.zone
-        )
-    }
-
-    private fun buildFallbackRecurrenceRequest(
-        events: List<ImportEvent>,
-        zone: ZoneId
-    ): RecurrenceCreateRequest? {
-        if (events.size < 2) return null
-        val sorted = events.sortedBy { it.startAt }
-        val first = sorted.first()
-        val startLocal = first.startAt.atZone(zone)
-        val days = sorted.map { it.startAt.atZone(zone).dayOfWeek }.distinct().sortedBy { it.value }
-        if (days.isEmpty()) return null
-        return RecurrenceCreateRequest(
-            frequency = RecurrenceFrequency.WEEKLY,
-            interval = 1,
-            daysOfWeek = days,
-            until = first.startAt,
             timezone = startLocal.zone
         )
     }

--- a/app/src/main/java/com/tutorly/data/calendar/GoogleCalendarMigrationService.kt
+++ b/app/src/main/java/com/tutorly/data/calendar/GoogleCalendarMigrationService.kt
@@ -685,6 +685,7 @@ private data class ImportEvent(
             studentName = normalizedStudentName,
             lessonTitle = lessonTitle?.trim()?.lowercase(),
             startTime = startLocal.toLocalTime(),
+            dayOfWeek = startLocal.dayOfWeek,
             durationMinutes = durationMinutes,
             priceCents = priceCents
         )
@@ -695,6 +696,7 @@ private data class SeriesKey(
     val studentName: String,
     val lessonTitle: String?,
     val startTime: LocalTime,
+    val dayOfWeek: java.time.DayOfWeek,
     val durationMinutes: Int,
     val priceCents: Int?
 )


### PR DESCRIPTION
### Motivation
- Fix parsing where exam tags like `ОГЭ`/`ЕГЭ`/`ГИА`/`ВПР` were being swallowed into student names instead of being attached to subjects. 
- Make reasonable defaults for `grade` when an exam tag implies a grade (ЕГЭ → `11 класс`, ОГЭ → `9 класс`) to reduce manual corrections after import. 
- Preserve prior improvements for subject normalization and series grouping while addressing the name/tag parsing bug. 

### Description
- Updated title parsing by introducing `parseLessonDetails` and `ParsedLessonDetails`, and changed `parseEventTitle` to return `subject`, `grade`, and `rateCents` alongside the student name and lesson title. 
- Excluded exam tokens from student surnames in `extractStudentName` by checking a set of exam tokens and removing them from the name tokens so they are collected into `examTags` instead. 
- If no explicit `grade` was parsed, infer `grade` from exam tags (`ЕГЭ` → `11 класс`, `ОГЭ` → `9 класс`) and append exam tags to the parsed `subject`. 
- Propagated parsed `subject`/`grade`/`rateCents` into `findOrCreateStudent`, updating existing `Student` records when fields are missing and creating new students with parsed defaults; also implemented event aggregation (`ImportEvent`) and price-aware series grouping and recurrence creation logic so created lessons include `priceCents` and series anchoring. 

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698229cbc17083208da7b59c73f85902)