### PR TITLE
Add initial Tutorly welcome screen

### DIFF
--- a/app/src/main/java/com/tutorly/MainActivity.kt
+++ b/app/src/main/java/com/tutorly/MainActivity.kt
@@ -3,13 +3,19 @@ package com.tutorly
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.tutorly.navigation.AppNavRoot
 import com.tutorly.ui.UserProfileViewModel
+import com.tutorly.ui.screens.WelcomeScreen
 import com.tutorly.ui.theme.AppTheme
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.delay
 
 
 @AndroidEntryPoint // ✅ подключает Hilt к Activity (чтобы внутри Compose работали hiltViewModel() и т.д.)
@@ -20,8 +26,19 @@ class MainActivity : ComponentActivity() {
         setContent {
             val profileViewModel: UserProfileViewModel = hiltViewModel()
             val profileState by profileViewModel.profile.collectAsStateWithLifecycle()
+            var showWelcome by remember { mutableStateOf(true) }
+
+            LaunchedEffect(Unit) {
+                delay(1800)
+                showWelcome = false
+            }
+
             AppTheme(preset = profileState.theme) {
-                AppNavRoot()
+                if (showWelcome) {
+                    WelcomeScreen()
+                } else {
+                    AppNavRoot()
+                }
             }
         }
     }

--- a/app/src/main/java/com/tutorly/ui/screens/WelcomeScreen.kt
+++ b/app/src/main/java/com/tutorly/ui/screens/WelcomeScreen.kt
@@ -1,28 +1,35 @@
 package com.tutorly.ui.screens
 
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Lightbulb
+import androidx.compose.material.icons.filled.MenuBook
+import androidx.compose.material.icons.filled.School
+import androidx.compose.material.icons.filled.Star
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import com.tutorly.R
 
 @Composable
 fun WelcomeScreen(modifier: Modifier = Modifier) {
@@ -31,43 +38,106 @@ fun WelcomeScreen(modifier: Modifier = Modifier) {
             .fillMaxSize()
             .background(
                 brush = Brush.verticalGradient(
-                    colors = listOf(Color(0xFF4B9E87), Color(0xFF2E746A))
+                    colors = listOf(
+                        Color(0xFF59B88B),
+                        Color(0xFF2C8E74),
+                        Color(0xFF146E64)
+                    )
                 )
             )
-            .padding(horizontal = 24.dp, vertical = 40.dp),
-        contentAlignment = Alignment.Center
+            .padding(horizontal = 24.dp, vertical = 36.dp)
     ) {
         Column(
+            modifier = Modifier.fillMaxSize(),
             horizontalAlignment = Alignment.CenterHorizontally,
             verticalArrangement = Arrangement.Center
         ) {
-            Image(
-                painter = painterResource(id = R.drawable.splash_logo),
-                contentDescription = "Tutorly welcome illustration"
-            )
+            TopEducationBlock()
+            Spacer(modifier = Modifier.height(28.dp))
+            MascotBlock()
             Spacer(modifier = Modifier.height(20.dp))
             Text(
                 text = "Tutorly",
                 color = Color.White,
-                fontSize = 56.sp,
+                fontSize = 68.sp,
                 fontWeight = FontWeight.ExtraBold
             )
-            Spacer(modifier = Modifier.height(6.dp))
-            Text(
-                text = "Learn. Grow. Succeed.",
-                color = Color.White.copy(alpha = 0.92f),
-                fontSize = 26.sp,
-                fontWeight = FontWeight.SemiBold
-            )
-            Spacer(modifier = Modifier.height(32.dp))
-            CircularProgressIndicator(
+            Spacer(modifier = Modifier.height(8.dp))
+            Row(
+                modifier = Modifier.fillMaxWidth(0.86f),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                HorizontalDivider(modifier = Modifier.weight(1f), color = Color.White.copy(alpha = 0.35f))
+                Text(
+                    modifier = Modifier.padding(horizontal = 12.dp),
+                    text = "Learn. Grow. Succeed.",
+                    color = Color.White.copy(alpha = 0.92f),
+                    fontSize = 28.sp,
+                    fontWeight = FontWeight.Bold
+                )
+                HorizontalDivider(modifier = Modifier.weight(1f), color = Color.White.copy(alpha = 0.35f))
+            }
+        }
+    }
+}
+
+@Composable
+private fun TopEducationBlock() {
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(30.dp))
+            .background(Color(0x33FFFFFF))
+            .padding(vertical = 28.dp, horizontal = 22.dp)
+    ) {
+        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(18.dp)
+            ) {
+                Icon(Icons.Default.School, contentDescription = null, tint = Color(0xFF143D56), modifier = Modifier.size(46.dp))
+                Icon(Icons.Default.Lightbulb, contentDescription = null, tint = Color(0xFFFFD24A), modifier = Modifier.size(86.dp))
+                Icon(Icons.Default.MenuBook, contentDescription = null, tint = Color(0xFF13395B), modifier = Modifier.size(46.dp))
+            }
+            Spacer(modifier = Modifier.height(12.dp))
+            Box(
                 modifier = Modifier
-                    .size(30.dp)
-                    .alpha(0.92f),
-                color = Color.White,
-                trackColor = Color.White.copy(alpha = 0.22f),
-                strokeWidth = 3.dp
+                    .fillMaxWidth(0.8f)
+                    .height(26.dp)
+                    .clip(RoundedCornerShape(100))
+                    .background(Color(0x884CA064))
             )
         }
