### PR TITLE
Add foundational Tutorly component library components

### DIFF
--- a/app/src/main/java/com/tutorly/ui/components/ComponentLibrary.kt
+++ b/app/src/main/java/com/tutorly/ui/components/ComponentLibrary.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -29,10 +30,12 @@ import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
@@ -259,11 +262,11 @@ fun ScheduleLessonCard(
                 modifier = Modifier
                     .fillMaxWidth()
                     .padding(start = 10.dp, end = 12.dp, top = 8.dp, bottom = 8.dp),
-                verticalAlignment = Alignment.CenterVertically
+                verticalAlignment = Alignment.CenterVertically,
             ) {
-                Column(modifier = Modifier.weight(1f)) {
-                    Text(studentName, style = MaterialTheme.typography.titleSmall, maxLines = 1, overflow = TextOverflow.Ellipsis)
-                    Text(subtitle ?: "", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant, maxLines = 1, overflow = TextOverflow.Ellipsis)
+                Column(modifier = Modifier.weight(2f)) {
+                    Text(studentName, style = MaterialTheme.typography.titleMedium, maxLines = 1, overflow = TextOverflow.Ellipsis)
+                    Text(subtitle ?: "", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant, maxLines = 1, overflow = TextOverflow.Visible)
                 }
                 Spacer(Modifier.width(10.dp))
                 Column(horizontalAlignment = Alignment.End, verticalArrangement = Arrangement.spacedBy(6.dp)) {
@@ -290,13 +293,13 @@ fun ScheduleLessonCard(
                     .align(Alignment.CenterStart)
                     .matchParentSize()
             ) {
-                Box(
-                    modifier = Modifier
-                        .fillMaxHeight()
-                        .width(stripeWidth)
-                        .clip(RoundedCornerShape(topStart = 12.dp, bottomStart = 12.dp))
-                        .background(statusStripeColor)
-                )
+//                Box(
+//                    modifier = Modifier
+//                        .fillMaxHeight()
+//                        .width(stripeWidth)
+//                        .clip(RoundedCornerShape(topStart = 12.dp, bottomStart = 12.dp))
+//                        .background(statusStripeColor)
+//                )
             }
         }
     }

--- a/app/src/main/java/com/tutorly/ui/components/ComponentLibrary.kt
+++ b/app/src/main/java/com/tutorly/ui/components/ComponentLibrary.kt
@@ -1,0 +1,222 @@
+package com.tutorly.ui.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Star
+import androidx.compose.material3.AssistChip
+import androidx.compose.material3.AssistChipDefaults
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.ElevatedCard
+import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import com.tutorly.ui.theme.TutorlyColors
+import com.tutorly.ui.theme.TutorlyElevation
+import com.tutorly.ui.theme.TutorlyRadii
+import com.tutorly.ui.theme.TutorlySpacing
+
+@Composable
+fun TutorlyButton(
+    text: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true
+) {
+    androidx.compose.material3.Button(onClick = onClick, modifier = modifier, enabled = enabled) { Text(text) }
+}
+
+@Composable
+fun TutorlyCard(modifier: Modifier = Modifier, content: @Composable () -> Unit) {
+    ElevatedCard(
+        modifier = modifier,
+        shape = RoundedCornerShape(TutorlyRadii.card),
+        colors = CardDefaults.elevatedCardColors(containerColor = MaterialTheme.colorScheme.surface),
+        elevation = CardDefaults.elevatedCardElevation(defaultElevation = TutorlyElevation.cardSoft)
+    ) { Box(Modifier.padding(TutorlySpacing.lg)) { content() } }
+}
+
+@Composable
+fun LessonCard(title: String, subtitle: String, modifier: Modifier = Modifier, trailing: @Composable (() -> Unit)? = null) {
+    TutorlyCard(modifier.fillMaxWidth()) {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Column(Modifier.weight(1f)) {
+                Text(title, style = MaterialTheme.typography.titleMedium, maxLines = 1, overflow = TextOverflow.Ellipsis)
+                Text(subtitle, style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
+            }
+            trailing?.invoke()
+        }
+    }
+}
+
+@Composable
+fun StudentCard(name: String, details: String, modifier: Modifier = Modifier, avatarText: String = name.take(1)) {
+    TutorlyCard(modifier.fillMaxWidth()) {
+        Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(TutorlySpacing.md)) {
+            Avatar(label = avatarText)
+            Column {
+                Text(name, style = MaterialTheme.typography.titleMedium)
+                Text(details, style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
+            }
+        }
+    }
+}
+
+@Composable
+fun EarningsCard(title: String, amount: String, modifier: Modifier = Modifier) {
+    Card(
+        modifier = modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(TutorlyRadii.cardLarge),
+        colors = CardDefaults.cardColors(containerColor = TutorlyColors.softContainer)
+    ) {
+        Column(Modifier.padding(TutorlySpacing.lg)) {
+            Text(title, style = MaterialTheme.typography.bodyMedium, color = TutorlyColors.textSecondary)
+            Spacer(Modifier.width(2.dp))
+            Text(amount, style = MaterialTheme.typography.headlineSmall, fontWeight = FontWeight.Bold, color = TutorlyColors.contentColor)
+        }
+    }
+}
+
+@Composable
+fun EmptyState(title: String, description: String, modifier: Modifier = Modifier, action: (@Composable () -> Unit)? = null) {
+    Column(
+        modifier = modifier.fillMaxWidth().padding(TutorlySpacing.xl),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(TutorlySpacing.sm)
+    ) {
+        Text(title, style = MaterialTheme.typography.titleLarge)
+        Text(description, style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
+        action?.invoke()
+    }
+}
+
+@Composable
+fun FAB(onClick: () -> Unit, icon: ImageVector, contentDescription: String, modifier: Modifier = Modifier) {
+    FloatingActionButton(onClick = onClick, modifier = modifier, containerColor = MaterialTheme.colorScheme.primary) {
+        Icon(icon, contentDescription = contentDescription, tint = MaterialTheme.colorScheme.onPrimary)
+    }
+}
+
+@Composable
+fun FilterChip(label: String, selected: Boolean, onSelectedChange: (Boolean) -> Unit, modifier: Modifier = Modifier) {
+    AssistChip(
+        onClick = { onSelectedChange(!selected) },
+        label = { Text(label) },
+        modifier = modifier,
+        colors = AssistChipDefaults.assistChipColors(
+            containerColor = if (selected) MaterialTheme.colorScheme.secondaryContainer else MaterialTheme.colorScheme.surface,
+            labelColor = if (selected) MaterialTheme.colorScheme.onSecondaryContainer else MaterialTheme.colorScheme.onSurface
+        ),
+        border = AssistChipDefaults.assistChipBorder(borderColor = if (selected) Color.Transparent else MaterialTheme.colorScheme.outlineVariant)
+    )
+}
+
+@Composable
+fun FilterChipGroup(
+    options: List<String>,
+    selectedOptions: Set<String>,
+    onSelectionChange: (Set<String>) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    LazyRow(modifier = modifier, horizontalArrangement = Arrangement.spacedBy(TutorlySpacing.sm)) {
+        items(options) { option ->
+            FilterChip(label = option, selected = selectedOptions.contains(option)) { isSelected ->
+                val next = selectedOptions.toMutableSet()
+                if (isSelected) next.add(option) else next.remove(option)
+                onSelectionChange(next)
+            }
+        }
+    }
+}
+
+@Composable
+fun PremiumBanner(title: String, subtitle: String, modifier: Modifier = Modifier, onClick: () -> Unit = {}) {
+    Card(
+        modifier = modifier.fillMaxWidth().clickable(onClick = onClick),
+        shape = RoundedCornerShape(TutorlyRadii.cardLarge)
+    ) {
+        Box(
+            Modifier.background(
+                Brush.horizontalGradient(listOf(TutorlyColors.premiumGradientStart, TutorlyColors.premiumGradientEnd))
+            ).padding(TutorlySpacing.lg)
+        ) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Column(Modifier.weight(1f)) {
+                    Text(title, style = MaterialTheme.typography.titleMedium, color = Color.White)
+                    Text(subtitle, style = MaterialTheme.typography.bodyMedium, color = Color.White.copy(alpha = 0.9f))
+                }
+                Icon(Icons.Default.Star, contentDescription = null, tint = Color.White)
+            }
+        }
+    }
+}
+
+@Composable
+fun Avatar(label: String, modifier: Modifier = Modifier, background: Color = TutorlyColors.textPrimary, content: Color = Color.White) {
+    Box(
+        modifier = modifier
+            .size(40.dp)
+            .background(background, CircleShape),
+        contentAlignment = Alignment.Center
+    ) { Text(label, color = content, style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.SemiBold) }
+}
+
+@Composable
+fun MenuItem(title: String, modifier: Modifier = Modifier, subtitle: String? = null, leading: (@Composable () -> Unit)? = null, onClick: () -> Unit = {}) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick)
+            .padding(horizontal = TutorlySpacing.lg, vertical = TutorlySpacing.md),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(TutorlySpacing.md)
+    ) {
+        leading?.invoke()
+        Column(Modifier.weight(1f)) {
+            Text(title, style = MaterialTheme.typography.bodyLarge)
+            if (subtitle != null) Text(subtitle, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+        }
+    }
+}
+
+@Composable
+fun SearchField(
+    value: String,
+    onValueChange: (String) -> Unit,
+    modifier: Modifier = Modifier,
+    placeholder: String = "Поиск"
+) {
+    OutlinedTextField(
+        value = value,
+        onValueChange = onValueChange,
+        placeholder = { Text(placeholder) },
+        modifier = modifier.fillMaxWidth(),
+        singleLine = true,
+        shape = RoundedCornerShape(TutorlyRadii.segmented)
+    )
+}

