### PR TITLE
Вынести дизайн-токены и перейти на них в UI-компонентах

### DIFF
--- a/app/src/main/java/com/tutorly/ui/components/AppBottomBar.kt
+++ b/app/src/main/java/com/tutorly/ui/components/AppBottomBar.kt
@@ -33,6 +33,10 @@ import com.tutorly.navigation.ROUTE_FINANCE
 import com.tutorly.navigation.ROUTE_STUDENTS
 import com.tutorly.navigation.ROUTE_TODAY
 import com.tutorly.ui.theme.SecondaryTextColor
+import com.tutorly.ui.theme.TutorlyColors
+import com.tutorly.ui.theme.TutorlyRadii
+import com.tutorly.ui.theme.TutorlySizing
+import com.tutorly.ui.theme.TutorlySpacing
 
 enum class Tab(val route:String, val label:String, val icon: androidx.compose.ui.graphics.vector.ImageVector){
     Calendar(ROUTE_CALENDAR, "Расписание", Icons.Outlined.CalendarMonth),
@@ -45,15 +49,15 @@ enum class Tab(val route:String, val label:String, val icon: androidx.compose.ui
 fun AppBottomBar(currentRoute: String, onSelect:(String)->Unit) {
     val primaryColor = MaterialTheme.colorScheme.primary
     Surface(
-        color = Color.White,
+        color = TutorlyColors.bottomBarContainer,
         tonalElevation = 0.dp,
         shadowElevation = 8.dp
     ) {
         Row(
             modifier = Modifier
                 .fillMaxWidth()
-                .height(80.dp)
-                .padding(horizontal = 12.dp),
+                .height(TutorlySizing.bottomBarHeight)
+                .padding(horizontal = TutorlySpacing.md),
             horizontalArrangement = Arrangement.SpaceBetween,
             verticalAlignment = Alignment.CenterVertically
         ) {
@@ -64,29 +68,29 @@ fun AppBottomBar(currentRoute: String, onSelect:(String)->Unit) {
                     modifier = Modifier
                         .weight(1f)
                         .fillMaxHeight()
-                        .clip(RoundedCornerShape(16.dp))
+                        .clip(RoundedCornerShape(TutorlyRadii.tabItem))
                         .clickable(
                             interactionSource = interactionSource,
                             indication = null
                         ) { onSelect(tab.route) },
                     horizontalAlignment = Alignment.CenterHorizontally
                 ) {
-                    Spacer(modifier = Modifier.height(3.dp))
+                    Spacer(modifier = Modifier.height(TutorlySpacing.xxs))
                     Box(
                         modifier = Modifier
                             .fillMaxWidth()
-                            .height(3.dp)
-                            .clip(RoundedCornerShape(2.dp))
+                            .height(TutorlySizing.tabIndicatorHeight)
+                            .clip(RoundedCornerShape(TutorlyRadii.tabIndicator))
                             .background(if (selected) primaryColor else Color.Transparent)
                     )
-                    Spacer(modifier = Modifier.height(9.dp))
+                    Spacer(modifier = Modifier.height(TutorlySpacing.sm + 1.dp))
                     Icon(
                         imageVector = tab.icon,
                         contentDescription = tab.label,
                         tint = if (selected) primaryColor else SecondaryTextColor,
-                        modifier = Modifier.size(24.dp)
+                        modifier = Modifier.size(TutorlySizing.navIcon)
                     )
-                    Spacer(modifier = Modifier.height(4.dp))
+                    Spacer(modifier = Modifier.height(TutorlySpacing.xs))
                     Text(
                         text = tab.label,
                         color = if (selected) primaryColor else SecondaryTextColor,

--- a/app/src/main/java/com/tutorly/ui/components/AppBottomBar.kt
+++ b/app/src/main/java/com/tutorly/ui/components/AppBottomBar.kt
@@ -34,9 +34,11 @@ import com.tutorly.navigation.ROUTE_STUDENTS
 import com.tutorly.navigation.ROUTE_TODAY
 import com.tutorly.ui.theme.SecondaryTextColor
 import com.tutorly.ui.theme.TutorlyColors
+import com.tutorly.ui.theme.TutorlyElevation
 import com.tutorly.ui.theme.TutorlyRadii
 import com.tutorly.ui.theme.TutorlySizing
 import com.tutorly.ui.theme.TutorlySpacing
+import com.tutorly.ui.theme.TutorlyComponentSpacing
 
 enum class Tab(val route:String, val label:String, val icon: androidx.compose.ui.graphics.vector.ImageVector){
     Calendar(ROUTE_CALENDAR, "Расписание", Icons.Outlined.CalendarMonth),
@@ -50,8 +52,8 @@ fun AppBottomBar(currentRoute: String, onSelect:(String)->Unit) {
     val primaryColor = MaterialTheme.colorScheme.primary
     Surface(
         color = TutorlyColors.bottomBarContainer,
-        tonalElevation = 0.dp,
-        shadowElevation = 8.dp
+        tonalElevation = TutorlyElevation.bottomBarTonal,
+        shadowElevation = TutorlyElevation.bottomBarShadow
     ) {
         Row(
             modifier = Modifier
@@ -83,7 +85,7 @@ fun AppBottomBar(currentRoute: String, onSelect:(String)->Unit) {
                             .clip(RoundedCornerShape(TutorlyRadii.tabIndicator))
                             .background(if (selected) primaryColor else Color.Transparent)
                     )
-                    Spacer(modifier = Modifier.height(TutorlySpacing.sm + 1.dp))
+                    Spacer(modifier = Modifier.height(TutorlyComponentSpacing.tabIndicatorToIcon))
                     Icon(
                         imageVector = tab.icon,
                         contentDescription = tab.label,

--- a/app/src/main/java/com/tutorly/ui/components/PaymentBadge.kt
+++ b/app/src/main/java/com/tutorly/ui/components/PaymentBadge.kt
@@ -12,6 +12,8 @@ import com.tutorly.ui.theme.DebtChipContent
 import com.tutorly.ui.theme.DebtChipFill
 import com.tutorly.ui.theme.PaidChipContent
 import com.tutorly.ui.theme.TutorlyColors
+import com.tutorly.ui.theme.TutorlyComponentSpacing
+import com.tutorly.ui.theme.TutorlyElevation
 import com.tutorly.ui.theme.TutorlyRadii
 import com.tutorly.ui.theme.TutorlySpacing
 import com.tutorly.ui.theme.TutorlyTypeScale
@@ -44,12 +46,12 @@ fun PaymentBadge(
         color = container,
         contentColor = content,
         shape = RoundedCornerShape(TutorlyRadii.pill),
-        tonalElevation = 1.dp
+        tonalElevation = TutorlyElevation.paymentBadgeTonal
     ) {
         Text(
             txt,
             fontSize = TutorlyTypeScale.badgeText,
-            modifier = Modifier.padding(horizontal = TutorlySpacing.sm + 2.dp, vertical = TutorlySpacing.xs)
+            modifier = Modifier.padding(horizontal = TutorlyComponentSpacing.paymentBadgeHorizontal, vertical = TutorlySpacing.xs)
         )
     }
 }

--- a/app/src/main/java/com/tutorly/ui/components/PaymentBadge.kt
+++ b/app/src/main/java/com/tutorly/ui/components/PaymentBadge.kt
@@ -8,10 +8,13 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import com.tutorly.ui.theme.DebtChipContent
 import com.tutorly.ui.theme.DebtChipFill
 import com.tutorly.ui.theme.PaidChipContent
+import com.tutorly.ui.theme.TutorlyColors
+import com.tutorly.ui.theme.TutorlyRadii
+import com.tutorly.ui.theme.TutorlySpacing
+import com.tutorly.ui.theme.TutorlyTypeScale
 
 enum class PaymentBadgeStatus {
     PAID,
@@ -24,7 +27,7 @@ fun PaymentBadge(
     status: PaymentBadgeStatus,
     modifier: Modifier = Modifier
 ) {
-    val paidColor = Color(0xFF4E998C)
+    val paidColor = TutorlyColors.paymentPaid
     val (txt, container, content) = when (status) {
         PaymentBadgeStatus.PAID -> Triple("Оплачено", paidColor, PaidChipContent)
 
@@ -40,13 +43,13 @@ fun PaymentBadge(
         modifier = modifier,
         color = container,
         contentColor = content,
-        shape = RoundedCornerShape(999.dp),
+        shape = RoundedCornerShape(TutorlyRadii.pill),
         tonalElevation = 1.dp
     ) {
         Text(
             txt,
-            fontSize = 12.sp,
-            modifier = Modifier.padding(horizontal = 10.dp, vertical = 4.dp)
+            fontSize = TutorlyTypeScale.badgeText,
+            modifier = Modifier.padding(horizontal = TutorlySpacing.sm + 2.dp, vertical = TutorlySpacing.xs)
         )
     }
 }

--- a/app/src/main/java/com/tutorly/ui/components/StatusChip.kt
+++ b/app/src/main/java/com/tutorly/ui/components/StatusChip.kt
@@ -22,6 +22,7 @@ import com.tutorly.ui.theme.DebtChipContent
 import com.tutorly.ui.theme.DebtChipFill
 import com.tutorly.ui.theme.PaidChipContent
 import com.tutorly.ui.theme.TutorlyColors
+import com.tutorly.ui.theme.TutorlySizing
 import java.time.ZonedDateTime
 
 /** Visual parameters for the payment status indicator. */
@@ -39,7 +40,7 @@ fun StatusChip(data: StatusChipData, modifier: Modifier = Modifier) {
         contentColor = data.content,
         shape = CircleShape,
         modifier = modifier
-            .defaultMinSize(minWidth = 24.dp, minHeight = 24.dp)
+            .defaultMinSize(minWidth = TutorlySizing.statusChipMinSize, minHeight = TutorlySizing.statusChipMinSize)
             .semantics { contentDescription = data.description }
     ) {
         Box(contentAlignment = Alignment.Center) {

--- a/app/src/main/java/com/tutorly/ui/components/StatusChip.kt
+++ b/app/src/main/java/com/tutorly/ui/components/StatusChip.kt
@@ -21,6 +21,7 @@ import com.tutorly.models.PaymentStatus
 import com.tutorly.ui.theme.DebtChipContent
 import com.tutorly.ui.theme.DebtChipFill
 import com.tutorly.ui.theme.PaidChipContent
+import com.tutorly.ui.theme.TutorlyColors
 import java.time.ZonedDateTime
 
 /** Visual parameters for the payment status indicator. */
@@ -61,7 +62,7 @@ fun statusChipData(
 ): StatusChipData {
     val colorScheme = MaterialTheme.colorScheme
     val cancelledColor = colorScheme.outline
-    val paidColor = Color(0xFF4E998C)
+    val paidColor = TutorlyColors.paymentPaid
 
     fun defaultContentColor(background: Color): Color =
         if (background.luminance() < 0.5f) Color.White else colorScheme.onSurface
@@ -85,7 +86,7 @@ fun statusChipData(
 
         PaymentStatus.DUE, PaymentStatus.UNPAID -> {
             if (isFutureLesson) {
-                val futureUnpaid = Color(0xFF727272)
+                val futureUnpaid = TutorlyColors.futureUnpaid
                 StatusChipData(
                     label = "₽",
                     description = stringResource(R.string.lesson_status_unpaid),

--- a/app/src/main/java/com/tutorly/ui/components/TopBar.kt
+++ b/app/src/main/java/com/tutorly/ui/components/TopBar.kt
@@ -32,6 +32,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.tutorly.R
 import com.tutorly.ui.theme.TutorlyColors
+import com.tutorly.ui.theme.TutorlyElevation
 import com.tutorly.ui.theme.TutorlySizing
 import com.tutorly.ui.theme.extendedColors
 
@@ -102,8 +103,8 @@ fun TopBarContainer(content: @Composable () -> Unit) {
     Surface(
         modifier = Modifier.fillMaxWidth(),
         color = Color.Transparent,
-        shadowElevation = 4.dp,
-        tonalElevation = 0.dp
+        shadowElevation = TutorlyElevation.topBarShadow,
+        tonalElevation = TutorlyElevation.topBarTonal
     ) {
         Box(
             modifier = Modifier.background(

--- a/app/src/main/java/com/tutorly/ui/components/TopBar.kt
+++ b/app/src/main/java/com/tutorly/ui/components/TopBar.kt
@@ -31,6 +31,8 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.tutorly.R
+import com.tutorly.ui.theme.TutorlyColors
+import com.tutorly.ui.theme.TutorlySizing
 import com.tutorly.ui.theme.extendedColors
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -45,7 +47,7 @@ fun AppTopBar(
         TopAppBar(
             modifier = Modifier
                 .fillMaxWidth()
-                .height(80.dp),
+                .height(TutorlySizing.topBarHeight),
             title = {
                 Box(
                     modifier = Modifier
@@ -57,7 +59,7 @@ fun AppTopBar(
                         maxLines = 1,
                         overflow = TextOverflow.Ellipsis,
                         textAlign = TextAlign.Center,
-                        color = Color(0xFFFEFEFE)
+                        color = TutorlyColors.topBarOnGradient
                     )
                 }
             },
@@ -84,9 +86,9 @@ fun AppTopBar(
             colors = TopAppBarDefaults.topAppBarColors(
                 containerColor = Color.Transparent,
                 scrolledContainerColor = Color.Transparent,
-                titleContentColor = Color(0xFFFEFEFE),
-                actionIconContentColor = Color(0xFFFEFEFE),
-                navigationIconContentColor = Color(0xFFFEFEFE)
+                titleContentColor = TutorlyColors.topBarOnGradient,
+                actionIconContentColor = TutorlyColors.topBarOnGradient,
+                navigationIconContentColor = TutorlyColors.topBarOnGradient
             ),
             windowInsets = WindowInsets(0, 0, 0, 0)
         )

--- a/app/src/main/java/com/tutorly/ui/components/TutorlyBottomSheetContainer.kt
+++ b/app/src/main/java/com/tutorly/ui/components/TutorlyBottomSheetContainer.kt
@@ -16,6 +16,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import com.tutorly.ui.theme.TutorlyElevation
 import com.tutorly.ui.theme.TutorlyRadii
 import com.tutorly.ui.theme.TutorlySpacing
 
@@ -28,7 +29,7 @@ import com.tutorly.ui.theme.TutorlySpacing
 fun TutorlyBottomSheetContainer(
     modifier: Modifier = Modifier,
     color: Color = Color.Unspecified,
-    tonalElevation: Dp = 0.dp,
+    tonalElevation: Dp = TutorlyElevation.bottomSheetTonal,
     shape: Shape = RoundedCornerShape(topStart = TutorlyRadii.bottomSheetTop, topEnd = TutorlyRadii.bottomSheetTop),
     dragHandle: @Composable (() -> Unit)? = { BottomSheetDefaults.DragHandle() },
     content: @Composable () -> Unit,

--- a/app/src/main/java/com/tutorly/ui/components/TutorlyBottomSheetContainer.kt
+++ b/app/src/main/java/com/tutorly/ui/components/TutorlyBottomSheetContainer.kt
@@ -16,6 +16,8 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import com.tutorly.ui.theme.TutorlyRadii
+import com.tutorly.ui.theme.TutorlySpacing
 
 /**
  * Wraps bottom-sheet content into a surface with rounded top corners so we can keep
@@ -27,7 +29,7 @@ fun TutorlyBottomSheetContainer(
     modifier: Modifier = Modifier,
     color: Color = Color.Unspecified,
     tonalElevation: Dp = 0.dp,
-    shape: Shape = RoundedCornerShape(topStart = 28.dp, topEnd = 28.dp),
+    shape: Shape = RoundedCornerShape(topStart = TutorlyRadii.bottomSheetTop, topEnd = TutorlyRadii.bottomSheetTop),
     dragHandle: @Composable (() -> Unit)? = { BottomSheetDefaults.DragHandle() },
     content: @Composable () -> Unit,
 ) {
@@ -47,7 +49,7 @@ fun TutorlyBottomSheetContainer(
                 Box(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .padding(top = 12.dp, bottom = 4.dp),
+                        .padding(top = TutorlySpacing.md, bottom = TutorlySpacing.xs),
                     contentAlignment = Alignment.Center
                 ) {
                     dragHandle()

--- a/app/src/main/java/com/tutorly/ui/components/TutorlyDialog.kt
+++ b/app/src/main/java/com/tutorly/ui/components/TutorlyDialog.kt
@@ -16,6 +16,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
+import com.tutorly.ui.theme.TutorlySpacing
 import androidx.compose.ui.window.DialogProperties
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -33,7 +34,7 @@ fun TutorlyDialog(
         Surface(
             modifier = modifier
                 .fillMaxWidth()
-                .padding(horizontal = 16.dp)
+                .padding(horizontal = TutorlySpacing.lg)
                 .widthIn(max = 560.dp),
             shape = AlertDialogDefaults.shape,
             tonalElevation = AlertDialogDefaults.TonalElevation,
@@ -43,12 +44,12 @@ fun TutorlyDialog(
             Box(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(horizontal = 20.dp, vertical = 16.dp)
+                    .padding(horizontal = TutorlySpacing.xl, vertical = TutorlySpacing.lg)
                     .heightIn(max = 600.dp)
             ) {
                 Column(
                     modifier = Modifier.fillMaxWidth(),
-                    verticalArrangement = Arrangement.spacedBy(20.dp),
+                    verticalArrangement = Arrangement.spacedBy(TutorlySpacing.xl),
                     content = content
                 )
             }

--- a/app/src/main/java/com/tutorly/ui/components/TutorlyDialog.kt
+++ b/app/src/main/java/com/tutorly/ui/components/TutorlyDialog.kt
@@ -16,6 +16,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
+import com.tutorly.ui.theme.TutorlySizing
 import com.tutorly.ui.theme.TutorlySpacing
 import androidx.compose.ui.window.DialogProperties
 
@@ -35,7 +36,7 @@ fun TutorlyDialog(
             modifier = modifier
                 .fillMaxWidth()
                 .padding(horizontal = TutorlySpacing.lg)
-                .widthIn(max = 560.dp),
+                .widthIn(max = TutorlySizing.dialogMaxWidth),
             shape = AlertDialogDefaults.shape,
             tonalElevation = AlertDialogDefaults.TonalElevation,
             color = Color.White,
@@ -45,7 +46,7 @@ fun TutorlyDialog(
                 modifier = Modifier
                     .fillMaxWidth()
                     .padding(horizontal = TutorlySpacing.xl, vertical = TutorlySpacing.lg)
-                    .heightIn(max = 600.dp)
+                    .heightIn(max = TutorlySizing.dialogMaxHeight)
             ) {
                 Column(
                     modifier = Modifier.fillMaxWidth(),

--- a/app/src/main/java/com/tutorly/ui/theme/DesignTokens.kt
+++ b/app/src/main/java/com/tutorly/ui/theme/DesignTokens.kt
@@ -1,0 +1,63 @@
+package com.tutorly.ui.theme
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+
+/** Единая точка редактирования отступов. */
+object TutorlySpacing {
+    /** Минимальный вертикальный отступ между микроэлементами (индикаторы, разделители). */
+    val xxs = 3.dp
+    /** Очень маленький отступ между иконкой и подписью/строкой. */
+    val xs = 4.dp
+    /** Малый отступ в плотных группах. */
+    val sm = 8.dp
+    /** Базовый отступ по умолчанию для большинства блоков. */
+    val md = 12.dp
+    /** Средний внешний/внутренний отступ секций. */
+    val lg = 16.dp
+    /** Крупный отступ для карточек/диалогов. */
+    val xl = 20.dp
+}
+
+/** Радиусы скругления UI-элементов. */
+object TutorlyRadii {
+    /** Скругление интерактивного айтема таббара. */
+    val tabItem = 16.dp
+    /** Скругление верхнего активного индикатора в таббаре. */
+    val tabIndicator = 2.dp
+    /** Капсульный chip/badge. */
+    val pill = 999.dp
+    /** Скругление верхних углов bottom-sheet. */
+    val bottomSheetTop = 28.dp
+}
+
+/** Высоты ключевых контейнеров и индикаторов. */
+object TutorlySizing {
+    /** Высота нижнего бара приложения. */
+    val bottomBarHeight = 80.dp
+    /** Высота верхнего бара приложения. */
+    val topBarHeight = 80.dp
+    /** Толщина верхнего индикатора активной вкладки. */
+    val tabIndicatorHeight = 3.dp
+    /** Базовый размер иконки в навигационных компонентах. */
+    val navIcon = 24.dp
+}
+
+/** Явные токены типографики для мелких бейджей/чипов. */
+object TutorlyTypeScale {
+    /** Размер текста внутри бейджа оплаты. */
+    val badgeText = 12.sp
+}
+
+/** Дополнительные цветовые токены для компонентов. */
+object TutorlyColors {
+    /** Фон нижнего бара. */
+    val bottomBarContainer = Color.White
+    /** Светлый текст на цветном фоне top bar. */
+    val topBarOnGradient = Color(0xFFFEFEFE)
+    /** Акцентный цвет успешной оплаты/предоплаты. */
+    val paymentPaid = Color(0xFF4E998C)
+    /** Нейтральный цвет неоплаченного будущего урока. */
+    val futureUnpaid = Color(0xFF727272)
+}

--- a/app/src/main/java/com/tutorly/ui/theme/DesignTokens.kt
+++ b/app/src/main/java/com/tutorly/ui/theme/DesignTokens.kt
@@ -32,7 +32,7 @@ object TutorlyRadii {
     val bottomSheetTop = 28.dp
 }
 
-/** Высоты ключевых контейнеров и индикаторов. */
+/** Высоты/ширины ключевых контейнеров и индикаторов. */
 object TutorlySizing {
     /** Высота нижнего бара приложения. */
     val bottomBarHeight = 80.dp
@@ -42,6 +42,36 @@ object TutorlySizing {
     val tabIndicatorHeight = 3.dp
     /** Базовый размер иконки в навигационных компонентах. */
     val navIcon = 24.dp
+    /** Минимальный размер кружка статуса урока. */
+    val statusChipMinSize = 24.dp
+    /** Максимальная ширина контейнера диалога на больших экранах. */
+    val dialogMaxWidth = 560.dp
+    /** Максимальная высота контента диалога перед скроллом. */
+    val dialogMaxHeight = 600.dp
+}
+
+/** Отдельные токены для локальных паддингов компонентов. */
+object TutorlyComponentSpacing {
+    /** Отступ между верхним индикатором таба и иконкой. */
+    val tabIndicatorToIcon = 9.dp
+    /** Горизонтальный паддинг текста в бейдже оплаты. */
+    val paymentBadgeHorizontal = 10.dp
+}
+
+/** Токены для теней/тональных возвышений. */
+object TutorlyElevation {
+    /** Тень нижней панели навигации. */
+    val bottomBarShadow = 8.dp
+    /** Тональная высота нижней панели навигации. */
+    val bottomBarTonal = 0.dp
+    /** Тень верхнего бара. */
+    val topBarShadow = 4.dp
+    /** Тональная высота верхнего бара. */
+    val topBarTonal = 0.dp
+    /** Тональная высота бейджа оплаты. */
+    val paymentBadgeTonal = 1.dp
+    /** Тональная высота контейнера bottom sheet по умолчанию. */
+    val bottomSheetTonal = 0.dp
 }
 
 /** Явные токены типографики для мелких бейджей/чипов. */

--- a/docs/ui-style-tokens-guide.md
+++ b/docs/ui-style-tokens-guide.md
@@ -1,0 +1,60 @@
+# UI Style Tokens Guide
+
+Этот документ описывает, как менять стили элементов через токены в `app/src/main/java/com/tutorly/ui/theme/DesignTokens.kt`.
+
+## Общие правила
+- Не меняйте размеры/позиционирование напрямую в компонентах.
+- Для отступов используйте `TutorlySpacing`.
+- Для радиусов используйте `TutorlyRadii`.
+- Для размеров (высоты/ширины/минимальные размеры) используйте `TutorlySizing`.
+- Для локальных интервалов конкретных компонентов используйте `TutorlyComponentSpacing`.
+- Для теней/тональных возвышений используйте `TutorlyElevation`.
+- Для мелкой типографики используйте `TutorlyTypeScale`.
+- Для служебных цветов компонентов используйте `TutorlyColors`.
+
+## Как менять стили по элементам
+
+### AppBottomBar
+Файл: `ui/components/AppBottomBar.kt`
+- Высота бара: `TutorlySizing.bottomBarHeight`.
+- Горизонтальный внутренний отступ: `TutorlySpacing.md`.
+- Скругление кнопки вкладки: `TutorlyRadii.tabItem`.
+- Толщина/скругление верхнего индикатора активной вкладки: `TutorlySizing.tabIndicatorHeight`, `TutorlyRadii.tabIndicator`.
+- Расстояние от индикатора до иконки: `TutorlyComponentSpacing.tabIndicatorToIcon`.
+- Размер иконки вкладки: `TutorlySizing.navIcon`.
+- Цвет фона бара: `TutorlyColors.bottomBarContainer`.
+- Тень/тональность: `TutorlyElevation.bottomBarShadow`, `TutorlyElevation.bottomBarTonal`.
+
+### TopBar
+Файл: `ui/components/TopBar.kt`
+- Высота бара: `TutorlySizing.topBarHeight`.
+- Цвет текста и иконок на градиенте: `TutorlyColors.topBarOnGradient`.
+- Тень/тональность контейнера: `TutorlyElevation.topBarShadow`, `TutorlyElevation.topBarTonal`.
+
+### PaymentBadge
+Файл: `ui/components/PaymentBadge.kt`
+- Радиус капсулы: `TutorlyRadii.pill`.
+- Размер текста: `TutorlyTypeScale.badgeText`.
+- Горизонтальный паддинг: `TutorlyComponentSpacing.paymentBadgeHorizontal`.
+- Вертикальный паддинг: `TutorlySpacing.xs`.
+- Цвет успешной оплаты/предоплаты: `TutorlyColors.paymentPaid`.
+- Тональность: `TutorlyElevation.paymentBadgeTonal`.
+
+### StatusChip
+Файл: `ui/components/StatusChip.kt`
+- Минимальный размер чипа: `TutorlySizing.statusChipMinSize`.
+- Цвет paid: `TutorlyColors.paymentPaid`.
+- Цвет future unpaid: `TutorlyColors.futureUnpaid`.
+
+### TutorlyBottomSheetContainer
+Файл: `ui/components/TutorlyBottomSheetContainer.kt`
+- Скругление верхних углов: `TutorlyRadii.bottomSheetTop`.
+- Отступы области drag handle: `TutorlySpacing.md`, `TutorlySpacing.xs`.
+- Тональная высота по умолчанию: `TutorlyElevation.bottomSheetTonal`.
+
+### TutorlyDialog
+Файл: `ui/components/TutorlyDialog.kt`
+- Горизонтальный внешний отступ диалога: `TutorlySpacing.lg`.
+- Внутренние отступы контента: `TutorlySpacing.xl`, `TutorlySpacing.lg`.
+- Расстояние между блоками контента: `TutorlySpacing.xl`.
+- Максимальная ширина/высота: `TutorlySizing.dialogMaxWidth`, `TutorlySizing.dialogMaxHeight`.


### PR DESCRIPTION
### Motivation
- Централизовать все отступы, радиусы, размеры, цвета и мелкие типографические токены чтобы убрать «магические числа» в компонентах и упростить правки интерфейса. 
- Добавить комментарии к каждому токену, чтобы было ясно, за что отвечает каждая переменная и где её изменить.

### Description
- Добавлен файл `app/src/main/java/com/tutorly/ui/theme/DesignTokens.kt` с объектами `TutorlySpacing`, `TutorlyRadii`, `TutorlySizing`, `TutorlyTypeScale` и `TutorlyColors` и краткими комментариями для каждого токена. 
- Компоненты `AppBottomBar`, `TopBar`, `PaymentBadge`, `StatusChip`, `TutorlyBottomSheetContainer` и `TutorlyDialog` заменены на использование токенов вместо хардкода (фон нижнего бара, высота `bottomBar`/`topBar`, горизонтальные отступы, радиусы элементов, высота индикатора вкладки, размер иконок, размеры и паддинги для бейджей, цвета состояний оплаты и т.п.).
- Обновлены импорты и формы вызова (`RoundedCornerShape`, paddings и т.д.) для привязки к токенам, при этом оставлена интеграция с `MaterialTheme` для цветовой схемы там, где это уместно.
- В токенах добавлены поясняющие комментарии — каждый параметр снабжён описанием его роли в UI.

### Testing
- Попытка выполнить `./gradlew :app:compileDebugKotlin` не удалась из-за сетевых/прокси ограничений при скачивании Gradle (ошибка `HTTP/1.1 403 Forbidden`).
- Локальный коммит изменений выполнен успешно (`git` зафиксировал изменения).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0772cd69708320a7a6d1d49b0ce7b0)