+    }
+}
+
+@Composable
+private fun MascotBlock() {
+    Box(
+        modifier = Modifier
+            .size(190.dp)
+            .clip(CircleShape)
+            .background(Color(0x22FFFFFF)),
+        contentAlignment = Alignment.Center
+    ) {
+        Text(text = "🐱", fontSize = 110.sp)
+        Icon(
+            imageVector = Icons.Default.Star,
+            contentDescription = null,
+            tint = Color(0xFFFFD24A),
+            modifier = Modifier
+                .align(Alignment.TopStart)
+                .padding(start = 22.dp, top = 18.dp)
+                .size(20.dp)
+        )
+        Icon(
+            imageVector = Icons.Default.School,
+            contentDescription = null,
+            tint = Color(0xFF1A3658),
+            modifier = Modifier
+                .align(Alignment.TopCenter)
+                .padding(top = 18.dp)
+                .size(28.dp)
+        )
     }
 }

--- a/app/src/main/java/com/tutorly/ui/screens/WelcomeScreen.kt
+++ b/app/src/main/java/com/tutorly/ui/screens/WelcomeScreen.kt
@@ -1,0 +1,73 @@
+package com.tutorly.ui.screens
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.tutorly.R
+
+@Composable
+fun WelcomeScreen(modifier: Modifier = Modifier) {
+    Box(
+        modifier = modifier
+            .fillMaxSize()
+            .background(
+                brush = Brush.verticalGradient(
+                    colors = listOf(Color(0xFF4B9E87), Color(0xFF2E746A))
+                )
+            )
+            .padding(horizontal = 24.dp, vertical = 40.dp),
+        contentAlignment = Alignment.Center
+    ) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center
+        ) {
+            Image(
+                painter = painterResource(id = R.drawable.splash_logo),
+                contentDescription = "Tutorly welcome illustration"
+            )
+            Spacer(modifier = Modifier.height(20.dp))
+            Text(
+                text = "Tutorly",
+                color = Color.White,
+                fontSize = 56.sp,
+                fontWeight = FontWeight.ExtraBold
+            )
+            Spacer(modifier = Modifier.height(6.dp))
+            Text(
+                text = "Learn. Grow. Succeed.",
+                color = Color.White.copy(alpha = 0.92f),
+                fontSize = 26.sp,
+                fontWeight = FontWeight.SemiBold
+            )
+            Spacer(modifier = Modifier.height(32.dp))
+            CircularProgressIndicator(
+                modifier = Modifier
+                    .size(30.dp)
+                    .alpha(0.92f),
+                color = Color.White,
+                trackColor = Color.White.copy(alpha = 0.22f),
+                strokeWidth = 3.dp
+            )
+        }
+    }
+}


### PR DESCRIPTION
### Motivation

- Provide a branded welcome/splash experience on app launch before entering the main navigation flow. 
- Keep the existing `AppNavRoot` intact and show the welcome UI briefly without changing navigation logic.

### Description

- Added a new Compose screen `WelcomeScreen` at `app/src/main/java/com/tutorly/ui/screens/WelcomeScreen.kt` which renders a vertical gradient, `splash_logo` illustration, app title, tagline and a `CircularProgressIndicator`.
- Updated `MainActivity` to show the welcome screen for a short duration by adding a `showWelcome` state and a `LaunchedEffect` with `delay(1800)`, then conditionally rendering `WelcomeScreen` or `AppNavRoot` inside `AppTheme` (changes in `app/src/main/java/com/tutorly/MainActivity.kt`).
- Updated imports and coroutine usage (`delay`) to support the transient welcome behavior.
- Changes were committed with the message `Add compose welcome screen before app navigation`.

### Testing

- Attempted to run `bash ./gradlew :app:compileDebugKotlin`, but Gradle wrapper failed to download the distribution due to network/proxy restrictions (`HTTP 403 Forbidden`), so local compilation could not be verified.
- Attempted to capture a visual check via Playwright, but the environment had no reachable UI target (`ERR_EMPTY_RESPONSE`), so no screenshot was produced.
- No automated unit/instrumentation tests were added or run in this change set.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699606ab61a4832088be179b2f961452)