--- a/app/src/main/java/com/tutorly/ui/components/ComponentLibrary.kt
+++ b/app/src/main/java/com/tutorly/ui/components/ComponentLibrary.kt
@@ -145,11 +145,15 @@ fun FilterChipGroup(
 ) {
     LazyRow(modifier = modifier, horizontalArrangement = Arrangement.spacedBy(TutorlySpacing.sm)) {
         items(options) { option ->
-            FilterChip(label = option, selected = selectedOptions.contains(option)) { isSelected ->
+            FilterChip(
+                label = option,
+                selected = selectedOptions.contains(option),
+                onSelectedChange = { isSelected ->
                 val next = selectedOptions.toMutableSet()
                 if (isSelected) next.add(option) else next.remove(option)
-                onSelectionChange(next)
-            }
+                    onSelectionChange(next)
+                }
+            )
         }
     }
 }

--- a/app/src/main/java/com/tutorly/ui/components/ComponentLibrary.kt
+++ b/app/src/main/java/com/tutorly/ui/components/ComponentLibrary.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -245,7 +246,7 @@ fun ScheduleLessonCard(
     enabled: Boolean = true,
     stripeWidth: Dp = 4.dp
 ) {
-    val content: @Composable () -> Unit = {
+    val content: @Composable ColumnScope.() -> Unit = {
         Box(Modifier.fillMaxWidth()) {
             Row(
                 modifier = Modifier

--- a/app/src/main/java/com/tutorly/ui/components/ComponentLibrary.kt
+++ b/app/src/main/java/com/tutorly/ui/components/ComponentLibrary.kt
@@ -241,7 +241,14 @@ fun ScheduleLessonCard(
     statusStripeColor: Color,
     modifier: Modifier = Modifier,
     shape: RoundedCornerShape = RoundedCornerShape(12.dp),
-    elevation: CardElevation = CardDefaults.cardElevation(defaultElevation = 6.dp),
+    elevation: CardElevation = CardDefaults.cardElevation(
+        defaultElevation = 6.dp,
+        pressedElevation = 6.dp,
+        focusedElevation = 6.dp,
+        hoveredElevation = 6.dp,
+        draggedElevation = 6.dp,
+        disabledElevation = 0.dp
+    ),
     onClick: (() -> Unit)? = null,
     enabled: Boolean = true,
     stripeWidth: Dp = 4.dp

--- a/app/src/main/java/com/tutorly/ui/components/ComponentLibrary.kt
+++ b/app/src/main/java/com/tutorly/ui/components/ComponentLibrary.kt
@@ -22,6 +22,7 @@ import androidx.compose.material3.AssistChip
 import androidx.compose.material3.AssistChipDefaults
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CardElevation
 import androidx.compose.material3.ElevatedCard
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
@@ -36,6 +37,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.tutorly.ui.theme.TutorlyColors
 import com.tutorly.ui.theme.TutorlyElevation
@@ -224,4 +226,90 @@ fun SearchField(
         singleLine = true,
         shape = RoundedCornerShape(TutorlyRadii.segmented)
     )
+}
+
+@Composable
+fun ScheduleLessonCard(
+    studentName: String,
+    subtitle: String?,
+    statusIcon: String,
+    statusLabel: String,
+    badgeContainerColor: Color,
+    badgeContentColor: Color,
+    amountText: String,
+    statusStripeColor: Color,
+    modifier: Modifier = Modifier,
+    shape: RoundedCornerShape = RoundedCornerShape(12.dp),
+    elevation: CardElevation = CardDefaults.cardElevation(defaultElevation = 6.dp),
+    onClick: (() -> Unit)? = null,
+    enabled: Boolean = true,
+    stripeWidth: Dp = 4.dp
+) {
+    val content: @Composable () -> Unit = {
+        Box(Modifier.fillMaxWidth()) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(start = 10.dp, end = 12.dp, top = 8.dp, bottom = 8.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(studentName, style = MaterialTheme.typography.titleSmall, maxLines = 1, overflow = TextOverflow.Ellipsis)
+                    Text(subtitle ?: "", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant, maxLines = 1, overflow = TextOverflow.Ellipsis)
+                }
+                Spacer(Modifier.width(10.dp))
+                Column(horizontalAlignment = Alignment.End, verticalArrangement = Arrangement.spacedBy(6.dp)) {
+                    Surface(shape = RoundedCornerShape(999.dp), color = badgeContainerColor) {
+                        Row(
+                            verticalAlignment = Alignment.CenterVertically,
+                            modifier = Modifier.padding(start = 6.dp, end = 8.dp, top = 4.dp, bottom = 4.dp)
+                        ) {
+                            Box(
+                                modifier = Modifier.size(16.dp).background(badgeContentColor, CircleShape),
+                                contentAlignment = Alignment.Center
+                            ) {
+                                Text(statusIcon, color = Color.White, style = MaterialTheme.typography.labelSmall, fontWeight = FontWeight.Bold)
+                            }
+                            Spacer(Modifier.width(6.dp))
+                            Text(statusLabel, color = badgeContentColor, style = MaterialTheme.typography.labelSmall)
+                        }
+                    }
+                    Text(amountText, style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.Bold)
+                }
+            }
+            Box(
+                modifier = Modifier
+                    .align(Alignment.CenterStart)
+                    .matchParentSize()
+            ) {
+                Box(
+                    modifier = Modifier
+                        .fillMaxHeight()
+                        .width(stripeWidth)
+                        .clip(RoundedCornerShape(topStart = 12.dp, bottomStart = 12.dp))
+                        .background(statusStripeColor)
+                )
+            }
+        }
+    }
+
+    if (onClick != null) {
+        Card(
+            modifier = modifier,
+            onClick = onClick,
+            enabled = enabled,
+            shape = shape,
+            colors = CardDefaults.cardColors(containerColor = Color.White),
+            elevation = elevation,
+            content = content
+        )
+    } else {
+        Card(
+            modifier = modifier,
+            shape = shape,
+            colors = CardDefaults.cardColors(containerColor = Color.White),
+            elevation = elevation,
+            content = content
+        )
+    }
 }

--- a/app/src/main/java/com/tutorly/ui/components/ComponentLibrary.kt
+++ b/app/src/main/java/com/tutorly/ui/components/ComponentLibrary.kt
@@ -1,5 +1,6 @@
 package com.tutorly.ui.components
 
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -132,7 +133,7 @@ fun FilterChip(label: String, selected: Boolean, onSelectedChange: (Boolean) -> 
             containerColor = if (selected) MaterialTheme.colorScheme.secondaryContainer else MaterialTheme.colorScheme.surface,
             labelColor = if (selected) MaterialTheme.colorScheme.onSecondaryContainer else MaterialTheme.colorScheme.onSurface
         ),
-        border = AssistChipDefaults.assistChipBorder(borderColor = if (selected) Color.Transparent else MaterialTheme.colorScheme.outlineVariant)
+        border = if (selected) null else BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant)
     )
 }
 

