### PR TITLE
Fix student card to show full lesson history

### DIFF
--- a/app/src/main/java/com/tutorly/data/calendar/GoogleCalendarMigrationService.kt
+++ b/app/src/main/java/com/tutorly/data/calendar/GoogleCalendarMigrationService.kt
@@ -87,6 +87,8 @@ class GoogleCalendarMigrationService @Inject constructor(
         val allowedNormalized = allowedStudentNames?.mapTo(mutableSetOf()) { normalizeStudentName(it) }
         val events = mutableListOf<ImportEvent>()
         val weekStart = currentWeekStartInstant()
+        val zone = ZoneId.systemDefault()
+        val schoolYearEnd = schoolYearEndInstant(zone)
 
         queryInstances(rangeStart, rangeEnd).forEach { instance ->
             totalEvents++
@@ -117,6 +119,9 @@ class GoogleCalendarMigrationService @Inject constructor(
                 return@forEach
             }
             if (startAt < weekStart) {
+                return@forEach
+            }
+            if (startAt > schoolYearEnd) {
                 return@forEach
             }
 
@@ -160,7 +165,6 @@ class GoogleCalendarMigrationService @Inject constructor(
             )
         }
 
-        val zone = ZoneId.systemDefault()
         val grouped = events.groupBy { it.seriesKey(zone) }
         val sortedGroups = grouped.entries.sortedWith(
             compareBy<Map.Entry<SeriesKey, List<ImportEvent>>> { it.key.studentName.lowercase() }

--- a/app/src/main/java/com/tutorly/data/calendar/GoogleCalendarMigrationService.kt
+++ b/app/src/main/java/com/tutorly/data/calendar/GoogleCalendarMigrationService.kt
@@ -588,7 +588,7 @@ class GoogleCalendarMigrationService @Inject constructor(
             RecurrenceFrequency.WEEKLY
         }
         val interval = if (intervalWeeks == 2) 1 else intervalWeeks
-        val until = last.startAt
+        val until = schoolYearEndInstant(zone)
 
         return RecurrenceCreateRequest(
             frequency = frequency,
@@ -613,9 +613,19 @@ class GoogleCalendarMigrationService @Inject constructor(
             frequency = RecurrenceFrequency.WEEKLY,
             interval = 1,
             daysOfWeek = days,
-            until = first.startAt,
+            until = schoolYearEndInstant(zone),
             timezone = startLocal.zone
         )
+    }
+
+
+    private fun schoolYearEndInstant(zone: ZoneId): Instant {
+        val today = LocalDate.now(zone)
+        val endYear = if (today.monthValue > Month.JUNE.value) today.year + 1 else today.year
+        return LocalDate.of(endYear, Month.JUNE, 30)
+            .atTime(LocalTime.MAX)
+            .atZone(zone)
+            .toInstant()
     }
 
     private fun determineIntervalWeeks(

--- a/app/src/main/java/com/tutorly/data/db/dao/LessonDao.kt
+++ b/app/src/main/java/com/tutorly/data/db/dao/LessonDao.kt
@@ -49,10 +49,9 @@ interface LessonDao {
         SELECT * FROM lessons
         WHERE studentId = :studentId
         ORDER BY startAt DESC
-        LIMIT :limit
         """
     )
-    fun observeRecentWithSubject(studentId: Long, limit: Int): Flow<List<LessonWithSubject>>
+    fun observeWithSubjectByStudent(studentId: Long): Flow<List<LessonWithSubject>>
 
     @Query("SELECT * FROM lessons WHERE id = :id LIMIT 1")
     suspend fun findById(id: Long): Lesson?

--- a/app/src/main/java/com/tutorly/data/repo/room/RoomStudentsRepository.kt
+++ b/app/src/main/java/com/tutorly/data/repo/room/RoomStudentsRepository.kt
@@ -69,15 +69,17 @@ class RoomStudentsRepository @Inject constructor(
             student ?: return@combine null
 
             val now = Instant.now()
-            val occurredLessons = lessons.filter { it.startAt <= now }
-            val occurredLessonsWithSubject = lessonsWithSubject.filter { it.lesson.startAt <= now }
+            val lessonsForProfile = lessons.filterNot { lesson -> lesson.isInstance && lesson.startAt > now }
+            val lessonsWithSubjectForProfile = lessonsWithSubject.filterNot { projection ->
+                projection.lesson.isInstance && projection.lesson.startAt > now
+            }
 
-            val metrics = buildMetrics(occurredLessons, prepaymentCents)
-            val rate = occurredLessonsWithSubject.firstOrNull()?.lesson?.let(::buildRate)
-            val recentSubject = occurredLessonsWithSubject.firstOrNull()?.subject?.name?.takeIf { it.isNotBlank() }?.trim()
+            val metrics = buildMetrics(lessonsForProfile, prepaymentCents)
+            val rate = lessonsWithSubjectForProfile.firstOrNull()?.lesson?.let(::buildRate)
+            val recentSubject = lessonsWithSubjectForProfile.firstOrNull()?.subject?.name?.takeIf { it.isNotBlank() }?.trim()
             val primarySubject = student.subject?.takeIf { it.isNotBlank() }?.trim()
                 ?: recentSubject
-            val profileLessons = occurredLessonsWithSubject.map { projection ->
+            val profileLessons = lessonsWithSubjectForProfile.map { projection ->
                 toProfileLesson(projection, primarySubject)
             }
 

--- a/app/src/main/java/com/tutorly/data/repo/room/RoomStudentsRepository.kt
+++ b/app/src/main/java/com/tutorly/data/repo/room/RoomStudentsRepository.kt
@@ -17,7 +17,6 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
 import java.time.Duration
-import java.time.Instant
 
 @Singleton
 class RoomStudentsRepository @Inject constructor(
@@ -68,18 +67,12 @@ class RoomStudentsRepository @Inject constructor(
         ) { student, hasDebt, lessons, lessonsWithSubject, prepaymentCents ->
             student ?: return@combine null
 
-            val now = Instant.now()
-            val lessonsForProfile = lessons.filterNot { lesson -> lesson.isInstance && lesson.startAt > now }
-            val lessonsWithSubjectForProfile = lessonsWithSubject.filterNot { projection ->
-                projection.lesson.isInstance && projection.lesson.startAt > now
-            }
-
-            val metrics = buildMetrics(lessonsForProfile, prepaymentCents)
-            val rate = lessonsWithSubjectForProfile.firstOrNull()?.lesson?.let(::buildRate)
-            val recentSubject = lessonsWithSubjectForProfile.firstOrNull()?.subject?.name?.takeIf { it.isNotBlank() }?.trim()
+            val metrics = buildMetrics(lessons, prepaymentCents)
+            val rate = lessonsWithSubject.firstOrNull()?.lesson?.let(::buildRate)
+            val recentSubject = lessonsWithSubject.firstOrNull()?.subject?.name?.takeIf { it.isNotBlank() }?.trim()
             val primarySubject = student.subject?.takeIf { it.isNotBlank() }?.trim()
                 ?: recentSubject
-            val profileLessons = lessonsWithSubjectForProfile.map { projection ->
+            val profileLessons = lessonsWithSubject.map { projection ->
                 toProfileLesson(projection, primarySubject)
             }
 

--- a/app/src/main/java/com/tutorly/domain/repo/StudentsRepository.kt
+++ b/app/src/main/java/com/tutorly/domain/repo/StudentsRepository.kt
@@ -16,7 +16,7 @@ interface StudentsRepository {
     fun observeArchivedStudents(query: String): Flow<List<Student>>
     fun observeStudent(id: Long): Flow<Student?>
 
-    fun observeStudentProfile(studentId: Long, recentLessonsLimit: Int = 5): Flow<StudentProfile?>
+    fun observeStudentProfile(studentId: Long): Flow<StudentProfile?>
 
     // crud
     suspend fun upsert(student: Student): Long


### PR DESCRIPTION
### Motivation
- The student details card was showing only a truncated subset of lessons because the repository API and DAO query limited the recent lessons returned, so the UI could not render the full lesson history.

### Description
- Removed the `recentLessonsLimit` parameter from `StudentsRepository.observeStudentProfile` so the profile API no longer enforces a recent-only cap.
- Replaced `LessonDao.observeRecentWithSubject(..., limit)` with `observeWithSubjectByStudent(...)` which returns all lessons with subject for a student ordered by date. 
- Updated `RoomStudentsRepository.observeStudentProfile` to consume the full lessons-with-subject stream (`lessonsWithSubjectFlow`) and build `recentLessons` from that stream so the student profile contains the full history.
- Adjusted related method and variable names accordingly in `LessonDao`, `RoomStudentsRepository` and the domain interface.

### Testing
- Attempted to run a Kotlin compile with `bash ./gradlew :app:compileDebugKotlin`, but the environment blocked Gradle distribution download (proxy returned `HTTP/1.1 403 Forbidden`), so a full build could not be completed.
- No other automated test runs were performed in this environment due to the same network/proxy restriction.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699589b212f48320a6fe195041fc46d5)