### PR TITLE
Include weekday in Google Calendar import series grouping

### DIFF
--- a/app/src/main/java/com/tutorly/data/calendar/GoogleCalendarMigrationService.kt
+++ b/app/src/main/java/com/tutorly/data/calendar/GoogleCalendarMigrationService.kt
@@ -153,8 +153,13 @@ class GoogleCalendarMigrationService @Inject constructor(
         }
 
         val zone = ZoneId.systemDefault()
-        val grouped = events.groupBy { it.seriesKey(zone) }.toSortedMap(compareBy { it.studentName.lowercase() })
-        for ((_, group) in grouped) {
+        val grouped = events.groupBy { it.seriesKey(zone) }
+        val sortedGroups = grouped.entries.sortedWith(
+            compareBy<Map.Entry<SeriesKey, List<ImportEvent>>> { it.key.studentName.lowercase() }
+                .thenBy { it.key.dayOfWeek.value }
+                .thenBy { it.key.startTime }
+        )
+        for ((_, group) in sortedGroups) {
             if (group.isEmpty()) continue
             val sorted = group.sortedBy { it.startAt }
             val recurrenceRequest = buildRecurrenceRequest(sorted, zone)

--- a/app/src/main/java/com/tutorly/data/calendar/GoogleCalendarMigrationService.kt
+++ b/app/src/main/java/com/tutorly/data/calendar/GoogleCalendarMigrationService.kt
@@ -691,6 +691,7 @@ private data class ImportEvent(
         return SeriesKey(
             studentName = normalizedStudentName,
             lessonTitle = lessonTitle?.trim()?.lowercase(),
+            dayOfWeek = startLocal.dayOfWeek,
             startTime = startLocal.toLocalTime(),
             durationMinutes = durationMinutes,
             priceCents = priceCents
@@ -701,6 +702,7 @@ private data class ImportEvent(
 private data class SeriesKey(
     val studentName: String,
     val lessonTitle: String?,
+    val dayOfWeek: java.time.DayOfWeek,
     val startTime: LocalTime,
     val durationMinutes: Int,
     val priceCents: Int?


### PR DESCRIPTION
### Motivation
- Ensure events imported from Google Calendar that occur multiple times per week for the same student are preserved as separate series so edits (e.g. subject or price) can be applied per series instead of being merged.

### Description
- Add `dayOfWeek` to `SeriesKey` and populate it in `ImportEvent.seriesKey` to include the weekday when grouping series in `app/src/main/java/com/tutorly/data/calendar/GoogleCalendarMigrationService.kt`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69835204f1288320bd7e4549348a367c)