--- a/app/src/main/java/com/tutorly/ui/components/WeekMosaic.kt
+++ b/app/src/main/java/com/tutorly/ui/components/WeekMosaic.kt
@@ -1,9 +1,7 @@
 package com.tutorly.ui.components
 
-import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
@@ -18,9 +16,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.compositeOver
-import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.tutorly.models.PaymentStatus
@@ -30,7 +25,6 @@ import java.time.DayOfWeek
 import java.time.LocalDate
 import java.time.ZonedDateTime
 import java.time.ZoneId
-import java.time.format.DateTimeFormatter
 import java.time.format.TextStyle
 import java.util.Locale
 
@@ -212,130 +206,49 @@ private fun LessonRowCompact(
         end = lesson.end,
         now = currentDateTime
     )
-
-    val subjectColor = lesson.subjectColorArgb?.let { Color(it) }
-    val baseSurface = MaterialTheme.colorScheme.surface
-
-    val containerColor = MaterialTheme.colorScheme.onPrimaryContainer
-//
-//        when {
-//        tone == LessonTone.Ongoing -> MaterialTheme.colorScheme.primaryContainer
-//        subjectColor != null -> subjectColor.copy(alpha = 0.12f).compositeOver(baseSurface)
-//        else -> MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.35f).compositeOver(baseSurface)
-//    }
-
-    val titleColor = when {
-        tone == LessonTone.Ongoing -> MaterialTheme.colorScheme.onSurface
-        subjectColor != null -> subjectColor
-        else -> MaterialTheme.colorScheme.onSurface
-    }
-
-    val secondaryColor = if (tone == LessonTone.Ongoing) {
-        MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.9f)
-    } else {
-        MaterialTheme.colorScheme.onSurfaceVariant
-    }
-
-    val border = if (tone == LessonTone.Ongoing) {
-        null
-    } else {
-        BorderStroke(1.dp, MaterialTheme.colorScheme.outline.copy(alpha = 0.2f))
-    }
-
-    val locale = remember { Locale("ru") }
-    val timeFormatter = remember(locale) { DateTimeFormatter.ofPattern("HH:mm", locale) }
-    val timeRange = remember(lesson.start, lesson.end, timeFormatter) {
-        "${lesson.start.format(timeFormatter)} – ${lesson.end.format(timeFormatter)}"
-    }
+    val isFutureLesson = lesson.start.isAfter(currentDateTime)
 
     val hasSubject = !lesson.subjectName.isNullOrBlank()
     val title = lesson.student
-
 
     val subtitleParts = mutableListOf<String>()
     if (hasSubject) {
         lesson.grade?.takeIf { it.isNotBlank() }?.let { subtitleParts += it.trim() }
         subtitleParts += lesson.subjectName!!.trim()
-
     } else {
         lesson.grade?.takeIf { it.isNotBlank() }?.let { subtitleParts += it.trim() }
     }
-
     val subtitle = subtitleParts.takeIf { it.isNotEmpty() }?.joinToString(separator = " • ")
 
