### PR TITLE
refactor(ui): migrate Today/Finance/Onboarding screens to design tokens

### DIFF
--- a/app/src/main/java/com/tutorly/ui/screens/FinanceScreen.kt
+++ b/app/src/main/java/com/tutorly/ui/screens/FinanceScreen.kt
@@ -63,6 +63,7 @@ import com.tutorly.ui.components.TopBarContainer
 import com.tutorly.ui.theme.MetricTileColors
 import com.tutorly.ui.theme.TutorlyCardDefaults
 import com.tutorly.ui.theme.extendedColors
+import com.tutorly.ui.theme.TutorlyScreenTokens
 import java.text.NumberFormat
 import java.time.format.DateTimeFormatter
 import java.time.format.TextStyle
@@ -80,13 +81,13 @@ fun FinanceTopBar(
         Column(
             modifier = modifier
                 .fillMaxWidth()
-                .padding(horizontal = 16.dp, vertical = 12.dp),
+                .padding(horizontal = TutorlyScreenTokens.screenHorizontal, vertical = TutorlyScreenTokens.tabHeaderVertical),
             verticalArrangement = Arrangement.spacedBy(12.dp)
         ) {
             Box(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .height(68.dp)
+                    .height(TutorlyScreenTokens.tabTitleHeight)
             ) {
                 Text(
                     text = stringResource(id = R.string.finance_title),
@@ -97,7 +98,7 @@ fun FinanceTopBar(
                     textAlign = TextAlign.Center,
                     modifier = Modifier
                         .align(Alignment.Center)
-                        .padding(horizontal = 96.dp)
+                        .padding(horizontal = TutorlyScreenTokens.tabTitleHorizontalInset)
                 )
             }
 
@@ -138,7 +139,7 @@ private fun FinancePeriodToggle(
                     Box(
                         modifier = Modifier
                             .tabIndicatorOffset(position)
-                            .padding(horizontal = 38.dp)
+                            .padding(horizontal = TutorlyScreenTokens.tabIndicatorHorizontalInset)
                             .height(3.dp)
                             .clip(RoundedCornerShape(topStart = 3.dp, topEnd = 3.dp))
                             .background(accent)
@@ -324,8 +325,8 @@ private fun FinanceContent(
             .background(MaterialTheme.colorScheme.background)
             .then(swipeModifier)
             .verticalScroll(scrollState)
-            .padding(horizontal = 16.dp, vertical = 24.dp),
-        verticalArrangement = Arrangement.spacedBy(16.dp)
+            .padding(horizontal = TutorlyScreenTokens.screenHorizontal, vertical = TutorlyScreenTokens.screenVertical),
+        verticalArrangement = Arrangement.spacedBy(TutorlyScreenTokens.sectionGap)
     ) {
         Text(
             text = periodRange,
@@ -519,8 +520,8 @@ private fun FinanceChartCard(
         Column(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(horizontal = 20.dp, vertical = 20.dp),
-            verticalArrangement = Arrangement.spacedBy(16.dp)
+                .padding(horizontal = TutorlyScreenTokens.cardHorizontal, vertical = TutorlyScreenTokens.cardHorizontal),
+            verticalArrangement = Arrangement.spacedBy(TutorlyScreenTokens.sectionGap)
         ) {
             Text(
                 text = stringResource(R.string.finance_chart_title),
@@ -648,8 +649,8 @@ private fun FinanceDebtorsSection(
         Column(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(horizontal = 20.dp, vertical = 20.dp),
-            verticalArrangement = Arrangement.spacedBy(16.dp)
+                .padding(horizontal = TutorlyScreenTokens.cardHorizontal, vertical = TutorlyScreenTokens.cardHorizontal),
+            verticalArrangement = Arrangement.spacedBy(TutorlyScreenTokens.sectionGap)
         ) {
             Text(
                 text = stringResource(R.string.finance_debtors_title),

--- a/app/src/main/java/com/tutorly/ui/screens/OnboardingDialog.kt
+++ b/app/src/main/java/com/tutorly/ui/screens/OnboardingDialog.kt
@@ -37,6 +37,8 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import com.tutorly.ui.theme.TutorlyScreenTokens
+import com.tutorly.ui.theme.TutorlySpacing
 import androidx.core.content.ContextCompat
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -63,10 +65,10 @@ fun OnboardingDialog(
         Column(
             modifier = Modifier
                 .fillMaxSize()
-                .padding(horizontal = 20.dp, vertical = 24.dp),
+                .padding(horizontal = TutorlyScreenTokens.cardHorizontal, vertical = TutorlyScreenTokens.screenVertical),
             verticalArrangement = Arrangement.SpaceBetween
         ) {
-            Column(verticalArrangement = Arrangement.spacedBy(16.dp)) {
+            Column(verticalArrangement = Arrangement.spacedBy(TutorlyScreenTokens.sectionGap)) {
                 Text(
                     text = "Добро пожаловать в Tutorly",
                     style = MaterialTheme.typography.headlineSmall,
@@ -85,7 +87,7 @@ fun OnboardingDialog(
                 }
             }
 
-            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+            Column(verticalArrangement = Arrangement.spacedBy(TutorlySpacing.sm)) {
                 when (state.step) {
                     1 -> {
                         Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
@@ -160,11 +162,11 @@ private fun StepSubjects(
     state: OnboardingUiState,
     viewModel: OnboardingViewModel
 ) {
-    Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+    Column(verticalArrangement = Arrangement.spacedBy(TutorlySpacing.md)) {
         Text("Выберите основные предметы:")
         FlowRow(
-            horizontalArrangement = Arrangement.spacedBy(8.dp),
-            verticalArrangement = Arrangement.spacedBy(8.dp)
+            horizontalArrangement = Arrangement.spacedBy(TutorlySpacing.sm),
+            verticalArrangement = Arrangement.spacedBy(TutorlySpacing.sm)
         ) {
             state.suggestedSubjects.forEach { subject ->
                 val selected = state.selectedSubjects.contains(subject)
@@ -192,7 +194,7 @@ private fun StepSubjects(
         }
 
         Row(
-            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            horizontalArrangement = Arrangement.spacedBy(TutorlySpacing.sm),
             verticalAlignment = Alignment.CenterVertically,
             modifier = Modifier.fillMaxWidth()
         ) {
@@ -217,11 +219,11 @@ private fun StepRate(
     state: OnboardingUiState,
     viewModel: OnboardingViewModel
 ) {
-    Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+    Column(verticalArrangement = Arrangement.spacedBy(TutorlySpacing.md)) {
         Text("Выберите ставку за час:")
         FlowRow(
-            horizontalArrangement = Arrangement.spacedBy(8.dp),
-            verticalArrangement = Arrangement.spacedBy(8.dp)
+            horizontalArrangement = Arrangement.spacedBy(TutorlySpacing.sm),
+            verticalArrangement = Arrangement.spacedBy(TutorlySpacing.sm)
         ) {
             state.recommendedRatesRubles.forEach { rate ->
                 val selected = state.selectedRateRubles == rate
@@ -251,7 +253,7 @@ private fun StepRate(
         Text(text = "Ставка: ₽${state.selectedRateRubles}/ч")
 
         Row(
-            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            horizontalArrangement = Arrangement.spacedBy(TutorlySpacing.sm),
             verticalAlignment = Alignment.CenterVertically,
             modifier = Modifier.fillMaxWidth()
         ) {
@@ -273,7 +275,7 @@ private fun StepRate(
 
 @Composable
 private fun StepImport(state: OnboardingUiState) {
-    Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+    Column(verticalArrangement = Arrangement.spacedBy(TutorlySpacing.md)) {
         Text(
             text = "Импортировать занятия из Google Календаря?",
             style = MaterialTheme.typography.titleMedium
@@ -313,7 +315,7 @@ private fun OnboardingImportCandidatesDialog(
                     .fillMaxWidth()
                     .heightIn(max = 360.dp)
                     .verticalScroll(rememberScrollState()),
-                verticalArrangement = Arrangement.spacedBy(12.dp)
+                verticalArrangement = Arrangement.spacedBy(TutorlySpacing.md)
             ) {
                 if (candidates.isEmpty()) {
                     Text(

--- a/app/src/main/java/com/tutorly/ui/screens/TodayScreen.kt
+++ b/app/src/main/java/com/tutorly/ui/screens/TodayScreen.kt
@@ -93,6 +93,7 @@ import com.tutorly.ui.theme.DebtChipFill
 import com.tutorly.ui.theme.PaidChipContent
 import com.tutorly.ui.theme.extendedColors
 import com.tutorly.ui.theme.TutorlyCardDefaults
+import com.tutorly.ui.theme.TutorlyScreenTokens
 import java.text.NumberFormat
 import java.time.ZoneId
 import java.time.ZonedDateTime
@@ -256,8 +257,8 @@ private fun EmptyState(
 ) {
     LazyColumn(
         modifier = Modifier.fillMaxSize(),
-        contentPadding = PaddingValues(horizontal = 16.dp, vertical = 24.dp),
-        verticalArrangement = Arrangement.spacedBy(16.dp)
+        contentPadding = PaddingValues(horizontal = TutorlyScreenTokens.screenHorizontal, vertical = TutorlyScreenTokens.screenVertical),
+        verticalArrangement = Arrangement.spacedBy(TutorlyScreenTokens.sectionGap)
     ) {
         item(key = "empty_state_header") {
             Card(
@@ -269,7 +270,7 @@ private fun EmptyState(
                 Column(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .padding(horizontal = 20.dp, vertical = 24.dp),
+                        .padding(horizontal = TutorlyScreenTokens.cardHorizontal, vertical = TutorlyScreenTokens.cardVertical),
                     horizontalAlignment = Alignment.CenterHorizontally,
                 ) {
                     Image(
@@ -328,7 +329,7 @@ private fun DayInProgressContent(
     LazyColumn(
         modifier = Modifier.fillMaxSize(),
         state = listState,
-        contentPadding = PaddingValues(horizontal = 16.dp, vertical = 24.dp),
+        contentPadding = PaddingValues(horizontal = TutorlyScreenTokens.screenHorizontal, vertical = TutorlyScreenTokens.screenVertical),
         verticalArrangement = Arrangement.spacedBy(12.dp)
     ) {
         if (showProgressSummary) {
@@ -411,8 +412,8 @@ private fun ReviewPendingContent(
 ) {
     LazyColumn(
         modifier = Modifier.fillMaxSize(),
-        contentPadding = PaddingValues(horizontal = 16.dp, vertical = 24.dp),
-        verticalArrangement = Arrangement.spacedBy(16.dp)
+        contentPadding = PaddingValues(horizontal = TutorlyScreenTokens.screenHorizontal, vertical = TutorlyScreenTokens.screenVertical),
+        verticalArrangement = Arrangement.spacedBy(TutorlyScreenTokens.sectionGap)
     ) {
         item(key = "review_summary") {
             ReviewSummaryCard(
@@ -486,7 +487,7 @@ private fun ReviewSummaryCard(
                     .fillMaxWidth()
                     .padding(horizontal = 20.dp, vertical = 18.dp),
                 horizontalAlignment = Alignment.CenterHorizontally,
-                verticalArrangement = Arrangement.spacedBy(16.dp)
+                verticalArrangement = Arrangement.spacedBy(TutorlyScreenTokens.sectionGap)
             ) {
                 Image(
                     painter = painterResource(id = R.drawable.undraw_to_do_list_o3jf),
@@ -598,7 +599,7 @@ private fun ReviewEmptyMarkedCard() {
         Box(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(horizontal = 20.dp, vertical = 24.dp),
+                .padding(horizontal = TutorlyScreenTokens.cardHorizontal, vertical = TutorlyScreenTokens.cardVertical),
             contentAlignment = Alignment.Center
         ) {
             Text(
@@ -641,7 +642,7 @@ private fun DayProgressSummary(
                 .fillMaxWidth()
                 .padding(horizontal = 20.dp, vertical = 18.dp),
             horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = Arrangement.spacedBy(16.dp)
+            verticalArrangement = Arrangement.spacedBy(TutorlyScreenTokens.sectionGap)
         )  {
             Image(
                 painter = painterResource(id = R.drawable.focused),
@@ -798,8 +799,8 @@ private fun DayClosedContent(
     val currencyFormatter = rememberCurrencyFormatter()
     LazyColumn(
         modifier = Modifier.fillMaxSize(),
-        contentPadding = PaddingValues(horizontal = 16.dp, vertical = 24.dp),
-        verticalArrangement = Arrangement.spacedBy(16.dp)
+        contentPadding = PaddingValues(horizontal = TutorlyScreenTokens.screenHorizontal, vertical = TutorlyScreenTokens.screenVertical),
+        verticalArrangement = Arrangement.spacedBy(TutorlyScreenTokens.sectionGap)
     ) {
         item(key = "summary") {
             DayClosedSummary(

--- a/app/src/main/java/com/tutorly/ui/theme/DesignTokens.kt
+++ b/app/src/main/java/com/tutorly/ui/theme/DesignTokens.kt
@@ -91,3 +91,18 @@ object TutorlyColors {
     /** Нейтральный цвет неоплаченного будущего урока. */
     val futureUnpaid = Color(0xFF727272)
 }
+
+
+/** Токены экранов (Today/Finance/Onboarding) для унификации паддингов и размеров. */
+object TutorlyScreenTokens {
+    val screenHorizontal = TutorlySpacing.lg
+    val screenVertical = 24.dp
+    val sectionGap = TutorlySpacing.lg
+    val cardHorizontal = TutorlySpacing.xl
+    val cardVertical = 24.dp
+    val buttonRowGap = TutorlySpacing.sm
+    val tabHeaderVertical = TutorlySpacing.md
+    val tabTitleHeight = 68.dp
+    val tabTitleHorizontalInset = 96.dp
+    val tabIndicatorHorizontalInset = 38.dp
+}


### PR DESCRIPTION
### Motivation
- Централизовать горизонтальные/вертикальные паддинги, интервалы и ключевые размеры экранов чтобы избежать расхождений и упростить поддержку UI.
- Уменьшить количество хардкодных `dp` в экранах `Today`, `Finance` и `Onboarding` и сделать их зависимыми от единого набора токенов.

### Description
- Добавлен новый объект токенов `TutorlyScreenTokens` в `app/src/main/java/com/tutorly/ui/theme/DesignTokens.kt` с набором экранных значений (`screenHorizontal`, `screenVertical`, `sectionGap`, `cardHorizontal`, `cardVertical`, `tabTitleHeight`, `tabIndicatorHorizontalInset` и др.).
- В `TodayScreen.kt` заменены хардкодные `PaddingValues`, `spacedBy` и некоторые внутренние паддинги карточек на соответствующие токены из `TutorlyScreenTokens`.
- В `FinanceScreen.kt` переведены отступы/высота заголовка и отступ индикатора вкладок на `TutorlyScreenTokens`, а также контентные паддинги и карточечные паддинги заменены на токены.
- В `OnboardingDialog.kt` заменены внешние паддинги и вертикальные интервалы на `TutorlyScreenTokens` и `TutorlySpacing` и добавлены нужные импорты.

### Testing
- Попытка запустить Kotlin-компиляцию с `./gradlew :app:compileDebugKotlin` завершилась неудачей, так как скачивание Gradle-дистрибутива было заблокировано прокси (`HTTP/1.1 403 Forbidden`).
- Других автоматических тестов в среде не запускалось.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a085303aa74832080a2fabe9d9436f4)