### PR TITLE
Показывать все долги прошлых дней на экране «Сегодня»

### DIFF
--- a/app/src/main/java/com/tutorly/ui/screens/TodayScreen.kt
+++ b/app/src/main/java/com/tutorly/ui/screens/TodayScreen.kt
@@ -61,6 +61,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.State
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
@@ -1141,17 +1142,19 @@ private fun LessonsList(
         return
     }
     Column(modifier = Modifier.fillMaxWidth()) {
-        lessons.forEachIndexed { index, lesson ->
-            TodayLessonRow(
-                lesson = lesson,
-                onSwipeRight = onSwipeRight,
-                onSwipeLeft = onSwipeLeft,
-                onClick = { onLessonOpen(lesson.baseLessonId) },
-                onLongPress = { onLessonLongPress(lesson) },
-                cardElevation = cardElevation,
-                showLessonDate = showLessonDate,
-            )
-            Spacer(modifier = Modifier.height(12.dp))
+        lessons.forEach { lesson ->
+            key(lesson.id) {
+                TodayLessonRow(
+                    lesson = lesson,
+                    onSwipeRight = onSwipeRight,
+                    onSwipeLeft = onSwipeLeft,
+                    onClick = { onLessonOpen(lesson.baseLessonId) },
+                    onLongPress = { onLessonLongPress(lesson) },
+                    cardElevation = cardElevation,
+                    showLessonDate = showLessonDate,
+                )
+                Spacer(modifier = Modifier.height(12.dp))
+            }
         }
     }
 }

--- a/app/src/main/java/com/tutorly/ui/screens/TodayViewModel.kt
+++ b/app/src/main/java/com/tutorly/ui/screens/TodayViewModel.kt
@@ -147,8 +147,8 @@ class TodayViewModel @Inject constructor(
         val outstanding = outstandingLessons
             .filter { it.paymentStatus in PaymentStatus.outstandingStatuses }
             .sortedByDescending { it.priceCents }
-        val pastDueLessonsPreview = outstanding.take(3)
-        val hasMorePastLessons = outstanding.size > pastDueLessonsPreview.size
+        val pastDueLessonsPreview = outstanding
+        val hasMorePastLessons = false
 
         if (todayLessons.isEmpty()) {
             if (dayClosedState.value) {


### PR DESCRIPTION
### Motivation
- Убрать искусственный лимит предварительного просмотра в блоке «Долги прошлых дней», чтобы в секции отображались все занятия с задолженностями, а не только последние три.

### Description
- В `TodayViewModel` внутри `buildUiState` заменено `val pastDueLessonsPreview = outstanding.take(3)` на `val pastDueLessonsPreview = outstanding` и `val hasMorePastLessons = outstanding.size > pastDueLessonsPreview.size` на `val hasMorePastLessons = false`, чтобы передавать полный список задолженностей и отключить флаг «еще». 

### Testing
- Попытка запустить сборку `./gradlew :app:compileDebugKotlin` была выполнена, но сборка не завершилась из‑за невозможности скачать Gradle (HTTP 403 через прокси), поэтому автоматические проверки не прошли.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6995934521588320aa7a37c0d4f92169)