-    Surface(
-//        color = containerColor,
-//        contentColor = MaterialTheme.colorScheme.onSurface,
-        shape = RoundedCornerShape(12.dp),
-        border = border,
-//        tonalElevation = if (tone == LessonTone.Ongoing) 2.dp else 0.dp,
-        modifier = Modifier
-            .fillMaxWidth()
-            .defaultMinSize(minHeight = 64.dp)
-//            .clip(RoundedCornerShape(18.dp))
-            .clickable(onClick = onClick)
-    ) {
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .height(IntrinsicSize.Min),
-            verticalAlignment = Alignment.CenterVertically
-        ) {
-            Column(
-                modifier = Modifier
-                    .weight(1f)
-                    .padding(horizontal = 16.dp, vertical = 8.dp),
-//                verticalArrangement = Arrangement.spacedBy(6.dp)
-            ) {
-                Text(
-                    text = title,
-                    style = MaterialTheme.typography.titleSmall,
-                    color = MaterialTheme.colorScheme.onSurface,
-                    fontWeight = FontWeight.SemiBold,
-                    maxLines = 2,
-                    overflow = TextOverflow.Ellipsis
-                )
-
-                subtitle?.let {
-                    Text(
-                        text = it,
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        maxLines = 1,
-                        overflow = TextOverflow.Ellipsis
-                    )
-                }
-
-//                Text(
-//                    text = status.description,
-//                    style = MaterialTheme.typography.labelSmall,
-//                    color = secondaryColor,
-//                    maxLines = 1,
-//                    overflow = TextOverflow.Ellipsis
-//                )
-                Spacer(Modifier.height(6.dp))
-                Text(
-                    text = timeRange,
-                    style = MaterialTheme.typography.bodyMedium,
-                    fontWeight = FontWeight.Medium,
-                    color = if (tone == LessonTone.Ongoing) {
-                        MaterialTheme.colorScheme.onPrimaryContainer
-                    } else {
-                        MaterialTheme.colorScheme.onSurface
-                    }
-                )
-            }
-
-            Box(
-                modifier = Modifier
-                    .fillMaxHeight()
-                    .width(12.dp)
-                    .clip(RoundedCornerShape(topEnd = 12.dp, bottomEnd = 12.dp))
-                    .background(status.background)
-            )
-        }
+    val (statusIcon, statusLabel, badgeContainer, badgeContent) = when {
+        lesson.paymentStatus == PaymentStatus.PAID && isFutureLesson -> Quadruple("∞", "Абонемент", Color(0xFFE9ECFF), Color(0xFF4A56D9))
+        lesson.paymentStatus == PaymentStatus.PAID -> Quadruple("✓", "Оплачено", Color(0xFFE6F7EC), Color(0xFF2DA45A))
+        lesson.paymentStatus == PaymentStatus.UNPAID && !isFutureLesson -> Quadruple("!", "Долг", Color(0xFFFFE9EC), Color(0xFFD64258))
+        lesson.paymentStatus == PaymentStatus.CANCELLED -> Quadruple("×", "Отменено", Color(0xFFEDF1F6), Color(0xFF667085))
+        else -> Quadruple("◷", "Ожидает оплаты", Color(0xFFFFF2E6), Color(0xFFE08A22))
     }
+
+    ScheduleLessonCard(
+        studentName = title,
+        subtitle = subtitle,
+        statusIcon = statusIcon,
+        statusLabel = statusLabel,
+        badgeContainerColor = badgeContainer,
+        badgeContentColor = badgeContent,
+        amountText = formatRubles(lesson.priceCents),
+        statusStripeColor = status.background,
+        modifier = Modifier.fillMaxWidth().defaultMinSize(minHeight = 64.dp),
+        onClick = onClick
+    )
 }
+
+private fun formatRubles(amountCents: Int): String {
+    val rubles = (amountCents / 100.0)
+    val formatted = java.text.DecimalFormat("#,##0").format(rubles).replace(',', ' ')
+    return "$formatted ₽"
+}
+
+private data class Quadruple<A, B, C, D>(val first: A, val second: B, val third: C, val fourth: D)
 
 @Composable
 private fun MiniBadge() {

--- a/app/src/main/java/com/tutorly/ui/components/WeekMosaic.kt
+++ b/app/src/main/java/com/tutorly/ui/components/WeekMosaic.kt
@@ -2,6 +2,7 @@ package com.tutorly.ui.components
 
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
@@ -16,6 +17,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.tutorly.models.PaymentStatus

--- a/app/src/main/java/com/tutorly/ui/components/WeekMosaic.kt
+++ b/app/src/main/java/com/tutorly/ui/components/WeekMosaic.kt
@@ -291,6 +291,7 @@ data class LessonBrief(
     val grade: String?,
     val subjectName: String?,
     val subjectColorArgb: Int?,
+    val priceCents: Int,
     val paymentStatus: PaymentStatus
 )
 
@@ -323,6 +324,7 @@ private fun demoLessonsFor(date: LocalDate): List<LessonBrief> {
                 grade = null,
                 subjectName = "Математика",
                 subjectColorArgb = null,
+                priceCents = 150_000,
                 paymentStatus = PaymentStatus.PAID
             ),
             LessonBrief(
@@ -333,6 +335,7 @@ private fun demoLessonsFor(date: LocalDate): List<LessonBrief> {
                 grade = "7 класс",
                 subjectName = "Физика",
                 subjectColorArgb = null,
+                priceCents = 180_000,
                 paymentStatus = PaymentStatus.UNPAID
             ),
             LessonBrief(
@@ -343,6 +346,7 @@ private fun demoLessonsFor(date: LocalDate): List<LessonBrief> {
                 grade = null,
                 subjectName = "Русский",
                 subjectColorArgb = null,
+                priceCents = 200_000,
                 paymentStatus = PaymentStatus.DUE
             )
         )
@@ -355,6 +359,7 @@ private fun demoLessonsFor(date: LocalDate): List<LessonBrief> {
                 grade = "10 класс",
                 subjectName = "Химия",
                 subjectColorArgb = null,
+                priceCents = 170_000,
                 paymentStatus = PaymentStatus.PAID
             )
         )

--- a/app/src/main/java/com/tutorly/ui/screens/CalendarScreen.kt
+++ b/app/src/main/java/com/tutorly/ui/screens/CalendarScreen.kt
@@ -1283,7 +1283,6 @@ private fun LessonBlock(
                     }
                 )
             }
