### PR TITLE
Оставить в приложении только премиальную тему

### DIFF
--- a/app/src/main/java/com/tutorly/data/repo/preferences/PreferencesUserProfileRepository.kt
+++ b/app/src/main/java/com/tutorly/data/repo/preferences/PreferencesUserProfileRepository.kt
@@ -75,7 +75,7 @@ class PreferencesUserProfileRepository @Inject constructor(
                 runCatching { AppThemePreset.valueOf(value) }.getOrNull()
                     ?: legacyTheme(value)
             }
-            ?: AppThemePreset.ORIGINAL
+            ?: AppThemePreset.PREMIUM
         return UserProfile(
             workDayStartMinutes = sanitizedStart,
             workDayEndMinutes = sanitizedEnd,
@@ -86,9 +86,7 @@ class PreferencesUserProfileRepository @Inject constructor(
     }
 
     private fun legacyTheme(value: String): AppThemePreset? = when (value) {
-        "OCEAN" -> AppThemePreset.ROYAL
-        "FOREST" -> AppThemePreset.PLUM
-        "SUNSET" -> AppThemePreset.ORIGINAL
+        "OCEAN", "FOREST", "SUNSET", "ORIGINAL", "PLUM", "ROYAL" -> AppThemePreset.PREMIUM
         else -> null
     }
 

--- a/app/src/main/java/com/tutorly/models/UserProfile.kt
+++ b/app/src/main/java/com/tutorly/models/UserProfile.kt
@@ -9,7 +9,7 @@ data class UserProfile(
     val workDayStartMinutes: Int = DEFAULT_WORK_DAY_START,
     val workDayEndMinutes: Int = DEFAULT_WORK_DAY_END,
     val weekendDays: Set<DayOfWeek> = emptySet(),
-    val theme: AppThemePreset = AppThemePreset.ORIGINAL,
+    val theme: AppThemePreset = AppThemePreset.PREMIUM,
     val onboardingCompleted: Boolean = false
 ) {
     companion object {
@@ -19,7 +19,5 @@ data class UserProfile(
 }
 
 enum class AppThemePreset {
-    ORIGINAL,
-    PLUM,
-    ROYAL
+    PREMIUM
 }

--- a/app/src/main/java/com/tutorly/ui/screens/SettingsViewModel.kt
+++ b/app/src/main/java/com/tutorly/ui/screens/SettingsViewModel.kt
@@ -247,7 +247,7 @@ data class SettingsUiState(
     val workDayEndMinutes: Int = UserProfile.DEFAULT_WORK_DAY_END,
     val workDayEndExtendsToNextDay: Boolean = false,
     val weekendDays: Set<DayOfWeek> = emptySet(),
-    val selectedTheme: AppThemePreset = AppThemePreset.ORIGINAL,
+    val selectedTheme: AppThemePreset = AppThemePreset.PREMIUM,
     val availableThemes: List<ThemeOption> = ThemeOption.defaults(),
     val isCalendarImporting: Boolean = false,
     val isCalendarCandidatesLoading: Boolean = false,
@@ -266,19 +266,9 @@ data class ThemeOption(
     companion object {
         fun defaults(): List<ThemeOption> = listOf(
             ThemeOption(
-                preset = AppThemePreset.ORIGINAL,
-                labelRes = R.string.settings_theme_original,
-                previewColor = 0xFF4E998C
-            ),
-            ThemeOption(
-                preset = AppThemePreset.PLUM,
-                labelRes = R.string.settings_theme_plum,
-                previewColor = 0xFF8F4AA1
-            ),
-            ThemeOption(
-                preset = AppThemePreset.ROYAL,
-                labelRes = R.string.settings_theme_royal,
-                previewColor = 0xFF4D71CE
+                preset = AppThemePreset.PREMIUM,
+                labelRes = R.string.settings_theme_premium,
+                previewColor = 0xFF2F2BFF
             )
         )
     }

--- a/app/src/main/java/com/tutorly/ui/theme/Theme.kt
+++ b/app/src/main/java/com/tutorly/ui/theme/Theme.kt
@@ -35,16 +35,16 @@ data class ExtendedColors(
 
 private val LocalExtendedColors = staticCompositionLocalOf {
     ExtendedColors(
-        topBarStart = OriginalPalette.topBarStart,
-        topBarEnd = OriginalPalette.topBarEnd,
-        accent = OriginalPalette.accent,
-        chipSelected = OriginalPalette.chipFill,
-        backgroundTop = OriginalPalette.backgroundTop,
-        backgroundBottom = OriginalPalette.backgroundBottom,
-        lessonsMetric = OriginalPalette.lessonsHighlight.toMetricTileColors(),
-        rateMetric = OriginalPalette.rateHighlight.toMetricTileColors(),
-        earnedMetric = OriginalPalette.earnedHighlight.toMetricTileColors(),
-        prepaymentMetric = OriginalPalette.prepaymentHighlight.toMetricTileColors()
+        topBarStart = PremiumPalette.topBarStart,
+        topBarEnd = PremiumPalette.topBarEnd,
+        accent = PremiumPalette.accent,
+        chipSelected = PremiumPalette.chipFill,
+        backgroundTop = PremiumPalette.backgroundTop,
+        backgroundBottom = PremiumPalette.backgroundBottom,
+        lessonsMetric = PremiumPalette.lessonsHighlight.toMetricTileColors(),
+        rateMetric = PremiumPalette.rateHighlight.toMetricTileColors(),
+        earnedMetric = PremiumPalette.earnedHighlight.toMetricTileColors(),
+        prepaymentMetric = PremiumPalette.prepaymentHighlight.toMetricTileColors()
     )
 }
 
@@ -55,7 +55,7 @@ val MaterialTheme.extendedColors: ExtendedColors
 
 @Composable
 fun AppTheme(
-    preset: AppThemePreset = AppThemePreset.ORIGINAL,
+    preset: AppThemePreset = AppThemePreset.PREMIUM,
     content: @Composable () -> Unit
 ) {
     val palette = remember(preset) { paletteForPreset(preset) }
@@ -70,9 +70,7 @@ fun AppTheme(
 }
 
 private fun paletteForPreset(preset: AppThemePreset): PaletteResult = when (preset) {
-    AppThemePreset.ORIGINAL -> createPalette(OriginalPalette)
-    AppThemePreset.PLUM -> createPalette(PlumPalette)
-    AppThemePreset.ROYAL -> createPalette(RoyalPalette)
+    AppThemePreset.PREMIUM -> createPalette(PremiumPalette)
 }
 
 private fun createPalette(themePalette: ThemePalette): PaletteResult {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -313,9 +313,7 @@
     <string name="settings_work_end">Окончание дня</string>
     <string name="settings_weekends">Выходные</string>
     <string name="settings_theme">Цвет темы</string>
-    <string name="settings_theme_original">Фирменная</string>
-    <string name="settings_theme_plum">Лиловая</string>
-    <string name="settings_theme_royal">Королевская</string>
+    <string name="settings_theme_premium">Премиальная</string>
     <string name="settings_calendar_import_title">Импорт из Google Календаря</string>
     <string name="settings_calendar_import_description">
         Перенесём занятия из Google Календаря за текущий учебный год и автоматически создадим учеников.


### PR DESCRIPTION
### Motivation
- Упростить систему тем и оставить в приложении только премиальную тему для единообразия интерфейса и упрощения настроек.
- Обеспечить корректную миграцию старых сохранённых значений темы на новую единую пресетную модель.

### Description
- Оставлен только один пресет в `AppThemePreset` — `PREMIUM`, и дефолтная тема в `UserProfile` и состоянии настроек (`SettingsUiState`) изменена на `PREMIUM` (файлы: `models/UserProfile.kt`, `ui/screens/SettingsViewModel.kt`).
- `AppTheme` и `LocalExtendedColors` теперь используют исключительно `PremiumPalette`, а `paletteForPreset` маппит только на `PremiumPalette` (файл: `ui/theme/Theme.kt`).
- Ограничен список опций в настройках до одной записи (`ThemeOption.defaults()` возвращает только `PREMIUM`) и добавлен строковый ресурс `settings_theme_premium` вместо старых названий (файл: `res/values/strings.xml`).
- В `PreferencesUserProfileRepository` добавлена миграция legacy-значений тем и дефолт при отсутствии значения установлен в `PREMIUM`, чтобы старые сохранения переводились в новый пресет (файл: `data/repo/preferences/PreferencesUserProfileRepository.kt`).

### Testing
- Выполнен поисковый запрос `rg` по коду на наличие старых пресетов и ресурсов и подтверждённо, что `ORIGINAL/PLUM/ROYAL` и старые `settings_theme_*` больше не встречаются (успешно).
- Попытка собрать `:app:compileDebugKotlin` через `./gradlew` не завершилась из‑за сетевого ограничения при загрузке дистрибутива Gradle (`HTTP/1.1 403 Forbidden` через прокси), поэтому сборка не прошла (неуспешно).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0dd86e848883209c028b747ce50946)