### PR TITLE
Добавить мультивыбор учеников с подтверждением архивирования/удаления

### DIFF
--- a/app/src/main/java/com/tutorly/ui/screens/StudentsScreen.kt
+++ b/app/src/main/java/com/tutorly/ui/screens/StudentsScreen.kt
@@ -7,6 +7,7 @@ import androidx.compose.animation.core.FastOutSlowInEasing
 import androidx.compose.animation.core.tween
 //import androidx.compose.animation.sharedBounds
 import androidx.compose.foundation.background
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -689,12 +690,13 @@ private fun StudentCard(
             ),
         shape = MaterialTheme.shapes.large,
         colors = CardDefaults.cardColors(
-            containerColor = if (isSelected) {
-                MaterialTheme.colorScheme.primaryContainer
-            } else {
-                MaterialTheme.colorScheme.surfaceContainerLowest
-            }
+            containerColor = MaterialTheme.colorScheme.surfaceContainerLowest
         ),
+        border = if (isSelected) {
+            BorderStroke(1.5.dp, MaterialTheme.colorScheme.outline)
+        } else {
+            null
+        },
         elevation = TutorlyCardDefaults.elevation()
     ) {
         Box(Modifier.fillMaxWidth()) {
@@ -702,8 +704,8 @@ private fun StudentCard(
                 SelectionIndicator(
                     selected = isSelected,
                     modifier = Modifier
-                        .align(Alignment.TopEnd)
-                        .padding(top = 12.dp, end = 16.dp)
+                        .align(Alignment.BottomEnd)
+                        .padding(bottom = 12.dp, end = 16.dp)
                 )
             }
 
@@ -712,10 +714,7 @@ private fun StudentCard(
                     status = PaymentBadgeStatus.DEBT,
                     modifier = Modifier
                         .align(Alignment.TopEnd)
-                        .padding(
-                            top = if (isSelectionMode) 40.dp else 12.dp,
-                            end = 16.dp
-                        )
+                        .padding(top = 12.dp, end = 16.dp)
                 )
             }
 
@@ -826,7 +825,7 @@ private fun SelectionIndicator(
         shape = CircleShape,
         color = if (selected) MaterialTheme.colorScheme.primary else Color.Transparent,
         contentColor = MaterialTheme.colorScheme.onPrimary,
-        border = androidx.compose.foundation.BorderStroke(
+        border = BorderStroke(
             width = 1.5.dp,
             color = if (selected) {
                 MaterialTheme.colorScheme.primary

--- a/app/src/main/java/com/tutorly/ui/screens/StudentsScreen.kt
+++ b/app/src/main/java/com/tutorly/ui/screens/StudentsScreen.kt
@@ -693,22 +693,13 @@ private fun StudentCard(
             containerColor = MaterialTheme.colorScheme.surfaceContainerLowest
         ),
         border = if (isSelected) {
-            BorderStroke(1.5.dp, MaterialTheme.colorScheme.outline)
+            BorderStroke(2.5.dp, MaterialTheme.colorScheme.outline)
         } else {
             null
         },
         elevation = TutorlyCardDefaults.elevation()
     ) {
         Box(Modifier.fillMaxWidth()) {
-            if (isSelectionMode) {
-                SelectionIndicator(
-                    selected = isSelected,
-                    modifier = Modifier
-                        .align(Alignment.BottomEnd)
-                        .padding(bottom = 12.dp, end = 16.dp)
-                )
-            }
-
             if (item.hasDebt) {
                 PaymentBadge(
                     status = PaymentBadgeStatus.DEBT,
@@ -779,7 +770,7 @@ private fun StudentCard(
                             }
                         }
                         Surface(
-                            color = MaterialTheme.colorScheme.surfaceContainerLowest,
+                            color = Color.Transparent,
                             contentColor = MaterialTheme.colorScheme.primary,
                             shape = MaterialTheme.shapes.small
                         ) {
@@ -810,6 +801,15 @@ private fun StudentCard(
                         }
                     }
                 }
+            }
+
+            if (isSelectionMode) {
+                SelectionIndicator(
+                    selected = isSelected,
+                    modifier = Modifier
+                        .align(Alignment.BottomEnd)
+                        .padding(bottom = 12.dp, end = 16.dp)
+                )
             }
         }
     }

--- a/app/src/main/java/com/tutorly/ui/screens/StudentsScreen.kt
+++ b/app/src/main/java/com/tutorly/ui/screens/StudentsScreen.kt
@@ -7,6 +7,7 @@ import androidx.compose.animation.core.FastOutSlowInEasing
 import androidx.compose.animation.core.tween
 //import androidx.compose.animation.sharedBounds
 import androidx.compose.foundation.background
+import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -28,6 +29,7 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.PersonAdd
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.icons.outlined.Archive
@@ -38,6 +40,7 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
@@ -106,12 +109,15 @@ fun StudentsScreen(
     val students by vm.students.collectAsState()
     val formState by vm.editorFormState.collectAsState()
     val isArchiveMode by vm.isArchiveMode.collectAsState()
+    val selectedStudentIds by vm.selectedStudentIds.collectAsState()
     val subjectPresets by vm.subjectPresets.collectAsState()
     val snackbarHostState = remember { SnackbarHostState() }
     val coroutineScope = rememberCoroutineScope()
     val context = LocalContext.current
     var showEditor by rememberSaveable { mutableStateOf(false) }
     var editorOrigin by rememberSaveable { mutableStateOf(StudentEditorOrigin.NONE) }
+    var showDeleteConfirm by rememberSaveable { mutableStateOf(false) }
+    var showArchiveConfirm by rememberSaveable { mutableStateOf(false) }
 
     val openCreationEditor: (StudentEditorOrigin) -> Unit = { origin ->
         editorOrigin = origin
@@ -173,19 +179,26 @@ fun StudentsScreen(
         topBar = {
             StudentsTopBar(
                 isArchiveMode = isArchiveMode,
-                onToggleArchive = vm::toggleArchiveMode
+                hasSelection = selectedStudentIds.isNotEmpty(),
+                selectedCount = selectedStudentIds.size,
+                onToggleArchive = vm::toggleArchiveMode,
+                onClearSelection = vm::clearSelection,
+                onDeleteSelection = { showDeleteConfirm = true },
+                onArchiveSelection = { showArchiveConfirm = true }
             )
         },
         floatingActionButton = {
-            FloatingActionButton(
-                onClick = { openCreationEditor(StudentEditorOrigin.STUDENTS) },
-                containerColor = MaterialTheme.extendedColors.accent,
-                contentColor = MaterialTheme.colorScheme.onPrimary
-            ) {
-                Icon(
-                    imageVector = Icons.Default.PersonAdd,
-                    contentDescription = stringResource(id = R.string.add_student)
-                )
+            if (selectedStudentIds.isEmpty()) {
+                FloatingActionButton(
+                    onClick = { openCreationEditor(StudentEditorOrigin.STUDENTS) },
+                    containerColor = MaterialTheme.extendedColors.accent,
+                    contentColor = MaterialTheme.colorScheme.onPrimary
+                ) {
+                    Icon(
+                        imageVector = Icons.Default.PersonAdd,
+                        contentDescription = stringResource(id = R.string.add_student)
+                    )
+                }
             }
         }
     ) { innerPadding ->
@@ -240,7 +253,11 @@ fun StudentsScreen(
                         val sharedKey = "student-card-${item.student.id}"
                         StudentCard(
                             item = item,
-                            onClick = { onStudentOpen(item.student.id) },
+                            isSelected = item.student.id in selectedStudentIds,
+                            onClick = {
+                                vm.onStudentClick(item.student.id, onStudentOpen)
+                            },
+                            onLongClick = { vm.onStudentLongPress(item.student.id) },
                             sharedTransitionScope = sharedTransitionScope,
                             animatedVisibilityScope = animatedVisibilityScope,
                             sharedContentKey = sharedKey
@@ -270,18 +287,131 @@ fun StudentsScreen(
             }
         )
     }
+
+    if (showArchiveConfirm) {
+        val inArchiveMode = isArchiveMode
+        AlertDialog(
+            onDismissRequest = { showArchiveConfirm = false },
+            title = {
+                Text(
+                    text = stringResource(
+                        id = if (inArchiveMode) {
+                            R.string.students_confirm_unarchive_title
+                        } else {
+                            R.string.students_confirm_archive_title
+                        }
+                    )
+                )
+            },
+            text = {
+                Text(
+                    text = stringResource(
+                        id = if (inArchiveMode) {
+                            R.string.students_confirm_unarchive_message
+                        } else {
+                            R.string.students_confirm_archive_message
+                        },
+                        selectedStudentIds.size
+                    )
+                )
+            },
+            confirmButton = {
+                Button(onClick = {
+                    vm.archiveSelectedStudents(
+                        archive = !inArchiveMode,
+                        onSuccess = {
+                            showArchiveConfirm = false
+                        },
+                        onError = {
+                            showArchiveConfirm = false
+                            coroutineScope.launch {
+                                snackbarHostState.showSnackbar(
+                                    context.getString(R.string.students_bulk_action_error)
+                                )
+                            }
+                        }
+                    )
+                }) {
+                    Text(
+                        text = stringResource(
+                            id = if (inArchiveMode) {
+                                R.string.students_unarchive_action
+                            } else {
+                                R.string.students_archive_action
+                            }
+                        )
+                    )
+                }
+            },
+            dismissButton = {
+                Button(onClick = { showArchiveConfirm = false }) {
+                    Text(text = stringResource(id = R.string.student_editor_cancel))
+                }
+            }
+        )
+    }
+
+    if (showDeleteConfirm) {
+        AlertDialog(
+            onDismissRequest = { showDeleteConfirm = false },
+            title = { Text(text = stringResource(id = R.string.students_confirm_delete_title)) },
+            text = {
+                Text(
+                    text = stringResource(
+                        id = R.string.students_confirm_delete_message,
+                        selectedStudentIds.size
+                    )
+                )
+            },
+            confirmButton = {
+                Button(onClick = {
+                    vm.deleteSelectedStudents(
+                        onSuccess = {
+                            showDeleteConfirm = false
+                        },
+                        onError = {
+                            showDeleteConfirm = false
+                            coroutineScope.launch {
+                                snackbarHostState.showSnackbar(
+                                    context.getString(R.string.students_bulk_action_error)
+                                )
+                            }
+                        }
+                    )
+                }) {
+                    Text(text = stringResource(id = R.string.students_delete_action))
+                }
+            },
+            dismissButton = {
+                Button(onClick = { showDeleteConfirm = false }) {
+                    Text(text = stringResource(id = R.string.student_editor_cancel))
+                }
+            }
+        )
+    }
 }
 
 @Composable
 private fun StudentsTopBar(
     isArchiveMode: Boolean,
-    onToggleArchive: () -> Unit
+    hasSelection: Boolean,
+    selectedCount: Int,
+    onToggleArchive: () -> Unit,
+    onClearSelection: () -> Unit,
+    onDeleteSelection: () -> Unit,
+    onArchiveSelection: () -> Unit
 ) {
     TopBarContainer {
-        val titleRes = if (isArchiveMode) {
-            R.string.students_archive_title
+        val titleText = if (hasSelection) {
+            stringResource(id = R.string.students_selected_count, selectedCount)
         } else {
-            R.string.students_title
+            stringResource(
+                id = if (isArchiveMode) {
+                    R.string.students_archive_title
+                } else {
+                    R.string.students_title
+                }
+            )
         }
         val actionIcon = if (isArchiveMode) {
             Icons.Outlined.Unarchive
@@ -303,7 +433,7 @@ private fun StudentsTopBar(
                 .padding(horizontal = 16.dp)
         ) {
             Text(
-                text = stringResource(id = titleRes),
+                text = titleText,
                 style = MaterialTheme.typography.titleLarge,
                 color = MaterialTheme.colorScheme.surface,
                 textAlign = TextAlign.Center,
@@ -314,17 +444,58 @@ private fun StudentsTopBar(
                     .padding(horizontal = 72.dp)
             )
 
-            IconButton(
-                onClick = onToggleArchive,
-                modifier = Modifier.align(Alignment.CenterEnd),
-                colors = IconButtonDefaults.iconButtonColors(
-                    contentColor = MaterialTheme.colorScheme.surface
-                )
-            ) {
-                Icon(
-                    imageVector = actionIcon,
-                    contentDescription = contentDescription
-                )
+            if (hasSelection) {
+                Row(
+                    modifier = Modifier.align(Alignment.CenterEnd),
+                    horizontalArrangement = Arrangement.spacedBy(4.dp)
+                ) {
+                    IconButton(
+                        onClick = onArchiveSelection,
+                        colors = IconButtonDefaults.iconButtonColors(
+                            contentColor = MaterialTheme.colorScheme.surface
+                        )
+                    ) {
+                        Icon(
+                            imageVector = actionIcon,
+                            contentDescription = contentDescription
+                        )
+                    }
+                    IconButton(
+                        onClick = onDeleteSelection,
+                        colors = IconButtonDefaults.iconButtonColors(
+                            contentColor = MaterialTheme.colorScheme.surface
+                        )
+                    ) {
+                        Icon(
+                            imageVector = Icons.Default.Delete,
+                            contentDescription = stringResource(id = R.string.students_delete_action)
+                        )
+                    }
+                    IconButton(
+                        onClick = onClearSelection,
+                        colors = IconButtonDefaults.iconButtonColors(
+                            contentColor = MaterialTheme.colorScheme.surface
+                        )
+                    ) {
+                        Icon(
+                            imageVector = Icons.Default.Close,
+                            contentDescription = stringResource(id = R.string.student_editor_close)
+                        )
+                    }
+                }
+            } else {
+                IconButton(
+                    onClick = onToggleArchive,
+                    modifier = Modifier.align(Alignment.CenterEnd),
+                    colors = IconButtonDefaults.iconButtonColors(
+                        contentColor = MaterialTheme.colorScheme.surface
+                    )
+                ) {
+                    Icon(
+                        imageVector = actionIcon,
+                        contentDescription = contentDescription
+                    )
+                }
             }
         }
     }
@@ -465,6 +636,8 @@ private fun EmptyStudentsState(isArchiveMode: Boolean, modifier: Modifier = Modi
 private fun StudentCard(
     item: StudentsViewModel.StudentListItem,
     onClick: () -> Unit,
+    onLongClick: () -> Unit,
+    isSelected: Boolean,
     modifier: Modifier = Modifier,
     sharedTransitionScope: SharedTransitionScope? = null,
     animatedVisibilityScope: AnimatedVisibilityScope? = null,
@@ -501,13 +674,20 @@ private fun StudentCard(
     }
 
     Card(
-        onClick = onClick,
         modifier = modifier
             .fillMaxWidth()
-            .then(sharedModifier),
+            .then(sharedModifier)
+            .combinedClickable(
+                onClick = onClick,
+                onLongClick = onLongClick
+            ),
         shape = MaterialTheme.shapes.large,
         colors = CardDefaults.cardColors(
-            containerColor = MaterialTheme.colorScheme.surfaceContainerLowest
+            containerColor = if (isSelected) {
+                MaterialTheme.colorScheme.primaryContainer
+            } else {
+                MaterialTheme.colorScheme.surfaceContainerLowest
+            }
         ),
         elevation = TutorlyCardDefaults.elevation()
     ) {
@@ -647,4 +827,3 @@ fun StudentAvatar(
         )
     }
 }
-

--- a/app/src/main/java/com/tutorly/ui/screens/StudentsScreen.kt
+++ b/app/src/main/java/com/tutorly/ui/screens/StudentsScreen.kt
@@ -29,6 +29,7 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.PersonAdd
 import androidx.compose.material.icons.filled.Search
@@ -253,6 +254,7 @@ fun StudentsScreen(
                         val sharedKey = "student-card-${item.student.id}"
                         StudentCard(
                             item = item,
+                            isSelectionMode = selectedStudentIds.isNotEmpty(),
                             isSelected = item.student.id in selectedStudentIds,
                             onClick = {
                                 vm.onStudentClick(item.student.id, onStudentOpen)
@@ -436,12 +438,15 @@ private fun StudentsTopBar(
                 text = titleText,
                 style = MaterialTheme.typography.titleLarge,
                 color = MaterialTheme.colorScheme.surface,
-                textAlign = TextAlign.Center,
+                textAlign = if (hasSelection) TextAlign.Start else TextAlign.Center,
                 maxLines = 1,
                 overflow = TextOverflow.Ellipsis,
                 modifier = Modifier
-                    .align(Alignment.Center)
-                    .padding(horizontal = 72.dp)
+                    .align(if (hasSelection) Alignment.CenterStart else Alignment.Center)
+                    .padding(
+                        start = if (hasSelection) 0.dp else 72.dp,
+                        end = 72.dp
+                    )
             )
 
             if (hasSelection) {
@@ -637,6 +642,7 @@ private fun StudentCard(
     item: StudentsViewModel.StudentListItem,
     onClick: () -> Unit,
     onLongClick: () -> Unit,
+    isSelectionMode: Boolean,
     isSelected: Boolean,
     modifier: Modifier = Modifier,
     sharedTransitionScope: SharedTransitionScope? = null,
@@ -692,12 +698,24 @@ private fun StudentCard(
         elevation = TutorlyCardDefaults.elevation()
     ) {
         Box(Modifier.fillMaxWidth()) {
+            if (isSelectionMode) {
+                SelectionIndicator(
+                    selected = isSelected,
+                    modifier = Modifier
+                        .align(Alignment.TopEnd)
+                        .padding(top = 12.dp, end = 16.dp)
+                )
+            }
+
             if (item.hasDebt) {
                 PaymentBadge(
                     status = PaymentBadgeStatus.DEBT,
                     modifier = Modifier
                         .align(Alignment.TopEnd)
-                        .padding(top = 12.dp, end = 16.dp)
+                        .padding(
+                            top = if (isSelectionMode) 40.dp else 12.dp,
+                            end = 16.dp
+                        )
                 )
             }
 
@@ -793,6 +811,37 @@ private fun StudentCard(
                         }
                     }
                 }
+            }
+        }
+    }
+}
+
+@Composable
+private fun SelectionIndicator(
+    selected: Boolean,
+    modifier: Modifier = Modifier
+) {
+    Surface(
+        modifier = modifier.size(22.dp),
+        shape = CircleShape,
+        color = if (selected) MaterialTheme.colorScheme.primary else Color.Transparent,
+        contentColor = MaterialTheme.colorScheme.onPrimary,
+        border = androidx.compose.foundation.BorderStroke(
+            width = 1.5.dp,
+            color = if (selected) {
+                MaterialTheme.colorScheme.primary
+            } else {
+                MaterialTheme.colorScheme.outline
+            }
+        )
+    ) {
+        if (selected) {
+            Box(contentAlignment = Alignment.Center) {
+                Icon(
+                    imageVector = Icons.Default.Check,
+                    contentDescription = null,
+                    modifier = Modifier.size(14.dp)
+                )
             }
         }
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -8,6 +8,17 @@
     <string name="students_archive_title">Архив учеников</string>
     <string name="students_archive_show">Открыть архив учеников</string>
     <string name="students_archive_show_active">Показать активных учеников</string>
+    <string name="students_selected_count">Выбрано: %1$d</string>
+    <string name="students_archive_action">В архив</string>
+    <string name="students_unarchive_action">Вернуть</string>
+    <string name="students_delete_action">Удалить</string>
+    <string name="students_confirm_archive_title">Отправить в архив?</string>
+    <string name="students_confirm_archive_message">Отправить в архив %1$d учен.</string>
+    <string name="students_confirm_unarchive_title">Вернуть из архива?</string>
+    <string name="students_confirm_unarchive_message">Вернуть в активные %1$d учен.</string>
+    <string name="students_confirm_delete_title">Удалить учеников?</string>
+    <string name="students_confirm_delete_message">Удалить %1$d учен. без возможности восстановления?</string>
+    <string name="students_bulk_action_error">Не удалось выполнить действие</string>
     <string name="students_subject_label">Предмет</string>
     <string name="students_subject_placeholder">Не указан</string>
     <string name="students_grade_label">Класс</string>


### PR DESCRIPTION
### Motivation
- Пользовательская задача — сделать возможным выделение нескольких учеников через долгое нажатие и выполнять массовые операции (удаление/отправка в архив/возврат из архива) с подтверждением.

### Description
- Добавлено хранение и синхронизация выделения в `StudentsViewModel`: `MutableStateFlow` `selectedStudentIds`, методы `onStudentLongPress`, `onStudentClick`, `toggleStudentSelection`, `clearSelection`, `archiveSelectedStudents`, `deleteSelectedStudents` и `syncSelection`.
- UI: `StudentsScreen` обновлён для поддержки мультивыбора — карточки используют `combinedClickable` и принимают `isSelected`, `onClick`, `onLongClick`; FAB скрывается в режиме выбора; в `TopBar` показывается счётчик выделенных и кнопки массовых действий (архив/вернуть, удалить, сброс выделения); добавлены `AlertDialog`-подтверждения для архивирования/возврата и удаления.
- Добавлены строковые ресурсы для интерфейса мультивыбора и подтверждений в `app/src/main/res/values/strings.xml`.
- Затронутые файлы: `StudentsViewModel.kt`, `StudentsScreen.kt`, `strings.xml`.

### Testing
- Выполнены статические проверки изменённых мест кода с помощью поиска по проекту (`rg`) для подтверждения наличия новых символов и вызовов, и они показали ожидаемые изменения (успешно).
- Попытка собрать модуль с помощью `./gradlew :app:compileDebugKotlin` завершилась неудачно из-за ограничения окружения при загрузке Gradle (сетевая ошибка: `HTTP/1.1 403 Forbidden` через proxy), поэтому полноценная компиляция и интеграционные тесты не были выполнены.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69957e6d54c48320b9c4f79298687255)