-            .clip(RoundedCornerShape(12.dp))
     ) {
         LessonCardVisual(
             lessonUi = lessonUi,

--- a/app/src/main/java/com/tutorly/ui/screens/CalendarScreen.kt
+++ b/app/src/main/java/com/tutorly/ui/screens/CalendarScreen.kt
@@ -1384,21 +1384,6 @@ private fun LessonCardInner(
                 .padding(start = 10.dp, end = 12.dp, top = 8.dp, bottom = 8.dp),
             verticalAlignment = Alignment.CenterVertically
         ) {
-            Box(
-                modifier = Modifier
-                    .size(42.dp)
-                    .clip(RoundedCornerShape(12.dp))
-                    .background(Color(0xFFF5F7FF)),
-                contentAlignment = Alignment.Center
-            ) {
-                Text(
-                    text = lessonUi.leadingSymbol,
-                    style = MaterialTheme.typography.titleMedium,
-                    color = Color(0xFF3E43D6),
-                    fontWeight = FontWeight.SemiBold
-                )
-            }
-            Spacer(modifier = Modifier.width(12.dp))
             Column(modifier = Modifier.weight(1f)) {
                 Text(
                     text = lessonUi.studentName,
@@ -1450,7 +1435,6 @@ private data class LessonUi(
     val studentName: String,
     val secondaryLine: String?,
     val statusColor: Color,
-    val leadingSymbol: String,
     val statusLabel: String,
     val badgeContainerColor: Color,
     val badgeContentColor: Color,
@@ -1468,7 +1452,7 @@ private fun CalendarLesson.toLessonUi(now: ZonedDateTime): LessonUi {
     val (badgeText, badgeContainer, badgeContent) = when (paymentStatus) {
         PaymentStatus.PAID -> Triple("Оплачено", Color(0xFFE6F7EC), Color(0xFF2DA45A))
         PaymentStatus.DUE -> Triple("Ожидают оплаты", Color(0xFFFFF2E6), Color(0xFFE08A22))
-        PaymentStatus.UNPAID -> Triple("Просрочено", Color(0xFFFFE9EC), Color(0xFFD64258))
+        PaymentStatus.UNPAID -> Triple("Долг", Color(0xFFFFE9EC), Color(0xFFD64258))
         PaymentStatus.CANCELLED -> Triple("Отменено", Color(0xFFEDF1F6), Color(0xFF667085))
     }
 
@@ -1476,18 +1460,11 @@ private fun CalendarLesson.toLessonUi(now: ZonedDateTime): LessonUi {
         studentName = studentName,
         secondaryLine = secondaryLine,
         statusColor = status.background,
-        leadingSymbol = subject.toLeadingSymbol(),
         statusLabel = badgeText,
         badgeContainerColor = badgeContainer,
         badgeContentColor = badgeContent,
         amountText = formatRubles(priceCents)
     )
-}
-
-private fun String?.toLeadingSymbol(): String {
-    val value = this?.trim().orEmpty()
-    if (value.isEmpty()) return "Σ"
-    return value.first().uppercaseChar().toString()
 }
 
 private fun formatRubles(amountCents: Int): String {

--- a/app/src/main/java/com/tutorly/ui/screens/CalendarScreen.kt
+++ b/app/src/main/java/com/tutorly/ui/screens/CalendarScreen.kt
@@ -422,6 +422,7 @@ private fun CalendarLesson.toLessonBrief(): LessonBrief {
         grade = studentGrade,
         subjectName = subjectName,
         subjectColorArgb = subjectColorArgb,
+        priceCents = priceCents,
         paymentStatus = paymentStatus
     )
 }

--- a/app/src/main/java/com/tutorly/ui/screens/CalendarScreen.kt
+++ b/app/src/main/java/com/tutorly/ui/screens/CalendarScreen.kt
@@ -65,6 +65,7 @@ import com.tutorly.R
 import com.tutorly.ui.CalendarEvent
 import com.tutorly.models.PaymentStatus
 import com.tutorly.ui.components.LessonBrief
+import com.tutorly.ui.components.ScheduleLessonCard
 import com.tutorly.ui.components.StatusChipData
 import com.tutorly.ui.components.UnifiedTopBar
 import com.tutorly.ui.components.WeekMosaic
@@ -1316,133 +1317,20 @@ private fun LessonCardVisual(
     enabled: Boolean
 ) {
     val cardShape = RoundedCornerShape(12.dp)
-    val innerStrokeWidth = 1.dp
-    Box(modifier = modifier) {
-        if (onClick != null) {
-            Card(
-                modifier = Modifier.fillMaxSize(),
-                onClick = onClick,
-                shape = cardShape,
-                colors = CardDefaults.cardColors(containerColor = Color.White),
-                elevation = CardDefaults.cardElevation(defaultElevation = 6.dp),
-                enabled = enabled
-            ) {
-                LessonCardInner(
-                    lessonUi = lessonUi,
-                    innerStrokeWidth = innerStrokeWidth
-                )
-            }
-        } else {
-            Card(
-                modifier = Modifier.fillMaxSize(),
-                shape = cardShape,
-                colors = CardDefaults.cardColors(containerColor = Color.White),
-                elevation = CardDefaults.cardElevation(defaultElevation = 6.dp)
-            ) {
-                LessonCardInner(
-                    lessonUi = lessonUi,
-                    innerStrokeWidth = innerStrokeWidth
-                )
-            }
-        }
-
-        Box(
-            modifier = Modifier
-                .align(Alignment.CenterStart)
-                .fillMaxHeight()
-                .width(4.dp)
-                .clip(RoundedCornerShape(topStart = 12.dp, bottomStart = 12.dp))
-                .background(lessonUi.statusColor)
-        )
-    }
-}
-
-@Composable
-private fun LessonCardInner(
-    lessonUi: LessonUi,
-    innerStrokeWidth: Dp
-) {
-    Box(
-        modifier = Modifier
-            .fillMaxSize()
-            .drawBehind {
-                val strokeWidth = innerStrokeWidth.toPx()
-                val radius = 12.dp.toPx().coerceAtLeast(0f)
-                val adjustedRadius = (radius - strokeWidth / 2f).coerceAtLeast(0f)
-                drawRoundRect(
-                    color = Color(0x14000000),
-                    topLeft = Offset(strokeWidth / 2f, strokeWidth / 2f),
-                    size = Size(size.width - strokeWidth, size.height - strokeWidth),
-                    cornerRadius = CornerRadius(adjustedRadius, adjustedRadius),
-                    style = Stroke(width = strokeWidth)
-                )
-            }
-    ) {
-        Row(
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(start = 10.dp, end = 12.dp, top = 8.dp, bottom = 8.dp),
-            verticalAlignment = Alignment.CenterVertically
-        ) {
-            Column(modifier = Modifier.weight(1f)) {
-                Text(
-                    text = lessonUi.studentName,
-                    style = MaterialTheme.typography.titleSmall,
-                    color = MaterialTheme.colorScheme.onSurface,
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis
-                )
-                Text(
-                    text = lessonUi.secondaryLine ?: "",
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis
-                )
-            }
-            Spacer(modifier = Modifier.width(10.dp))
-            Column(
-                horizontalAlignment = Alignment.End,
-                verticalArrangement = Arrangement.spacedBy(6.dp)
-            ) {
-                Surface(
-                    shape = RoundedCornerShape(999.dp),
-                    color = lessonUi.badgeContainerColor
-                ) {
-                    Row(
-                        verticalAlignment = Alignment.CenterVertically,
-                        modifier = Modifier.padding(start = 6.dp, end = 8.dp, top = 4.dp, bottom = 4.dp)
-                    ) {
-                        Box(
-                            modifier = Modifier
-                                .size(16.dp)
-                                .background(lessonUi.badgeContentColor, CircleShape),
-                            contentAlignment = Alignment.Center
-                        ) {
-                            Text(
-                                text = lessonUi.statusIcon,
-                                color = Color.White,
-                                style = MaterialTheme.typography.labelSmall,
-                                fontWeight = FontWeight.Bold
-                            )
-                        }
-                        Spacer(modifier = Modifier.width(6.dp))
-                        Text(
-                            text = lessonUi.statusLabel,
-                            color = lessonUi.badgeContentColor,
-                            style = MaterialTheme.typography.labelSmall
-                        )
-                    }
-                }
-                Text(
-                    text = lessonUi.amountText,
-                    style = MaterialTheme.typography.titleSmall,
-                    fontWeight = FontWeight.Bold,
-                    color = MaterialTheme.colorScheme.onSurface
-                )
-            }
-        }
-    }
+    ScheduleLessonCard(
+        studentName = lessonUi.studentName,
+        subtitle = lessonUi.secondaryLine,
+        statusIcon = lessonUi.statusIcon,
+        statusLabel = lessonUi.statusLabel,
+        badgeContainerColor = lessonUi.badgeContainerColor,
+        badgeContentColor = lessonUi.badgeContentColor,
+        amountText = lessonUi.amountText,
+        statusStripeColor = lessonUi.statusColor,
+        modifier = modifier.fillMaxSize(),
+        shape = cardShape,
+        onClick = onClick,
+        enabled = enabled
+    )
 }
 
 @Composable

--- a/app/src/main/java/com/tutorly/ui/screens/CalendarScreen.kt
+++ b/app/src/main/java/com/tutorly/ui/screens/CalendarScreen.kt
@@ -24,7 +24,6 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Add
-import androidx.compose.material.icons.outlined.CalendarMonth
 import androidx.compose.material.icons.outlined.CheckCircle
 import androidx.compose.material.icons.outlined.AccessTime
 import androidx.compose.material.icons.outlined.Settings
@@ -1349,10 +1348,10 @@ private fun LessonCardVisual(
 
         Box(
             modifier = Modifier
-                .align(Alignment.CenterEnd)
+                .align(Alignment.CenterStart)
                 .fillMaxHeight()
-                .width(12.dp)
-                .clip(RoundedCornerShape(topEnd = 12.dp, bottomEnd = 12.dp))
+                .width(4.dp)
+                .clip(RoundedCornerShape(topStart = 12.dp, bottomStart = 12.dp))
                 .background(lessonUi.statusColor)
         )
     }
@@ -1373,18 +1372,34 @@ private fun LessonCardInner(
                 drawRoundRect(
                     color = Color(0x14000000),
                     topLeft = Offset(strokeWidth / 2f, strokeWidth / 2f),
-                    size = Size(size.width - strokeWidth + 20, size.height - strokeWidth),
+                    size = Size(size.width - strokeWidth, size.height - strokeWidth),
                     cornerRadius = CornerRadius(adjustedRadius, adjustedRadius),
                     style = Stroke(width = strokeWidth)
                 )
             }
     ) {
-        Row(modifier = Modifier.fillMaxSize()) {
-            Column(
+        Row(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(start = 10.dp, end = 12.dp, top = 8.dp, bottom = 8.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Box(
                 modifier = Modifier
-                    .weight(1f)
-                    .padding(horizontal = 16.dp, vertical = 8.dp)
+                    .size(42.dp)
+                    .clip(RoundedCornerShape(12.dp))
+                    .background(Color(0xFFF5F7FF)),
+                contentAlignment = Alignment.Center
             ) {
+                Text(
+                    text = lessonUi.leadingSymbol,
+                    style = MaterialTheme.typography.titleMedium,
+                    color = Color(0xFF3E43D6),
+                    fontWeight = FontWeight.SemiBold
+                )
+            }
+            Spacer(modifier = Modifier.width(12.dp))
+            Column(modifier = Modifier.weight(1f)) {
                 Text(
                     text = lessonUi.studentName,
                     style = MaterialTheme.typography.titleSmall,
@@ -1392,40 +1407,37 @@ private fun LessonCardInner(
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis
                 )
-                if (lessonUi.isRecurring) {
-                    Row(
-                        verticalAlignment = Alignment.CenterVertically,
-                        modifier = Modifier.padding(top = 2.dp)
-                    ) {
-                        Icon(
-                            imageVector = Icons.Outlined.CalendarMonth,
-                            contentDescription = null,
-                            modifier = Modifier.size(14.dp),
-                            tint = MaterialTheme.colorScheme.primary
-                        )
-                        Text(
-                            text = lessonUi.recurrenceLabel ?: stringResource(id = R.string.lesson_recurring_short),
-                            style = MaterialTheme.typography.labelSmall,
-                            color = MaterialTheme.colorScheme.primary,
-                            modifier = Modifier
-                                .padding(start = 4.dp)
-                                .weight(1f, fill = false),
-                            maxLines = 1,
-                            overflow = TextOverflow.Ellipsis
-                        )
-                    }
-                }
-                lessonUi.secondaryLine?.let { secondaryLine ->
-                    Text(
-                        text = secondaryLine,
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        maxLines = 1,
-                        overflow = TextOverflow.Ellipsis
-                    )
-                }
+                Text(
+                    text = lessonUi.secondaryLine ?: "",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
             }
             Spacer(modifier = Modifier.width(10.dp))
+            Column(
+                horizontalAlignment = Alignment.End,
+                verticalArrangement = Arrangement.spacedBy(6.dp)
+            ) {
+                Surface(
+                    shape = RoundedCornerShape(999.dp),
+                    color = lessonUi.badgeContainerColor
+                ) {
+                    Text(
+                        text = lessonUi.statusLabel,
+                        color = lessonUi.badgeContentColor,
+                        style = MaterialTheme.typography.labelSmall,
+                        modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp)
+                    )
+                }
+                Text(
+                    text = lessonUi.amountText,
+                    style = MaterialTheme.typography.titleSmall,
+                    fontWeight = FontWeight.Bold,
+                    color = MaterialTheme.colorScheme.onSurface
+                )
+            }
         }
     }
 }
@@ -1437,11 +1449,12 @@ private fun CalendarLesson.statusPresentation(now: ZonedDateTime): StatusChipDat
 private data class LessonUi(
     val studentName: String,
     val secondaryLine: String?,
-    val note: String?,
-    val statusDescription: String,
     val statusColor: Color,
-    val isRecurring: Boolean,
-    val recurrenceLabel: String?
+    val leadingSymbol: String,
+    val statusLabel: String,
+    val badgeContainerColor: Color,
+    val badgeContentColor: Color,
+    val amountText: String
 )
 
 @Composable
@@ -1452,18 +1465,35 @@ private fun CalendarLesson.toLessonUi(now: ZonedDateTime): LessonUi {
     val secondaryLine = listOfNotNull(grade, subject)
         .takeIf { it.isNotEmpty() }
         ?.joinToString(separator = " • ")
-    val note = lessonNote?.takeIf { it.isNotBlank() }?.trim()
-    val recurrence = recurrenceLabel?.takeIf { isRecurring }
+    val (badgeText, badgeContainer, badgeContent) = when (paymentStatus) {
+        PaymentStatus.PAID -> Triple("Оплачено", Color(0xFFE6F7EC), Color(0xFF2DA45A))
+        PaymentStatus.DUE -> Triple("Ожидают оплаты", Color(0xFFFFF2E6), Color(0xFFE08A22))
+        PaymentStatus.UNPAID -> Triple("Просрочено", Color(0xFFFFE9EC), Color(0xFFD64258))
+        PaymentStatus.CANCELLED -> Triple("Отменено", Color(0xFFEDF1F6), Color(0xFF667085))
+    }
 
     return LessonUi(
         studentName = studentName,
         secondaryLine = secondaryLine,
-        note = note,
-        statusDescription = status.description,
         statusColor = status.background,
-        isRecurring = isRecurring,
-        recurrenceLabel = recurrence
+        leadingSymbol = subject.toLeadingSymbol(),
+        statusLabel = badgeText,
+        badgeContainerColor = badgeContainer,
+        badgeContentColor = badgeContent,
+        amountText = formatRubles(priceCents)
     )
+}
+
+private fun String?.toLeadingSymbol(): String {
+    val value = this?.trim().orEmpty()
+    if (value.isEmpty()) return "Σ"
+    return value.first().uppercaseChar().toString()
+}
+
+private fun formatRubles(amountCents: Int): String {
+    val rubles = (amountCents / 100.0)
+    val formatted = java.text.DecimalFormat("#,##0").format(rubles).replace(',', ' ')
+    return "$formatted ₽"
 }
 
 @Composable

--- a/app/src/main/java/com/tutorly/ui/screens/CalendarScreen.kt
+++ b/app/src/main/java/com/tutorly/ui/screens/CalendarScreen.kt
@@ -1267,7 +1267,7 @@ private fun LessonBlock(
             .fillMaxWidth()
             .offset(y = top + LessonCardVerticalInset)
             .height(height - LessonCardVerticalInset * 2)
-            .padding(start = LabelWidth + 16.dp, end = 20.dp)
+            .padding(start = LabelWidth + 8.dp, end = 20.dp)
             .alpha(if (isDragging) 0.4f else 1f)
             .zIndex(if (isDragging) 0.25f else 0f)
             .onGloballyPositioned { coordinates ->
@@ -1354,7 +1354,7 @@ private fun CalendarLesson.toLessonUi(now: ZonedDateTime): LessonUi {
     val isFutureLesson = start.isAfter(now)
     val grade = normalizeGrade(studentGrade)
     val subject = subjectName?.takeIf { it.isNotBlank() }?.trim()
-    val secondaryLine = listOfNotNull(grade, subject)
+    val secondaryLine = listOfNotNull(subject)
         .takeIf { it.isNotEmpty() }
         ?.joinToString(separator = " • ")
     val (statusIcon, badgeText, badgeContainer, badgeContent) = when {

--- a/app/src/main/java/com/tutorly/ui/screens/CalendarScreen.kt
+++ b/app/src/main/java/com/tutorly/ui/screens/CalendarScreen.kt
@@ -1409,12 +1409,30 @@ private fun LessonCardInner(
                     shape = RoundedCornerShape(999.dp),
                     color = lessonUi.badgeContainerColor
                 ) {
-                    Text(
-                        text = lessonUi.statusLabel,
-                        color = lessonUi.badgeContentColor,
-                        style = MaterialTheme.typography.labelSmall,
-                        modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp)
-                    )
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        modifier = Modifier.padding(start = 6.dp, end = 8.dp, top = 4.dp, bottom = 4.dp)
+                    ) {
+                        Box(
+                            modifier = Modifier
+                                .size(16.dp)
+                                .background(lessonUi.badgeContentColor, CircleShape),
+                            contentAlignment = Alignment.Center
+                        ) {
+                            Text(
+                                text = lessonUi.statusIcon,
+                                color = Color.White,
+                                style = MaterialTheme.typography.labelSmall,
+                                fontWeight = FontWeight.Bold
+                            )
+                        }
+                        Spacer(modifier = Modifier.width(6.dp))
+                        Text(
+                            text = lessonUi.statusLabel,
+                            color = lessonUi.badgeContentColor,
+                            style = MaterialTheme.typography.labelSmall
+                        )
+                    }
                 }
                 Text(
                     text = lessonUi.amountText,
@@ -1435,6 +1453,7 @@ private data class LessonUi(
     val studentName: String,
     val secondaryLine: String?,
     val statusColor: Color,
+    val statusIcon: String,
     val statusLabel: String,
     val badgeContainerColor: Color,
     val badgeContentColor: Color,
@@ -1444,28 +1463,42 @@ private data class LessonUi(
 @Composable
 private fun CalendarLesson.toLessonUi(now: ZonedDateTime): LessonUi {
     val status = statusPresentation(now)
+    val isFutureLesson = start.isAfter(now)
     val grade = normalizeGrade(studentGrade)
     val subject = subjectName?.takeIf { it.isNotBlank() }?.trim()
     val secondaryLine = listOfNotNull(grade, subject)
         .takeIf { it.isNotEmpty() }
         ?.joinToString(separator = " • ")
-    val (badgeText, badgeContainer, badgeContent) = when (paymentStatus) {
-        PaymentStatus.PAID -> Triple("Оплачено", Color(0xFFE6F7EC), Color(0xFF2DA45A))
-        PaymentStatus.DUE -> Triple("Ожидают оплаты", Color(0xFFFFF2E6), Color(0xFFE08A22))
-        PaymentStatus.UNPAID -> Triple("Долг", Color(0xFFFFE9EC), Color(0xFFD64258))
-        PaymentStatus.CANCELLED -> Triple("Отменено", Color(0xFFEDF1F6), Color(0xFF667085))
+    val (statusIcon, badgeText, badgeContainer, badgeContent) = when {
+        paymentStatus == PaymentStatus.PAID && isFutureLesson ->
+            Quadruple("∞", "Абонемент", Color(0xFFE9ECFF), Color(0xFF4A56D9))
+
+        paymentStatus == PaymentStatus.PAID ->
+            Quadruple("✓", "Оплачено", Color(0xFFE6F7EC), Color(0xFF2DA45A))
+
+        paymentStatus == PaymentStatus.UNPAID && !isFutureLesson ->
+            Quadruple("!", "Долг", Color(0xFFFFE9EC), Color(0xFFD64258))
+
+        paymentStatus == PaymentStatus.CANCELLED ->
+            Quadruple("×", "Отменено", Color(0xFFEDF1F6), Color(0xFF667085))
+
+        else ->
+            Quadruple("◷", "Ожидает оплаты", Color(0xFFFFF2E6), Color(0xFFE08A22))
     }
 
     return LessonUi(
         studentName = studentName,
         secondaryLine = secondaryLine,
         statusColor = status.background,
+        statusIcon = statusIcon,
         statusLabel = badgeText,
         badgeContainerColor = badgeContainer,
         badgeContentColor = badgeContent,
         amountText = formatRubles(priceCents)
     )
 }
+
+private data class Quadruple<A, B, C, D>(val first: A, val second: B, val third: C, val fourth: D)
 
 private fun formatRubles(amountCents: Int): String {
     val rubles = (amountCents / 100.0)

--- a/app/src/main/java/com/tutorly/ui/screens/TodayScreen.kt
+++ b/app/src/main/java/com/tutorly/ui/screens/TodayScreen.kt
@@ -34,6 +34,7 @@ import androidx.compose.material.icons.outlined.CurrencyRuble
 import androidx.compose.material.icons.outlined.CheckCircle
 import androidx.compose.material.icons.outlined.AccessTime
 import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardColors
 import androidx.compose.material3.CardDefaults

--- a/app/src/main/java/com/tutorly/ui/screens/TodayScreen.kt
+++ b/app/src/main/java/com/tutorly/ui/screens/TodayScreen.kt
@@ -34,7 +34,6 @@ import androidx.compose.material.icons.outlined.CurrencyRuble
 import androidx.compose.material.icons.outlined.CheckCircle
 import androidx.compose.material.icons.outlined.AccessTime
 import androidx.compose.material3.AlertDialog
-import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardColors
 import androidx.compose.material3.CardDefaults
@@ -84,6 +83,8 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import com.tutorly.R
 import com.tutorly.domain.model.LessonForToday
 import com.tutorly.models.PaymentStatus
+import com.tutorly.ui.components.TutorlyButton
+import com.tutorly.ui.components.TutorlyCard
 import com.tutorly.ui.components.UnifiedTopBar
 import com.tutorly.ui.components.statusChipData
 import com.tutorly.ui.lessoncard.LessonCardSheet
@@ -590,12 +591,7 @@ private fun LessonsReviewCarousel(
 
 @Composable
 private fun ReviewEmptyMarkedCard() {
-    Card(
-        modifier = Modifier.fillMaxWidth(),
-        shape = MaterialTheme.shapes.large,
-        colors = TutorlyCardDefaults.colors(containerColor = Color.White),
-        elevation = TutorlyCardDefaults.elevation()
-    ) {
+    TutorlyCard(modifier = Modifier.fillMaxWidth()) {
         Box(
             modifier = Modifier
                 .fillMaxWidth()
@@ -631,12 +627,7 @@ private fun DayProgressSummary(
     remaining: Int,
     allLessonsCompleted: Boolean
 ) {
-    Card(
-        modifier = Modifier.fillMaxWidth(),
-        shape = MaterialTheme.shapes.large,
-        colors = TutorlyCardDefaults.colors(containerColor = Color.White),
-        elevation = TutorlyCardDefaults.elevation()
-    ) {
+    TutorlyCard(modifier = Modifier.fillMaxWidth()) {
         Column(
             modifier = Modifier
                 .fillMaxWidth()
@@ -737,12 +728,7 @@ private fun GradientProgressBar(
 
 @Composable
 private fun CloseDayCallout(onRequestCloseDay: () -> Unit) {
-    Card(
-        modifier = Modifier.fillMaxWidth(),
-        shape = MaterialTheme.shapes.large,
-        colors = TutorlyCardDefaults.colors(containerColor = Color.White),
-        elevation = TutorlyCardDefaults.elevation()
-    ) {
+    TutorlyCard(modifier = Modifier.fillMaxWidth()) {
         Column(
             modifier = Modifier
                 .fillMaxWidth()
@@ -758,9 +744,10 @@ private fun CloseDayCallout(onRequestCloseDay: () -> Unit) {
                 style = MaterialTheme.typography.bodyMedium,
                 color = MaterialTheme.colorScheme.onSurfaceVariant
             )
-            Button(onClick = onRequestCloseDay) {
-                Text(text = stringResource(R.string.today_close_day_action))
-            }
+            TutorlyButton(
+                text = stringResource(R.string.today_close_day_action),
+                onClick = onRequestCloseDay
+            )
         }
     }
 }
@@ -847,12 +834,7 @@ private fun DayClosedSummary(
     dueAmountCents: Long,
     formatter: NumberFormat
 ) {
-    Card(
-        modifier = Modifier.fillMaxWidth(),
-        shape = MaterialTheme.shapes.large,
-        colors = TutorlyCardDefaults.colors(containerColor = Color.White),
-        elevation = TutorlyCardDefaults.elevation()
-    ) {
+    TutorlyCard(modifier = Modifier.fillMaxWidth()) {
         Column(
             modifier = Modifier
                 .fillMaxWidth()
@@ -1328,12 +1310,7 @@ private fun LessonCard(
         now = ZonedDateTime.now(zoneId)
     )
 
-    Card(
-        modifier = modifier,
-        shape = MaterialTheme.shapes.large,
-        colors = cardColors,
-        elevation = cardElevation
-    ) {
+    TutorlyCard(modifier = modifier) {
         Row(
             modifier = Modifier
                 .fillMaxWidth()

--- a/app/src/main/java/com/tutorly/ui/theme/Color.kt
+++ b/app/src/main/java/com/tutorly/ui/theme/Color.kt
@@ -25,8 +25,8 @@ internal val OriginalPalette = ThemePalette(
     topBarEnd = Color(0xFF4E998C),
     accent = Color(0xFF4E998C),
     chipFill = Color(0xFFE7EFEA),
-    backgroundTop = Color(0xFFF7FBFA),
-    backgroundBottom = Color(0xFFF0F6F4),
+    backgroundTop = Color.White,
+    backgroundBottom = Color.White,
     lessonsHighlight = MetricPalette(
         border = Color(0xFF4C6388)
     ),
@@ -88,7 +88,7 @@ internal val PremiumPalette = ThemePalette(
     topBarEnd = Color(0xFFFFFFFF),
     accent = Color(0xFF2F2BFF),
     chipFill = Color(0xFFF1F2FF),
-    backgroundTop = Color(0xFFFBFCFF),
+    backgroundTop = Color.White,
     backgroundBottom = Color(0xFFF5F7FF),
     lessonsHighlight = MetricPalette(border = Color(0xFF6C5CFF)),
     rateHighlight = MetricPalette(border = Color(0xFFFF9F43)),

--- a/app/src/main/java/com/tutorly/ui/theme/DesignTokens.kt
+++ b/app/src/main/java/com/tutorly/ui/theme/DesignTokens.kt
@@ -113,7 +113,7 @@ object TutorlyColors {
     val paymentPaid = Color(0xFF4E998C)
     /** Нейтральный цвет неоплаченного будущего урока. */
     val futureUnpaid = Color(0xFF727272)
-    val screenBackground = Color(0xFFFBFCFF)
+    val screenBackground = Color.White
     val cardBorder = Color(0xFFE7EAF5)
     val softContainer = Color(0xFFF3F5FF)
     val textPrimary = Color(0xFF4445F2)


### PR DESCRIPTION
### Motivation
- Provide a set of reusable Compose UI primitives requested for the project to speed up UI development and enforce a consistent look-and-feel.
- Keep components aligned with existing design tokens so they can be used immediately across screens and feature work.

### Description
- Added a new file `app/src/main/java/com/tutorly/ui/components/ComponentLibrary.kt` that implements a base component library.
- Implemented the requested components: `TutorlyButton`, `TutorlyCard`, `LessonCard`, `StudentCard`, `EarningsCard`, `EmptyState`, `FAB`, `FilterChip`, `FilterChipGroup`, `PremiumBanner`, `Avatar`, `MenuItem`, and `SearchField`.
- Components are built on Material 3 primitives and the project theme tokens (`TutorlyColors`, `TutorlySpacing`, `TutorlyRadii`, `TutorlyElevation`) so visual tokens and spacing remain consistent.
- The `FilterChip` uses `AssistChip` and `FilterChipGroup` is implemented with `LazyRow`; overall imports were kept minimal and unused imports removed.

### Testing
- Attempted to compile with `./gradlew :app:compileDebugKotlin`, but the Gradle wrapper failed to download the distribution due to a proxy error (`HTTP/1.1 403 Forbidden`), so compilation could not be completed in this environment.
- No other automated tests were executed in this environment after the compile attempt failed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08c6252f50832081761a8f45178a05)